### PR TITLE
formulas tests for validating script steps

### DIFF
--- a/src/core/suite.js
+++ b/src/core/suite.js
@@ -7,74 +7,74 @@ const cloud = require('core/cloud');
 
 var exports = module.exports = {};
 
-const itPost = (api, payload, options, validationCb) => {
-  const name = util.format('should allow POST for %s', api);
-  it(name, () => cloud.withOptions(options).post(api, payload, validationCb));
+const itPost = (name, api, payload, options, validationCb) => {
+  const n = name || util.format('should allow POST for %s', api);
+  it(n, () => cloud.withOptions(options).post(api, payload, validationCb));
 };
 
-const itGet = (api, options, validationCb) => {
-  const name = util.format('should allow GET for %s', api);
-  it(name, () => cloud.withOptions(options).get(api, validationCb));
+const itGet = (name, api, options, validationCb) => {
+  const n = name || util.format('should allow GET for %s', api);
+  it(n, () => cloud.withOptions(options).get(api, validationCb));
 };
 
-const itCrd = (api, payload, validationCb) => {
-  const name = util.format('should allow CRD for %s', api);
-  it(name, () => cloud.crd(api, payload, validationCb));
+const itCrd = (name, api, payload, validationCb) => {
+  const n = name || util.format('should allow CRD for %s', api);
+  it(n, () => cloud.crd(api, payload, validationCb));
 };
 
-const itCd = (api, payload, validationCb) => {
-  const name = util.format('should allow CD for %s', api);
-  it(name, () => cloud.cd(api, payload, validationCb));
+const itCd = (name, api, payload, validationCb) => {
+  const n = name || util.format('should allow CD for %s', api);
+  it(n, () => cloud.cd(api, payload, validationCb));
 };
 
-const itCrds = (api, payload, validationCb) => {
-  const name = util.format('should allow CRDS for %s', api);
-  it(name, () => cloud.crd(api, payload, validationCb));
+const itCrds = (name, api, payload, validationCb) => {
+  const n = name || util.format('should allow CRDS for %s', api);
+  it(n, () => cloud.crd(api, payload, validationCb));
 };
 
-const itCrud = (api, payload, validationCb, updateCb) => {
-  const name = util.format('should allow CRUD for %s', api);
-  it(name, () => cloud.crud(api, payload, validationCb, updateCb));
+const itCrud = (name, api, payload, validationCb, updateCb) => {
+  const n = name || util.format('should allow CRUD for %s', api);
+  it(n, () => cloud.crud(api, payload, validationCb, updateCb));
 };
 
-const itCruds = (api, payload, validationCb, updateCb) => {
-  const name = util.format('should allow CRUDS for %s', api);
-  it(name, () => cloud.cruds(api, payload, validationCb, updateCb));
+const itCruds = (name, api, payload, validationCb, updateCb) => {
+  const n = name || util.format('should allow CRUDS for %s', api);
+  it(n, () => cloud.cruds(api, payload, validationCb, updateCb));
 };
 
-const itSr = (api, validationCb) => {
-  const name = util.format('should allow SR for %s', api);
-  it(name, () => cloud.get(api).then(r => cloud.get(api + '/' + r.body[0].id)));
+const itSr = (name, api, validationCb) => {
+  const n = name || util.format('should allow SR for %s', api);
+  it(n, () => cloud.get(api).then(r => cloud.get(api + '/' + r.body[0].id)));
 };
 
-const itPagination = (api, validationCb) => {
-  const name = util.format('should allow paginating %s', api);
+const itPagination = (name, api, validationCb) => {
+  const n = name || util.format('should allow paginating %s', api);
   const options = { qs: { page: 1, pageSize: 1 } };
 
-  it(name, () => cloud.withOptions(options).get(api, validationCb));
+  it(n, () => cloud.withOptions(options).get(api, validationCb));
 };
 
-const itGet404 = (api, invalidId) => {
-  const name = util.format('should throw a 404 when trying to retrieve a(n) %s with an ID that does not exist', api);
+const itGet404 = (name, api, invalidId) => {
+  const n = name || util.format('should throw a 404 when trying to retrieve a(n) %s with an ID that does not exist', api);
   if (invalidId) api = api + '/' + invalidId;
-  it(name, () => cloud.get(api, (r) => expect(r).to.have.statusCode(404)));
+  it(n, () => cloud.get(api, (r) => expect(r).to.have.statusCode(404)));
 };
 
-const itPatch404 = (api, payload, invalidId) => {
-  const name = util.format('should throw a 404 when trying to update a(n) %s with an ID that does not exist', api);
+const itPatch404 = (name, api, payload, invalidId) => {
+  const n = name || util.format('should throw a 404 when trying to update a(n) %s with an ID that does not exist', api);
   if (invalidId) api = api + '/' + invalidId;
-  it(name, () => cloud.update(api, (payload || {}), (r) => expect(r).to.have.statusCode(404), chakram.patch));
+  it(n, () => cloud.update(api, (payload || {}), (r) => expect(r).to.have.statusCode(404), chakram.patch));
 };
 
-const itPost400 = (api, payload) => {
-  let name = util.format('should throw a 400 when trying to create a(n) %s with an %s JSON body', api);
-  payload ? name = util.format(name, 'invalid') : name = util.format(name, 'empty');
-  it(name, () => cloud.post(api, payload, (r) => expect(r).to.have.statusCode(400)));
+const itPost400 = (name, api, payload) => {
+  let n = name || util.format('should throw a 400 when trying to create a(n) %s with an %s JSON body', api);
+  payload ? n = util.format(n, 'invalid') : n = util.format(n, 'empty');
+  it(n, () => cloud.post(api, payload, (r) => expect(r).to.have.statusCode(400)));
 };
 
-const itCeqlSearch = (api, payload, field) => {
-  const name = util.format('should support searching %s by %s', api, field);
-  it(name, () => {
+const itCeqlSearch = (name, api, payload, field) => {
+  const n = name || util.format('should support searching %s by %s', api, field);
+  it(n, () => {
     let id;
     return cloud.post(api, payload)
       .then(r => {
@@ -91,37 +91,39 @@ const itCeqlSearch = (api, payload, field) => {
 };
 
 const runTests = (api, payload, validationCb, tests) => {
-  const should = (api, validationCb, payload, options) => {
+  const should = (api, validationCb, payload, options, name) => {
     return {
-      return400OnPost: () => itPost400(api, payload),
-      return404OnPatch: (invalidId) => itPatch404(api, payload, invalidId),
-      return404OnGet: (invalidId) => itGet404(api, invalidId),
-      return200OnPost: () => itPost(api, payload, options, validationCb),
-      return200OnGet: () => itGet(api, options, validationCb),
-      supportPagination: () => itPagination(api, validationCb),
-      supportCeqlSearch: (field) => itCeqlSearch(api, payload, field),
-      supportCruds: (updateCb) => itCruds(api, payload, validationCb, updateCb),
-      supportCrud: (updateCb) => itCrud(api, payload, validationCb, updateCb),
-      supportCrd: () => itCrd(api, payload, validationCb),
-      supportCd: () => itCd(api, payload, validationCb),
-      supportCrds: () => itCrds(api, payload, validationCb),
-      supportSr: () => itSr(api, validationCb),
+      return400OnPost: () => itPost400(name, api, payload),
+      return404OnPatch: (invalidId) => itPatch404(name, api, payload, invalidId),
+      return404OnGet: (invalidId) => itGet404(name, api, invalidId),
+      return200OnPost: () => itPost(name, api, payload, options, validationCb),
+      return200OnGet: () => itGet(name, api, options, validationCb),
+      supportPagination: () => itPagination(name, api, validationCb),
+      supportCeqlSearch: (field) => itCeqlSearch(name, api, payload, field),
+      supportCruds: (updateCb) => itCruds(name, api, payload, validationCb, updateCb),
+      supportCrud: (updateCb) => itCrud(name, api, payload, validationCb, updateCb),
+      supportCrd: () => itCrd(name, api, payload, validationCb),
+      supportCd: () => itCd(name, api, payload, validationCb),
+      supportCrds: () => itCrds(name, api, payload, validationCb),
+      supportSr: () => itSr(name, api, validationCb),
     };
   };
 
-  const using = (myApi, myValidationCb, myPayload, myOptions) => {
+  const using = (myApi, myValidationCb, myPayload, myOptions, myName) => {
     return {
-      should: should(myApi, myValidationCb, myPayload, myOptions),
-      withApi: (myApi) => using(myApi, myValidationCb, myPayload, myOptions),
-      withValidation: (myValidationCb) => using(myApi, myValidationCb, myPayload, myOptions),
-      withJson: (myPayload) => using(myApi, myValidationCb, myPayload, myOptions),
-      withOptions: (myOptions) => using(api, validationCb, payload, myOptions)
+      should: should(myApi, myValidationCb, myPayload, myOptions, myName),
+      withName: (myName) => using(myApi, myValidationCb, myPayload, myOptions, myName),
+      withApi: (myApi) => using(myApi, myValidationCb, myPayload, myOptions, myName),
+      withValidation: (myValidationCb) => using(myApi, myValidationCb, myPayload, myOptions, myName),
+      withJson: (myPayload) => using(myApi, myValidationCb, myPayload, myOptions, myName),
+      withOptions: (myOptions) => using(api, validationCb, payload, myOptions, myName)
     };
   };
 
   const test = {
     api: api,
     should: should(api, validationCb, payload),
+    withName: (myName) => using(api, validationCb, payload, null, myName),
     withApi: (myApi) => using(myApi, validationCb, payload),
     withValidation: (myValidationCb) => using(api, myValidationCb, payload),
     withJson: (myPayload) => using(api, validationCb, myPayload),

--- a/src/test/platform/formulas/executions.js
+++ b/src/test/platform/formulas/executions.js
@@ -12,75 +12,11 @@ const b64 = require('core/tools').base64Encode;
 const sleep = require('sleep');
 const expect = require('chakram').expect;
 
-const provisionSfdcWithPolling = () => provisioner.create('sfdc',
-  {'event.notification.enabled': true,
-    'event.vendor.type': 'polling',
-    'event.poller.refresh_interval': 999999999});
-
-suite.forPlatform('formulas', null, null, (test) => {
-  let sfdcId;
-  before(done => provisionSfdcWithPolling().then(r => { sfdcId = r.body.id; done(); }));
-
-  it('should successfully execute a simple formula triggered by a single event', () => {
-    return common.deleteFormulasByName(test.api, 'simple-successful')
-        .then(r => {
-          const formula = require('./assets/simple-successful-formula');
-          const formulaInstance = require('./assets/simple-successful-formula-instance');
-
-          formulaInstance.configuration['trigger-instance'] = sfdcId;
-
-          return cloud.post(test.api, formula, fSchema)
-            .then(r => {
-              const formulaId = r.body.id;
-              return cloud.post(util.format('/formulas/%s/instances', formulaId), formulaInstance, fiSchema)
-                .then(r => {
-                  const formulaInstanceId = r.body.id;
-                  return generateSingleSfdcPollingEvent(sfdcId)
-                    .then(() => sleep.sleep(5))
-                    .then(() => common.getFormulaInstanceExecutions(formulaId, formulaInstanceId))
-                    .then(r => { expect(r).to.have.statusCode(200) && expect(r.body).to.have.length(1); return r; })
-                    .then(r => Promise.all(r.body.map(fie => common.getFormulaInstanceExecution(formulaId, formulaInstanceId, fie.id))))
-                    .then(rs => rs.map(r => validateExecution(r.body)(validateSimpleSuccessfulStepExecutions.forEvents(1))))
-                    .then(() => common.deleteFormulaInstance(formulaId, formulaInstanceId))
-                    .then(() => common.deleteFormula(formulaId))
-                  });
-            });
-        });
-  });
-
-  it('should successfully execute a simple formula triggered by a triple event', () => {
-    return common.deleteFormulasByName(test.api, 'simple-successful')
-        .then(r => {
-          const formula = require('./assets/simple-successful-formula');
-          const formulaInstance = require('./assets/simple-successful-formula-instance');
-
-          formulaInstance.configuration['trigger-instance'] = sfdcId;
-
-          return cloud.post(test.api, formula, fSchema)
-            .then(r => {
-              const formulaId = r.body.id;
-              return cloud.post(util.format('/formulas/%s/instances', formulaId), formulaInstance, fiSchema)
-                .then(r => {
-                  const formulaInstanceId = r.body.id;
-                  return generateTripleSfdcPollingEvent(sfdcId)
-                    .then(() => sleep.sleep(5))
-                    .then(() => common.getFormulaInstanceExecutions(formulaId, formulaInstanceId))
-                    .then(r => { expect(r).to.have.statusCode(200) && expect(r.body).to.have.length(3); return r; })
-                    .then(r => Promise.all(r.body.map(fie => common.getFormulaInstanceExecution(formulaId, formulaInstanceId, fie.id))))
-                    .then(rs => rs.map(r => validateExecution(r.body)(validateSimpleSuccessfulStepExecutions.forEvents(3))))
-                    .then(() => common.deleteFormulaInstance(formulaId, formulaInstanceId))
-                    .then(() => common.deleteFormula(formulaId))
-                  });
-            });
-        });
-  });
-
-  after(done => { provisioner.delete(sfdcId).then(() => done()) });
+const provisionSfdcWithPolling = () => provisioner.create('sfdc', {
+  'event.notification.enabled': true,
+  'event.vendor.type': 'polling',
+  'event.poller.refresh_interval': 999999999
 });
-
-const validateStepExecution = se => {
-  expect(se).to.have.property('status').and.equal('success');
-};
 
 const flattenStepExecutionValues = sevs =>
   sevs.reduce((flat, curr) => {
@@ -89,19 +25,8 @@ const flattenStepExecutionValues = sevs =>
     return flat;
   }, {});
 
-const validateTriggerBodyEvents = (tb, num) => {
-  expect(tb.message.events).to.have.length(num);
-}
-
-const validateSimpleSuccessfulEventTrigger = num => t => {
-  const flat = flattenStepExecutionValues(t.stepExecutionValues)
-  expect(flat['trigger.type']).to.equal('event');
-  expect(flat['trigger.event']).to.exist;
-  expect(flat['trigger.eventId']).to.exist;
-  validateTriggerBodyEvents(JSON.parse(flat['trigger.body']), num);
-};
 const validateSimpleSuccessfulRequestTrigger = t => {
-  const flat = flattenStepExecutionValues(t.stepExecutionValues)
+  const flat = flattenStepExecutionValues(t.stepExecutionValues);
   expect(flat['trigger.type']).to.equal('request');
   expect(flat['trigger.request.body']).to.exist;
   expect(flat['trigger.request.headers']).to.exist;
@@ -113,18 +38,18 @@ const validateSimpleSuccessfulRequestTrigger = t => {
   expect(flat['trigger.response.headers']).to.exist;
 };
 const validateSimpleSuccessfulScheduledTrigger = t => {
-  const flat = flattenStepExecutionValues(t.stepExecutionValues)
+  const flat = flattenStepExecutionValues(t.stepExecutionValues);
   expect(flat['trigger.type']).to.equal('scheduled');
 };
+
+const validateStepExecution = se => {
+  expect(se).to.have.property('status').and.equal('success');
+};
+
 const validateSimpleSuccessfulStepExecutionsForType = tValidator => ses => {
   expect(ses).to.have.length(2);
   ses.map(se => validateStepExecution(se));
   ses.filter(se => se.stepName === 'trigger').map(tValidator);
-};
-const validateSimpleSuccessfulStepExecutions = {
-  forEvents: (num) => validateSimpleSuccessfulStepExecutionsForType(validateSimpleSuccessfulEventTrigger(num)),
-  forRequest: validateSimpleSuccessfulStepExecutionsForType(validateSimpleSuccessfulRequestTrigger),
-  forScheduled: validateSimpleSuccessfulStepExecutionsForType(validateSimpleSuccessfulScheduledTrigger)
 };
 
 const validateStepExecutions = ses => {
@@ -134,7 +59,16 @@ const validateStepExecutions = ses => {
 const validateExecution = e => validator => {
   const fn = validator || validateStepExecutions;
   fn(e.stepExecutions);
-}
+};
+
+const generateSfdcPollingEvent = (instanceId, payload) => {
+  const headers = { 'Content-Type': 'application/json', 'Id': instanceId };
+  const encodedId = b64(instanceId.toString());
+
+  payload.instance_id = instanceId;
+
+  return chakram.post('/events/sfdcPolling/' + encodedId, payload, { 'headers': headers });
+};
 
 const generateTripleSfdcPollingEvent = (instanceId) => {
   const payload = require('./assets/triple-event-sfdc');
@@ -146,11 +80,90 @@ const generateSingleSfdcPollingEvent = (instanceId) => {
   return generateSfdcPollingEvent(instanceId, payload);
 };
 
-const generateSfdcPollingEvent = (instanceId, payload) => {
-  const headers = { 'Content-Type': 'application/json', 'Id': instanceId };
-  const encodedId = b64(instanceId.toString());
-
-  payload.instance_id = instanceId;
-
-  return chakram.post('/events/sfdcPolling/' + encodedId, payload, {'headers': headers});
+const validateTriggerBodyEvents = (tb, num) => {
+  expect(tb.message.events).to.have.length(num);
 };
+
+const validateSimpleSuccessfulEventTrigger = num => t => {
+  const flat = flattenStepExecutionValues(t.stepExecutionValues);
+  expect(flat['trigger.type']).to.equal('event');
+  expect(flat['trigger.event']).to.exist;
+  expect(flat['trigger.eventId']).to.exist;
+  validateTriggerBodyEvents(JSON.parse(flat['trigger.body']), num);
+};
+
+const validateSimpleSuccessfulStepExecutions = {
+  forEvents: (num) => validateSimpleSuccessfulStepExecutionsForType(validateSimpleSuccessfulEventTrigger(num)),
+  forRequest: validateSimpleSuccessfulStepExecutionsForType(validateSimpleSuccessfulRequestTrigger),
+  forScheduled: validateSimpleSuccessfulStepExecutionsForType(validateSimpleSuccessfulScheduledTrigger)
+};
+
+suite.forPlatform('formulas', null, null, (test) => {
+  let sfdcId;
+  before(done => provisionSfdcWithPolling().then(r => {
+    sfdcId = r.body.id;
+    done();
+  }));
+
+  it('should successfully execute a simple formula triggered by a single event', () => {
+    return common.deleteFormulasByName(test.api, 'simple-successful')
+      .then(r => {
+        const formula = require('./assets/simple-successful-formula');
+        const formulaInstance = require('./assets/simple-successful-formula-instance');
+
+        formulaInstance.configuration['trigger-instance'] = sfdcId;
+
+        return cloud.post(test.api, formula, fSchema)
+          .then(r => {
+            const formulaId = r.body.id;
+            return cloud.post(util.format('/formulas/%s/instances', formulaId), formulaInstance, fiSchema)
+              .then(r => {
+                const formulaInstanceId = r.body.id;
+                return generateSingleSfdcPollingEvent(sfdcId)
+                  .then(() => sleep.sleep(5))
+                  .then(() => common.getFormulaInstanceExecutions(formulaId, formulaInstanceId))
+                  .then(r => {
+                    expect(r).to.have.statusCode(200) && expect(r.body).to.have.length(1);
+                    return r;
+                  })
+                  .then(r => Promise.all(r.body.map(fie => common.getFormulaInstanceExecution(formulaId, formulaInstanceId, fie.id))))
+                  .then(rs => rs.map(r => validateExecution(r.body)(validateSimpleSuccessfulStepExecutions.forEvents(1))))
+                  .then(() => common.deleteFormulaInstance(formulaId, formulaInstanceId))
+                  .then(() => common.deleteFormula(formulaId));
+              });
+          });
+      });
+  });
+
+  it('should successfully execute a simple formula triggered by a triple event', () => {
+    return common.deleteFormulasByName(test.api, 'simple-successful')
+      .then(r => {
+        const formula = require('./assets/simple-successful-formula');
+        const formulaInstance = require('./assets/simple-successful-formula-instance');
+
+        formulaInstance.configuration['trigger-instance'] = sfdcId;
+
+        return cloud.post(test.api, formula, fSchema)
+          .then(r => {
+            const formulaId = r.body.id;
+            return cloud.post(util.format('/formulas/%s/instances', formulaId), formulaInstance, fiSchema)
+              .then(r => {
+                const formulaInstanceId = r.body.id;
+                return generateTripleSfdcPollingEvent(sfdcId)
+                  .then(() => sleep.sleep(5))
+                  .then(() => common.getFormulaInstanceExecutions(formulaId, formulaInstanceId))
+                  .then(r => {
+                    expect(r).to.have.statusCode(200) && expect(r.body).to.have.length(3);
+                    return r;
+                  })
+                  .then(r => Promise.all(r.body.map(fie => common.getFormulaInstanceExecution(formulaId, formulaInstanceId, fie.id))))
+                  .then(rs => rs.map(r => validateExecution(r.body)(validateSimpleSuccessfulStepExecutions.forEvents(3))))
+                  .then(() => common.deleteFormulaInstance(formulaId, formulaInstanceId))
+                  .then(() => common.deleteFormula(formulaId));
+              });
+          });
+      });
+  });
+
+  after(done => { provisioner.delete(sfdcId).then(() => done()); });
+});

--- a/src/test/platform/formulas/formulas.scripts.js
+++ b/src/test/platform/formulas/formulas.scripts.js
@@ -1,0 +1,82 @@
+'use strict';
+
+const suite = require('core/suite');
+const schema = require('./assets/formula.schema');
+const common = require('./assets/common');
+const cloud = require('core/cloud');
+const expect = require('chakram').expect;
+
+const genGoodV1Script = () => "return {foo: 'bar'};";
+
+const genGoodV2Script = () => "done({foo: 'bar'});";
+
+const genBadV2Script = () => "'use strict'; let name = 'foo';";
+
+const genBaseStep = (engine, genScript) => ({
+  name: "churros-script",
+  type: "script",
+  properties: {
+    mimeType: "application/javascript",
+    scriptEngine: engine,
+    body: genScript()
+  }
+});
+
+const genV1Step = (genScript) => genBaseStep('v1', genScript);
+
+const genV2Step = (genScript) => genBaseStep('v2', genScript);
+
+const gen = (genStep) => (genScript) => {
+  genStep = typeof genStep === 'function' ? genStep : () => {};
+  genScript = typeof genScript === 'function' ? genScript : () => {};
+
+  const f = common.genFormula({});
+  f.steps = [genStep(genScript)];
+  return f;
+};
+
+/**
+ * Handles validating that formula script steps that are trying to be created have the right error handling capabilities
+ * around them
+ */
+suite.forPlatform('formulas', null, schema, (test) => {
+  test
+    .withName('should allow creating a script step with the v1 engine')
+    .withJson(gen(genV1Step)(genGoodV1Script))
+    .should.supportCd();
+
+  test
+    .withName('should allow creating a script step with the v2 engine')
+    .withJson(gen(genV2Step)(genGoodV2Script))
+    .should.supportCd();
+
+  test
+    .withName('should not allow creating a script without a return statement in the v1 engine')
+    .withJson(gen(genV1Step)(genGoodV2Script))
+    .should.return400OnPost();
+
+  test
+    .withName('should not allow creating a script with a return statement in the v2 engine')
+    .withJson(gen(genV2Step)(genGoodV1Script))
+    .should.return400OnPost();
+
+  test
+    .withName('should not allow creating a script without a done() callback in the v2 engine')
+    .withJson(gen(genV2Step)(genBadV2Script))
+    .should.return400OnPost();
+
+  it('should not allow adding a filter step to a formula using the v2 engine with no done() callback', () => {
+    const validator = (res) => {
+      expect(res).to.have.statusCode(400);
+      expect(res.body.message).to.be.a('string');
+      expect(res.body.message).to.contain('done()'); // should warn about NOT calling the done() callback
+      return res;
+    };
+
+    let formulaId;
+    return cloud.post(test.api, gen()())
+      .then(r => formulaId = r.body.id)
+      .then(r => cloud.post(`${test.api}/${formulaId}/steps`, genV2Step(genBadV2Script), validator))
+      .then(r => cloud.delete(`${test.api}/${formulaId}`));
+  });
+});

--- a/test/core/cloud.test.js
+++ b/test/core/cloud.test.js
@@ -216,14 +216,14 @@ describe('cloud', () => {
 
   it('should support post file with options', () => {
     // should really NOT depend on the file system here :/
-    const filePath = '.tmp';
+    const filePath = '.post1.tmp';
     fs.closeSync(fs.openSync(filePath, 'w'));
     return cloud.withOptions({ json: false }).postFile('/foo/file', filePath)
       .then(r => fs.unlink(filePath));
   });
 
   it('should throw an error if post file validation fails', () => {
-    const filePath = '.tmp';
+    const filePath = '.post2.tmp';
     fs.closeSync(fs.openSync(filePath, 'w'));
     return cloud.postFile('/foo/bad/file', filePath)
       .then(r => {
@@ -237,7 +237,7 @@ describe('cloud', () => {
 
   it('should support patch file', () => {
     // should really NOT depend on the file system here :/
-    const filePath = '.tmp';
+    const filePath = '.patch1.tmp';
     fs.closeSync(fs.openSync(filePath, 'w'));
     return cloud.patchFile('/foo/file', filePath)
       .then(r => fs.unlink(filePath));
@@ -245,7 +245,7 @@ describe('cloud', () => {
 
   it('should support patch file with options', () => {
     // should really NOT depend on the file system here :/
-    const filePath = '.tmp';
+    const filePath = '.patch2.tmp';
     fs.closeSync(fs.openSync(filePath, 'w'));
     return cloud.withOptions({ json: false }).patchFile('/foo/file', filePath)
       .then(r => fs.unlink(filePath));

--- a/test/core/suite.test.js
+++ b/test/core/suite.test.js
@@ -149,7 +149,10 @@ describe('suite', () => {
     test.withApi(test.api + '/456').should.return404OnGet();
     // *****************************************
 
+    // with options, uses the request libraries options object
     test.withOptions({ qs: { page: 1, pageSize: 1 } }).should.return200OnGet();
+
+    // no with... functions, which will just use the defaults that were passed in to the `suite.forPlatform` above
     test.should.return200OnPost();
     test.should.supportSr();
     test.should.supportCruds();
@@ -160,6 +163,12 @@ describe('suite', () => {
     test.should.supportCrds();
     test.should.supportPagination();
     test.should.supportCeqlSearch('id');
+
+    // overriding the default API that was passed in as the default in the `suite.forPlatform`
     test.withApi('/foo/bad').should.return400OnPost();
+
+    // examples of using .withName(...) which will set the name of the test to be whatever string is passed in
+    test.withName('this should be the name of the test').should.return200OnPost();
+    test.withApi('/foo/bad').withName('this should be the name of the test').should.return400OnPost();
   });
 });


### PR DESCRIPTION
## Highlights
* Added tests to test `POST /formulas` and `POST /formulas/:id/steps` APIs to ensure that the proper validation is done depending on what `scriptEngine` you are using.
 * `v1` scripts *must* have a `return` statement in them
 * `v2` scripts *must* have a `done()` callback in them
