### PR TITLE
formula tests failing in circle CI

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "replacestream": "^4.0.0",
     "selenium-webdriver": "^2.48.2",
     "shelljs": "^0.5.3",
+    "sleep": "^3.0.1",
     "tv4": "^1.2.7",
     "winston": "^2.1.1"
   },


### PR DESCRIPTION
## Highlights
* tests rely on `sleep` npm package, however that was not in the `package.json`.