### PR TITLE
fix contributing reference in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ $ No box.event.json file found in the events/assets directory.  Please create th
 See [CHANGELOG.md](CHANGELOG.md)
 
 ## Contributing
-See [CONTRIBUTING.md](CONTRIBUTING.md)
+See [CONTRIBUTING.md](.github/CONTRIBUTING.md)
 
 ## License
 See [LICENSE.md](LICENSE.md)


### PR DESCRIPTION
## Highlights
* Fixed reference to `CONTRIBUTING.md` in `README.md` since it's now nested under the `.github` directory.

