### PR TITLE
formula activation APIs

### DIFF
--- a/src/core/cloud.js
+++ b/src/core/cloud.js
@@ -67,16 +67,13 @@ exports.patch = (api, payload, validationCb) => patch(api, payload, validationCb
 const put = (api, payload, validationCb, options) => update(api, payload, validationCb, chakram.put, options);
 exports.put = (api, payload, validationCb) => put(api, payload, validationCb, null);
 
-const remove = (api, options) => {
+const remove = (api, validationCb, options) => {
   logger.debug('DELETE %s with options %s', api, options);
   return chakram.delete(api, null, options)
-    .then(r => {
-      expect(r).to.have.statusCode(200);
-      return r;
-    })
+    .then(r => validator(validationCb)(r))
     .catch(r => tools.logAndThrow('Failed to delete %s', r, api));
 };
-exports.delete = (api) => remove(api, null);
+exports.delete = (api, validationCb) => remove(api, validationCb, null);
 
 const postFile = (api, filePath, options) => {
   options = (options || {});

--- a/src/core/suite.js
+++ b/src/core/suite.js
@@ -99,16 +99,16 @@ const itNextPagePagination = (name, api, payload, amount, options, validationCb)
   });
 };
 
-const itGet404 = (name, api, invalidId) => {
-  const n = name || `should throw a 404 when trying to retrieve a(n) ${api} with an ID that does not exist`;
+const it404 = (name, api, invalidId, method, cloudCb) => {
+  const n = name || `should throw a 404 when trying to ${method} ${api} with an ID that does not exist`;
   if (invalidId) api = api + '/' + invalidId;
-  it(n, () => cloud.get(api, (r) => expect(r).to.have.statusCode(404)));
+  it(n, () => cloudCb(api, (r) => expect(r).to.have.statusCode(404)));
 };
 
-const itPatch404 = (name, api, payload, invalidId) => {
-  const n = name || `should throw a 404 when trying to update a(n) ${api} with an ID that does not exist`;
+const itUpdate404 = (name, api, payload, invalidId, method, chakramUpdateCb) => {
+  const n = name || `should throw a 404 when trying to ${method} ${api} with an ID that does not exist`;
   if (invalidId) api = api + '/' + invalidId;
-  it(n, () => cloud.update(api, (payload || {}), (r) => expect(r).to.have.statusCode(404), chakram.patch));
+  it(n, () => cloud.update(api, (payload || {}), (r) => expect(r).to.have.statusCode(404), chakramUpdateCb));
 };
 
 const itPost400 = (name, api, payload) => {
@@ -138,8 +138,10 @@ const itCeqlSearch = (name, api, payload, field) => {
 const runTests = (api, payload, validationCb, tests) => {
   const should = (api, validationCb, payload, options, name) => ({
     return400OnPost: () => itPost400(name, api, payload),
-    return404OnPatch: (invalidId) => itPatch404(name, api, payload, invalidId),
-    return404OnGet: (invalidId) => itGet404(name, api, invalidId),
+    return404OnPatch: (invalidId) => itUpdate404(name, api, payload, invalidId, 'PATCH', chakram.patch),
+    return404OnPut: (invalidId) => itUpdate404(name, api, payload, invalidId, 'PUT', chakram.put),
+    return404OnGet: (invalidId) => it404(name, api, invalidId, 'GET', cloud.get),
+    return404OnDelete: (invalidId) => it404(name, api, invalidId, 'DELETE', cloud.delete),
     return200OnPost: () => itPost(name, api, payload, options, validationCb),
     return200OnGet: () => itGet(name, api, options, validationCb),
     supportPagination: () => itPagination(name, api, validationCb),

--- a/src/core/tools.js
+++ b/src/core/tools.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const logger = require('winston');
+const sleep = require('sleep');
 
 var exports = module.exports = {};
 
@@ -21,3 +22,8 @@ exports.logAndThrow = (msg, error, arg) => {
 
 exports.base64Encode = s => new Buffer(s).toString('base64');
 exports.base64Decode = s => new Buffer(s, 'base64').toString('ascii');
+
+exports.sleep = secs => {
+  logger.debug(`sleeping for ${secs} seconds`);
+  sleep.sleep(secs);
+};

--- a/src/test/platform/formulas/assets/big-formula-instance.json
+++ b/src/test/platform/formulas/assets/big-formula-instance.json
@@ -4,7 +4,7 @@
     "stIdFieldName": "field2",
     "synchableFieldName": "field",
     "notification.email": "churros+trash@cloud-elements.com",
-    "sfdc.instance.id": "%s",
-    "sailthru.instance.id": "%s"
+    "sfdc.instance.id": "<replace-me>",
+    "sailthru.instance.id": "<replace-me>"
   }
 }

--- a/src/test/platform/formulas/assets/common.js
+++ b/src/test/platform/formulas/assets/common.js
@@ -3,6 +3,10 @@
 const tools = require('core/tools');
 const chakram = require('chakram');
 const util = require('util');
+const provisioner = require('core/provisioner');
+const cloud = require('core/cloud');
+const fSchema = require('./formula.schema');
+const fiSchema = require('./formula.instance.schema');
 
 var exports = module.exports = {};
 
@@ -22,13 +26,37 @@ exports.genInstance = (opts) => new Object({
   name: (opts.name || 'churros-formula-instance-name')
 });
 
-exports.deleteFormulasByName = (api, name) =>
+const deleteFormulaInstance = (fId, fiId) =>
+  chakram.delete(util.format('/formulas/%s/instances/%s', fId, fiId));
+
+const getInstancesForFormula = (fId) =>
+  chakram.get(util.format('/formulas/%s/instances', fId))
+  .then(r => r.body);
+
+const getInstancesForFormulas = (fs) =>
+  Promise.all(fs.map(f => getInstancesForFormula(f.id)));
+
+const deleteFormula = (fId) =>
+  chakram.delete(util.format('/formulas/%s', fId));
+
+const deleteFormulas = (fs) =>
+  Promise.all(fs.map(f => deleteFormula(f.id)));
+
+const getFormulasByName = (api, name) =>
+  chakram.get(api)
+  .then(r => r.body.filter(f => f.name === name));
+
+const deleteInstancesForFormulas = (is) =>
+  Promise.all(is.map(i => deleteFormulaInstance(i.formula.id, i.id)));
+
+const deleteFormulasByName = (api, name) =>
   getFormulasByName(api, name)
-    .then(fs =>
-      getInstancesForFormulas(fs)
-        .then(fis => [].concat.apply([], fis))
-        .then(deleteInstancesForFormulas)
-        .then(() => deleteFormulas(fs)));
+  .then(fs =>
+    getInstancesForFormulas(fs)
+    .then(fis => [].concat.apply([], fis))
+    .then(deleteInstancesForFormulas)
+    .then(() => deleteFormulas(fs)));
+exports.deleteFormulasByName = deleteFormulasByName;
 
 exports.getFormulaInstanceExecutions = (fId, fiId) =>
   chakram.get(util.format('/formulas/%s/instances/%s/executions', fId, fiId));
@@ -36,28 +64,22 @@ exports.getFormulaInstanceExecutions = (fId, fiId) =>
 exports.getFormulaInstanceExecution = (fId, fiId, fieId) =>
   chakram.get(util.format('/formulas/%s/instances/%s/executions/%s', fId, fiId, fieId));
 
-const deleteFormulaInstance = (fId, fiId) =>
-  chakram.delete(util.format('/formulas/%s/instances/%s', fId, fiId))
-
-const deleteInstancesForFormulas = (is) =>
-  Promise.all(is.map(i => deleteFormulaInstance(i.formula.id, i.id)))
-
-const getInstancesForFormulas = (fs) =>
-  Promise.all(fs.map(f => getInstancesForFormula(f.id)))
-
-const getInstancesForFormula = (fId) =>
-  chakram.get(util.format('/formulas/%s/instances', fId))
-    .then(r => r.body)
-
-const deleteFormulas = (fs) =>
-  Promise.all(fs.map(f => deleteFormula(f.id)))
-
-const deleteFormula = (fId) =>
-  chakram.delete(util.format('/formulas/%s', fId))
-
-const getFormulasByName = (api, name) =>
-  chakram.get(api)
-    .then(r => r.body.filter(f => f.name === name));
-
 exports.deleteFormulaInstance = deleteFormulaInstance;
 exports.deleteFormula = deleteFormula;
+
+exports.createFAndFI = () => {
+  let elementInstanceId, formulaId, formulaInstanceId;
+  const formula = require('./simple-successful-formula');
+  return deleteFormulasByName('/formulas', 'simple-successful')
+    .then(r => cloud.post('/formulas', formula, fSchema))
+    .then(r => formulaId = r.body.id)
+    .then(r => provisioner.create('closeio')) // just chose a random element, as i just need a valid ID
+    .then(r => elementInstanceId = r.body.id)
+    .then(r => {
+      const formulaInstance = require('./simple-successful-formula-instance');
+      formulaInstance.configuration['trigger-instance'] = elementInstanceId;
+      return cloud.post(`/formulas/${formulaId}/instances`, formulaInstance, fiSchema);
+    })
+    .then(r => formulaInstanceId = r.body.id)
+    .then(r => ({ formulaInstanceId: formulaInstanceId, formulaId: formulaId, elementInstanceId: elementInstanceId }));
+};

--- a/src/test/platform/formulas/assets/formula.schema.json
+++ b/src/test/platform/formulas/assets/formula.schema.json
@@ -6,7 +6,10 @@
     },
     "name": {
       "type": "string"
+    },
+    "active": {
+      "type": "boolean"
     }
   },
-  "required": ["id", "name"]
+  "required": ["id", "name", "active"]
 }

--- a/src/test/platform/formulas/assets/loop-formula-instance.json
+++ b/src/test/platform/formulas/assets/loop-formula-instance.json
@@ -1,0 +1,6 @@
+{
+  "name": "churros-loop-formula-instance",
+  "configuration": {
+    "sfdc.instance.id": "<replace-me>"
+  }
+}

--- a/src/test/platform/formulas/assets/loop-formula.json
+++ b/src/test/platform/formulas/assets/loop-formula.json
@@ -1,0 +1,51 @@
+{
+  "name": "loop-formula",
+  "active": true,
+  "configuration": [{
+    "name": "sfdc.instance.id",
+    "description": "The SFDC element instance that will trigger this formula.",
+    "type": "elementInstance",
+    "key": "sfdc.instance.id",
+    "required": true
+  }],
+  "triggers": [{
+    "type": "event",
+    "properties": {
+      "elementInstanceId": "${sfdc.instance.id}"
+    },
+    "onSuccess": [
+      "create-list"
+    ]
+  }],
+  "steps": [{
+    "name": "create-list",
+    "type": "script",
+    "properties": {
+      "scriptEngine": "v1",
+      "mimeType": "application/javascript",
+      "body": "\nvar list = [];\nfor (var i = 0; i < 50; i ++) {\n  list.push({\n    name: 'churros-name-' + i,\n    index: i\n  })\n}\n\nreturn {\n  list: list\n};"
+    },
+    "onSuccess": [
+      "looper"
+    ]
+  }, {
+    "name": "get-element-by-key",
+    "type": "request",
+    "properties": {
+      "method": "GET",
+      "api": "/elements/sfdc"
+    },
+    "onSuccess": [
+      "looper"
+    ]
+  }, {
+    "name": "looper",
+    "type": "loop",
+    "properties": {
+      "list": "${steps.create-list.list}"
+    },
+    "onSuccess": [
+      "get-element-by-key"
+    ]
+  }]
+}

--- a/src/test/platform/formulas/executions.js
+++ b/src/test/platform/formulas/executions.js
@@ -191,7 +191,6 @@ suite.forPlatform('formulas', null, null, (test) => {
       executions.stepExecutions.forEach(se => {
         se.stepExecutionValues.forEach(sev => {
           if (sev.key.indexOf('error') >= 0) {
-            console.log(sev.value);
             errorValueExists = true;
             expect(sev.value).to.contain('found inactive');
           }

--- a/src/test/platform/formulas/formula.instances.js
+++ b/src/test/platform/formulas/formula.instances.js
@@ -1,0 +1,52 @@
+'use strict';
+
+const suite = require('core/suite');
+const common = require('./assets/common');
+const schema = require('./assets/formula.schema.json');
+const cloud = require('core/cloud');
+const expect = require('chakram').expect;
+const provisioner = require('core/provisioner');
+
+const cleanup = (eiId, fId, fiId) => {
+  return cloud.delete(`/formulas/${fId}/instances/${fiId}`)
+    .then(r => cloud.delete(`/formulas/${fId}`))
+    .then(r => provisioner.delete(eiId));
+};
+
+suite.forPlatform('formulas', common.genFormula({}), schema, (test) => {
+  /* Create a formula instance to use in the tests below */
+  let elementInstanceId, formulaId, formulaInstanceId;
+  before(() => {
+    return common.createFAndFI()
+      .then(r => {
+        formulaId = r.formulaId;
+        formulaInstanceId = r.formulaInstanceId;
+        elementInstanceId = r.elementInstanceId;
+      });
+  });
+
+  /* Cleanup */
+  after(() => cleanup(elementInstanceId, formulaId, formulaInstanceId));
+
+  /* 200 on DELETE and PUT to /formulas/:id/instances/:id/active to activate and deactivate instance */
+  it('should allow activating and deactivating formula instance', () => {
+    const baseApi = `/formulas/${formulaId}/instances/${formulaInstanceId}`;
+    const api = `${baseApi}/active`;
+    return cloud.delete(api)
+      .then(r => cloud.get(baseApi))
+      .then(r => expect(r.body.active).to.equal(false))
+      .then(r => cloud.put(api))
+      .then(r => cloud.get(baseApi))
+      .then(r => expect(r.body.active).to.equal(true));
+  });
+
+  /* 404 on PUT where formula and formula instance do not exist */
+  test
+    .withApi('/formulas/-1/instances/-1/active')
+    .should.return404OnPut();
+
+  /* 404 on DELETE where formula and formula instance do not exist */
+  test
+    .withApi('/formulas/-1/instances/-1/active')
+    .should.return404OnDelete();
+});

--- a/test/core/suite.test.js
+++ b/test/core/suite.test.js
@@ -177,6 +177,8 @@ describe('suite', () => {
     nock(baseUrl, headers())
       .delete('/foo/123')
       .reply(200, (uri, requestBody) => ({}))
+      .delete('/foo/456')
+      .reply(404, (uri, requestBody) => ({ message: 'No foo found with the given ID' }))
       .delete('/foo/pagination/123')
       .reply(200, (uri, requestBody) => ({}));
   });
@@ -207,16 +209,18 @@ describe('suite', () => {
     // NOTE: all of these are equivalent just as examples
     // *****************************************
     test.should.return404OnPatch(456);
-    test.should.return404OnGet(456);
     test.withApi(test.api + '/456').should.return404OnPatch();
-    test.withApi(test.api + '/456').should.return404OnGet();
     // *****************************************
 
-    // with options, uses the request libraries options object
+    // with options, extends the request libraries options object
     test.withOptions({ qs: { page: 1, pageSize: 1 } }).should.return200OnGet();
 
     // no with... functions, which will just use the defaults that were passed in to the `suite.forPlatform` above
     test.should.return200OnPost();
+    test.should.return404OnGet(456);
+    test.withApi(test.api + '/456').should.return404OnGet();
+    test.withApi('/foo/456').should.return404OnPut();
+    test.withApi('/foo/456').should.return404OnDelete();
     test.withOptions({ json: true }).should.supportSr();
     test.withOptions({ json: true }).should.supportCruds();
     test.withOptions({ json: true }).should.supportCruds(chakram.put);

--- a/test/core/tools.test.js
+++ b/test/core/tools.test.js
@@ -51,4 +51,8 @@ describe('tools', () => {
     expect(encoded).to.be.a('string');
     expect(encoded).to.equal('ABCD');
   });
+
+  it('should support sleeping for x seconds', () => {
+    tools.sleep(1);
+  });
 });


### PR DESCRIPTION
## Highlights
* added new formula tests around the new `/formulas/:id/instances/:id/active` APIs
* added a formula execution test to kick off a long-running formula, deactivate it, and then ensure that it was terminated properly and has the right error message in its step execution values.

## Examples
```
  formulas
    ✓ should terminate an execution if the deactivate API is called during execution (21632ms)

  1 passing (42s)
```
