### PR TITLE
add id and object to object.definitions.json if needed

### DIFF
--- a/src/cli/churros-add.js
+++ b/src/cli/churros-add.js
@@ -160,6 +160,9 @@ const stubPlatformFiles = (r) =>
 
 const stubElementFiles = (answers) =>
   new Promise((res, rej) => {
+    const objectDefinitionsFile = buildRootElementDir() + '/assets/object.definitions.json';
+    if (!fs.existsSync(objectDefinitionsFile)) fs.writeFileSync(objectDefinitionsFile, '{}');
+
     const suiteDir = buildRootElementDir() + '/' + answers.name;
     if (!fs.existsSync(suiteDir)) fs.mkdirSync(suiteDir);
 
@@ -217,6 +220,18 @@ const stubElementFiles = (answers) =>
         fs.writeFileSync(transformationsFile, JSON.stringify(currentTransformations, null, 2));
       } else {
         console.log('transformation for %s already exists for %s', name, answers.name);
+      }
+
+      const objectDefinitions = require(objectDefinitionsFile);
+      if (!objectDefinitions[name]) {
+        objectDefinitions[name] = {
+          fields: [{
+            path: 'id',
+            type: 'string'
+          }]
+        };
+      } else {
+        console.log('Object definition for %s already exists. To add fields to the object definition see elements/assets/object.definitions.json');
       }
     });
 


### PR DESCRIPTION
## Highlights
* if the resource does not exist in the global `object.definitions.json`, create the key and add the `id` field as a string

## Closes
* Closes #122 

