### PR TITLE
changed the --password option to churros test to be a flag

### DIFF
--- a/src/cli/assets/prompter.js
+++ b/src/cli/assets/prompter.js
@@ -1,0 +1,29 @@
+'use strict';
+
+const inquirer = require('inquirer');
+
+var exports = module.exports = {};
+
+/**
+ * Builds a question for inquirer to use
+ * @param  {string}   name      the name of the question
+ * @param  {string}   type      the type of question (input, confirm, list, rawlist, password)
+ * @param  {string}   message   the message to show to the user
+ * @param  {function} validate  the validation function
+ * @param  {boolean}  isDefault is default (i forget what this does ...)
+ * @return {array}               an object that the inquirer can use to prompt the user
+ */
+exports.buildQuestion = (name, type, message, validate, isDefault) => ({
+  name: name,
+  type: type,
+  message: message,
+  validate: validate,
+  default: isDefault
+});
+
+/**
+ * Using the inquirer module, takes the list of questions and prompts the user for each one
+ * @param  {array} questions The list of questions to prompt the user
+ * @return {Promise}           A promise that when resolved, will have all the answers to each question
+ */
+exports.askQuestions = (questions) => new Promise((res, rej) => inquirer.prompt(questions, (answers) => res(answers)));

--- a/src/cli/churros-add.js
+++ b/src/cli/churros-add.js
@@ -5,6 +5,7 @@ const fs = require('fs');
 const inquirer = require('inquirer');
 const replaceStream = require('replacestream');
 const tools = require('core/tools');
+const prompter = require('./assets/prompter');
 
 const terminate = (msg, args) => {
   args ? console.error(msg, args) : console.error(msg);
@@ -15,20 +16,10 @@ const buildRootPlatformDir = () => __dirname + '/../test/platform';
 
 const buildRootElementDir = () => __dirname + '/../test/elements';
 
-const askQuestions = (questions) => new Promise((res, rej) => inquirer.prompt(questions, (answers) => res(answers)));
-
 const validateValue = (value) => value ? true : 'Must enter a value';
 
-const buildQuestion = (name, type, message, validate, isDefault) => new Object({
-  name: name,
-  type: type,
-  message: message,
-  validate: validate,
-  default: isDefault
-});
-
 const buildChoiceQuestion = (name, type, message, choices, filter) => {
-  const q = buildQuestion(name, type, message);
+  const q = prompter.buildQuestion(name, type, message);
   q.choices = choices;
   q.filter = filter;
   return q;
@@ -36,23 +27,23 @@ const buildChoiceQuestion = (name, type, message, choices, filter) => {
 
 const buildPlatformQuestions = () =>
   new Promise((res, rej) => {
-    res([buildQuestion('name', 'input', 'Platform resource name:', (value) => validateValue(value))]);
+    res([prompter.buildQuestion('name', 'input', 'Platform resource name:', (value) => validateValue(value))]);
   });
 
 const buildElementQuestions = () =>
   new Promise((res, rej) => {
     res([
-      buildQuestion('name', 'input', 'Element name:', (value) => validateValue(value)),
-      buildQuestion('hub', 'input', 'Hub name:', (value) => validateValue(value)),
+      prompter.buildQuestion('name', 'input', 'Element name:', (value) => validateValue(value)),
+      prompter.buildQuestion('hub', 'input', 'Hub name:', (value) => validateValue(value)),
       buildChoiceQuestion('auth', 'list', 'Auth type:', ['standard', 'oauth1', 'oauth2'], (value) => value.toLowerCase())
     ]);
   });
 
 const buildResourceQuestions = () => [
-  buildQuestion('name', 'input', 'Resource name (CE name):', (value) => validateValue(value)),
-  buildQuestion('vendorName', 'input', 'Vendor resource name:', (value) => validateValue(value)),
-  buildQuestion('vendorId', 'input', 'Vendor ID field:', (value) => validateValue(value)),
-  buildQuestion('more', 'confirm', 'Add more resources:')
+  prompter.buildQuestion('name', 'input', 'Resource name (CE name):', (value) => validateValue(value)),
+  prompter.buildQuestion('vendorName', 'input', 'Vendor resource name:', (value) => validateValue(value)),
+  prompter.buildQuestion('vendorId', 'input', 'Vendor ID field:', (value) => validateValue(value)),
+  prompter.buildQuestion('more', 'confirm', 'Add more resources:')
 ];
 
 const askResourceQuestions = (r, resources) => {
@@ -73,23 +64,23 @@ const buildConfigQuestions = (auth, currentProps, firstTime) => {
   const qs = [];
   // these props are ALWAYS required for OAuth2 and OAuth1 elements
   if (firstTime && (auth === 'oauth1' || auth === 'oauth2')) {
-    qs.push(buildQuestion('oauth.api.key', 'input', 'OAuth API Key:', (value) => validateValue(value)));
-    qs.push(buildQuestion('oauth.api.secret', 'input', 'OAuth API Secret:', (value) => validateValue(value)));
-    qs.push(buildQuestion('username', 'input', 'Username:', (value) => validateValue(value)));
-    qs.push(buildQuestion('password', 'input', 'Password:', (value) => validateValue(value)));
-    qs.push(buildQuestion('oauth.scope', 'input', 'OAuth Scope (optional):'));
-    qs.push(buildQuestion('site.address', 'input', 'Subdomain (optional):'));
-    qs.push(buildQuestion('more', 'confirm', 'Add more configs:'));
+    qs.push(prompter.buildQuestion('oauth.api.key', 'input', 'OAuth API Key:', (value) => validateValue(value)));
+    qs.push(prompter.buildQuestion('oauth.api.secret', 'input', 'OAuth API Secret:', (value) => validateValue(value)));
+    qs.push(prompter.buildQuestion('username', 'input', 'Username:', (value) => validateValue(value)));
+    qs.push(prompter.buildQuestion('password', 'input', 'Password:', (value) => validateValue(value)));
+    qs.push(prompter.buildQuestion('oauth.scope', 'input', 'OAuth Scope (optional):'));
+    qs.push(prompter.buildQuestion('site.address', 'input', 'Subdomain (optional):'));
+    qs.push(prompter.buildQuestion('more', 'confirm', 'Add more configs:'));
   } else if (firstTime) {
-    qs.push(buildQuestion('more', 'confirm', 'Add configs:'));
+    qs.push(prompter.buildQuestion('more', 'confirm', 'Add configs:'));
   }
 
   if (!firstTime) {
     // using a random string so we can matchup these from key: "", value: "" to key: value later on
     const random = tools.random();
-    qs.push(buildQuestion('key.' + random, 'input', 'Key (i.e. my.config.key):'));
-    qs.push(buildQuestion('value.' + random, 'input', 'Value:'));
-    qs.push(buildQuestion('more', 'confirm', 'Add more configs:'));
+    qs.push(prompter.buildQuestion('key.' + random, 'input', 'Key (i.e. my.config.key):'));
+    qs.push(prompter.buildQuestion('value.' + random, 'input', 'Value:'));
+    qs.push(prompter.buildQuestion('more', 'confirm', 'Add more configs:'));
   }
 
   return qs;
@@ -235,7 +226,7 @@ const complete = (r, link) => {
 const add = (type, options) => {
   if (type === 'element') {
     buildElementQuestions(type)
-      .then(r => askQuestions(r))
+      .then(r => prompter.askQuestions(r))
       .then(r => askConfigQuestions(r))
       .then(r => askResourceQuestions(r))
       .then(r => stubElementFiles(r))
@@ -243,7 +234,7 @@ const add = (type, options) => {
       .catch(r => terminate(r));
   } else if (type === 'platform') {
     buildPlatformQuestions(type)
-      .then(r => askQuestions(r))
+      .then(r => prompter.askQuestions(r))
       .then(r => stubPlatformFiles(r))
       .then(r => complete(r, 'new-platform-suite'))
       .catch(r => terminate(r));


### PR DESCRIPTION
## Highlights
* When running `churros test`, the optional `--password` option is now just a flag.  When `--password` is passed, the user will then be prompted for their password on the command line.  Previously, you had to do `--password <password>`, forcing you to type your password in plain text on the command line.  No good at all.

## Examples
![gif](http://cl.ly/2W011u3C0934/Screen%20Recording%202016-03-05%20at%2009.43%20AM.gif)

## Closes
* Closes #121 