### PR TITLE
Custom update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 ## v0.4.0 <sub><sup>(TBD)</sup></sub>
 #### Highlights
+* `test.withOptions()` will now pass through for all variations of `shouldSupportCruds`
+* able to pass churros options to withOptions, currently only the following is supported (`qs` included for context):
+```javascript
+{
+  qs: {
+    where: 'foo=bar'
+  },
+  churros: {
+    updatePayload: inserUpdatePayloadHere  
+  }
+}
+```
+updatePayload is used to pass a different payload to the `update` portion of a CRUDS cycle
 
 ## v0.3.0 <sub><sup>(2016-02-28)</sup></sub>
 #### Highlights

--- a/src/core/cloud.js
+++ b/src/core/cloud.js
@@ -46,7 +46,15 @@ const get = (api, validationCb, options) => {
 };
 exports.get = (api, validationCb) => get(api, validationCb, null);
 
+const modifyPayload = (payload, options) => {
+  if (!options) return payload;
+  let updatePayload = options.updatePayload;
+  delete options.updatePayload;
+  return updatePayload ? updatePayload : payload;
+};
+
 const update = (api, payload, validationCb, chakramCb, options) => {
+  payload = modifyPayload(payload, options);
   chakramCb = (chakramCb || chakram.patch);
   logger.debug('%s %s with options %s', chakramCb === chakram.patch ? 'PATCH' : 'PUT', api, options);
 

--- a/src/core/cloud.js
+++ b/src/core/cloud.js
@@ -47,9 +47,8 @@ const get = (api, validationCb, options) => {
 exports.get = (api, validationCb) => get(api, validationCb, null);
 
 const modifyPayload = (payload, options) => {
-  if (!options) return payload;
-  let updatePayload = options.updatePayload;
-  delete options.updatePayload;
+  if (!options || !options.churros) return payload;
+  let updatePayload = options.churros.updatePayload;
   return updatePayload ? updatePayload : payload;
 };
 

--- a/test/core/cloud.test.js
+++ b/test/core/cloud.test.js
@@ -97,6 +97,14 @@ beforeEach(() => {
       requestBody.id = 123;
       return requestBody;
     })
+    .patch('/foo/123', {
+      id: 789,
+      foo: 'bar'
+    })
+    .reply(200, (uri, requestBody) => {
+      requestBody.id = 789;
+      return requestBody;
+    })
     .patch('/foo/456')
     .reply(404, (uri, requestBody) => {
       return { message: 'No foo found with the given ID' };
@@ -110,6 +118,14 @@ beforeEach(() => {
     .put('/foo/123')
     .reply(200, (uri, requestBody) => {
       requestBody.id = 123;
+      return requestBody;
+    })
+    .put('/foo/123', {
+      id: 789,
+      foo: 'bar'
+    })
+    .reply(200, (uri, requestBody) => {
+      requestBody.id = 789;
       return requestBody;
     })
     .put('/foo/456')
@@ -153,6 +169,10 @@ describe('cloud', () => {
   it('should support put', () => cloud.put('/foo/123', genPayload(), genSchema()));
   it('should support put with options', () => cloud.withOptions({ json: true }).put('/foo/123', genPayload(), genSchema()));
   it('should support put with custom validation', () => cloud.put('/foo/456', genPayload(), (r) => expect(r).to.have.statusCode(404)));
+  it('should support put with alternate payload', () => {
+    return cloud.withOptions({ updatePayload: genPayload({ id: 789 }) })
+      .put('/foo/123', genPayload({ id: 123 }), (r) => expect(r.body.id).to.equal(789));
+  });
   it('should support put with no custom validation', () => cloud.put('/foo/123', genPayload()));
   it('should throw an error if put validation fails', () => {
     return cloud.put('/foo/456', genPayload(), (r) => expect(r).to.have.statusCode(200))
@@ -165,6 +185,10 @@ describe('cloud', () => {
   it('should support patch', () => cloud.patch('/foo/123', genPayload({ id: 123 }), genSchema()));
   it('should support patch with options', () => cloud.withOptions({ json: true }).patch('/foo/123', genPayload({ id: 123 }), genSchema()));
   it('should support patch with custom validation', () => cloud.patch('/foo/456', genPayload(), (r) => expect(r).to.have.statusCode(404)));
+  it('should support patch with alternate payload', () => {
+    return cloud.withOptions({ updatePayload: genPayload({ id: 789 }) })
+      .patch('/foo/123', genPayload({ id: 123 }), (r) => expect(r.body.id).to.equal(789));
+  });
   it('should support patch with no custom validation', () => cloud.put('/foo/123', genPayload()));
   it('should throw an error if patch validation fails', () => {
     return cloud.patch('/foo/456', genPayload(), (r) => expect(r).to.have.statusCode(200))

--- a/test/core/cloud.test.js
+++ b/test/core/cloud.test.js
@@ -170,7 +170,7 @@ describe('cloud', () => {
   it('should support put with options', () => cloud.withOptions({ json: true }).put('/foo/123', genPayload(), genSchema()));
   it('should support put with custom validation', () => cloud.put('/foo/456', genPayload(), (r) => expect(r).to.have.statusCode(404)));
   it('should support put with alternate payload', () => {
-    return cloud.withOptions({ updatePayload: genPayload({ id: 789 }) })
+    return cloud.withOptions({ churros: { updatePayload: genPayload({ id: 789 }) } })
       .put('/foo/123', genPayload({ id: 123 }), (r) => expect(r.body.id).to.equal(789));
   });
   it('should support put with no custom validation', () => cloud.put('/foo/123', genPayload()));
@@ -186,7 +186,7 @@ describe('cloud', () => {
   it('should support patch with options', () => cloud.withOptions({ json: true }).patch('/foo/123', genPayload({ id: 123 }), genSchema()));
   it('should support patch with custom validation', () => cloud.patch('/foo/456', genPayload(), (r) => expect(r).to.have.statusCode(404)));
   it('should support patch with alternate payload', () => {
-    return cloud.withOptions({ updatePayload: genPayload({ id: 789 }) })
+    return cloud.withOptions({ churros: { updatePayload: genPayload({ id: 789 }) } })
       .patch('/foo/123', genPayload({ id: 123 }), (r) => expect(r.body.id).to.equal(789));
   });
   it('should support patch with no custom validation', () => cloud.put('/foo/123', genPayload()));

--- a/test/core/suite.test.js
+++ b/test/core/suite.test.js
@@ -95,6 +95,11 @@ beforeEach(() => {
       requestBody.id = 123;
       return requestBody;
     })
+    .patch('/foo/123')
+    .reply(200, (uri, requestBody) => {
+      requestBody.id = 123;
+      return requestBody;
+    })
     .patch('/foo/456')
     .reply(404, (uri, requestBody) => {
       return { message: 'No foo found with the given ID' };


### PR DESCRIPTION
## Highlights
* adds support for passing an alternate payload for the update portion of a CRUDS cycle via the churros segment of options.

## Examples
```
 let updatePayloadExample = {
  name: 'updated!'
};

let options = {
  qs: {
    where: 'foo=bar'
  },
  churros: {
    updatePayload: updatePayloadExample
  }
};

test.withOptions(options).should.supportCruds();
```

## Closes
* Closes #131 