### PR TITLE
propogate churros test shell code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## v0.3.0 <sub><sup>(TBD)</sup></sub>
 #### Highlights
+* `churros test` shell exit code is now propagated back to CLI properly.
+![CLI](http://cl.ly/0I262G3Q0u1z/Screen%20Recording%202016-02-24%20at%2001.45%20PM.gif)
+
 * To pass options on a given function in `cloud`, you now use the `cloud.withOptions` functions before your actual HTTP function, for example: `cloud.withOptions({qs: {foo: 'bar'}}).get('/foo')`.  As always, reference the unit tests for more examples.
 * Re-factored the schema validation code, and removed the expectation that all element tests would validate against schemas after revealing that, well, it's just not really worth it.
 

--- a/src/cli/churros-test.js
+++ b/src/cli/churros-test.js
@@ -81,7 +81,7 @@ const runTests = (suite, options) => {
   if (cliArgs.browser) args += util.format(" --browser %s", cliArgs.browser);
 
   let cmd = util.format(rootDir + '/../../node_modules/.bin/mocha %s %s', mochaPaths.join(' '), args);
-  shell.exec(cmd);
+  process.exit(shell.exec(cmd).code); // execute the cmd and make our exit code the same as 'churros test' code
 };
 
 commander


### PR DESCRIPTION
## Highlights
* `churros test` actually kicks off another `mocha` process and was swallowing the exit code from that shell command.  This code is now propagated back to the CLI properly.

## Examples
![CLI](http://cl.ly/0I262G3Q0u1z/Screen%20Recording%202016-02-24%20at%2001.45%20PM.gif)

