### PR TITLE
Adding Test for GET /formulas/:id/export

### DIFF
--- a/src/core/suite.js
+++ b/src/core/suite.js
@@ -46,12 +46,14 @@ const itPagination = (api, schema) => {
 
 const itGet404 = (api, invalidId) => {
   const name = util.format('should throw a 404 when trying to retrieve a(n) %s with an ID that does not exist', api);
-  it(name, () => cloud.get(api + '/' + (invalidId || -1), (r) => expect(r).to.have.statusCode(404)));
+  if (invalidId) api = api + '/' + invalidId;
+  it(name, () => cloud.get(api, (r) => expect(r).to.have.statusCode(404)));
 };
 
 const itPatch404 = (api, payload, invalidId) => {
   const name = util.format('should throw a 404 when trying to update a(n) %s with an ID that does not exist', api);
-  it(name, () => cloud.update(api + '/' + (invalidId || -1), (payload || {}), (r) => expect(r).to.have.statusCode(404), chakram.patch));
+  if (invalidId) api = api + '/' + invalidId;
+  it(name, () => cloud.update(api, (payload || {}), (r) => expect(r).to.have.statusCode(404), chakram.patch));
 };
 
 const itPost400 = (api, payload) => {

--- a/src/test/elements/closeio/contacts.js
+++ b/src/test/elements/closeio/contacts.js
@@ -23,10 +23,10 @@ suite.forElement('crm', 'contacts', gen(), schema, (test) => {
       .then(r => cloud.cruds(test.api, gen({ lead_id: accountId }), schema))
       .then(r => cloud.delete('/hubs/crm/accounts/' + accountId));
   });
-  
+
   test.should.supportPagination();
-  test.should.return404OnGet();
-  test.should.return404OnPatch();
+  test.should.return404OnGet(-1);
+  test.should.return404OnPatch(-1);
   test.should.return400OnPost();
   test.withJson({}).should.return400OnPost();
 });

--- a/src/test/platform/formulas/formulas.js
+++ b/src/test/platform/formulas/formulas.js
@@ -116,4 +116,6 @@ suite.forPlatform('formulas', common.genFormula({}), schema, (test) => {
       }))
       .then(r => cloud.delete(test.api + '/' + formulaId));
   });
+
+  test.withApi(test.api + '/-1/export').should.return404OnGet();
 });

--- a/src/test/platform/formulas/formulas.js
+++ b/src/test/platform/formulas/formulas.js
@@ -104,4 +104,16 @@ suite.forPlatform('formulas', common.genFormula({}), schema, (test) => {
           .then(r => provisioner.delete(id));
       });
   });
+
+  it('should allow exporting a formula', () => {
+    const f = common.genFormula({});
+    let formulaId;
+    return cloud.post(test.api, f, schema)
+      .then(r => formulaId = r.body.id)
+      .then(r => cloud.get(test.api + '/' + formulaId + '/export', (r) => {
+        expect(r).to.have.statusCode(200);
+        expect(r.body.name).to.equal(f.name);
+      }))
+      .then(r => cloud.delete(test.api + '/' + formulaId));
+  });
 });

--- a/src/test/platform/notifications/notifications.js
+++ b/src/test/platform/notifications/notifications.js
@@ -16,7 +16,7 @@ const genNotif = (opts) => new Object({
 
 suite.forPlatform('notifications', genNotif({}), schema, (test) => {
   test.should.supportCrd();
-  test.should.return404OnGet();
+  test.should.return404OnGet(-1);
   test.withJson({}).should.return400OnPost();
 
   // test with missing topic should be bad too

--- a/src/test/platform/notifications/subscriptions.js
+++ b/src/test/platform/notifications/subscriptions.js
@@ -12,7 +12,7 @@ const genSub = (opts) => new Object({
 suite.forPlatform('notifications/subscriptions', genSub({}), schema, (test) => {
   test.should.supportCrd();
   test.withJson({}).should.return400OnPost();
-  test.should.return404OnGet();
+  test.should.return404OnGet(-1);
 
   const bad = genSub();
   bad.config.url = null;

--- a/test/core/suite.test.js
+++ b/test/core/suite.test.js
@@ -140,8 +140,15 @@ describe('suite', () => {
     test.withApi('/foo').withOptions({}).should.return200OnPost();
     // *****************************************
 
+    // *****************************************
+    // NOTE: all of these are equivalent just as examples
+    // *****************************************
     test.should.return404OnPatch(456);
     test.should.return404OnGet(456);
+    test.withApi(test.api + '/456').should.return404OnPatch();
+    test.withApi(test.api + '/456').should.return404OnGet();
+    // *****************************************
+
     test.withOptions({ qs: { page: 1, pageSize: 1 } }).should.return200OnGet();
     test.should.return200OnPost();
     test.should.supportCruds();


### PR DESCRIPTION
## Highlights
* Added test for new `GET /formulas/:id/export` to validate that exporting a formula works.
* Changed the way `test.shouldReturn404...` methods work, where if an `id` is *not* passed in as an arg to the method, then it does not try to append `-1`.  This makes it easier to test `404`s for sub-resources, such as: `GET /formulas/:id/exports`