### PR TITLE
setting up github templates

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -132,16 +132,4 @@ Whenever adding any new code to the `src/core` directory, ensure that these chan
 
 All PRs submitted to the `churros` repository will have *all* of the unit tests run before they're able to be merged into `master`.  When creating a PR, please refrain from assigning it to someone else until all GitHub status checks have been completed and you have that nice little :white_check_mark:.
 
-> __NOTE:__ PR messages should be formatted in the following way:
-
-```markdown
-## Highlights
-* bullet separated list of highlights
-* another highlight
-
-## Closes
-Closes #${issueNumber}
-Closes #${anotherIssueNumberIfThisClosesMoreThanJustOne}
-```
-
 > __NOTE:__ When all tests have passed then you can assign the PR out.  Make sure the label at this point is `in review`.

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,11 @@
+# IF FEATURE
+## Description
+
+# IF BUG
+## Expected Behavior
+
+## Actual Behavior
+
+## Steps to Reproduce
+
+> NOTE: Attach any useful videos, screenshots, etc.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,7 @@
+## Highlights
+* bullet separated list of highlights
+* another highlight
+
+## Closes
+Closes #${issueNumber}
+Closes #${anotherIssueNumberIfThisClosesMoreThanJustOne}


### PR DESCRIPTION
## Highlights
* Moved `CONTRIBUTING.md` to a new `/.github` directory.
* Added templates for pull requests and issues to `/.github` directory