### PR TITLE
 removing invalid test due to formula script v1 "return" validation changes

### DIFF
--- a/src/core/oauth.js
+++ b/src/core/oauth.js
@@ -20,7 +20,7 @@ const manipulateDom = (element, browser, r, username, password, config) => {
   	  browser.wait(() => {
 	    return browser.getTitle().then((title) => !title);
   	  }, 10000);
-	  return browser.getCurrentUrl();	  
+	  return browser.getCurrentUrl();
     case 'desk':
       browser.get(r.body.oauthUrl);
       browser.findElement(webdriver.By.id('user_session_email')).sendKeys(username);
@@ -236,8 +236,8 @@ const manipulateDom = (element, browser, r, username, password, config) => {
     case 'sfdcmarketingcloud':
     case 'sfdcdocuments':
       browser.get(r.body.oauthUrl);
-      // wait 5 seconds for username to popup
-      browser.wait(webdriver.until.elementLocated(webdriver.By.name('username')), 5000);
+      // wait for username to show up
+      browser.wait(webdriver.until.elementLocated(webdriver.By.name('username')), 10000);
       browser.findElement(webdriver.By.id('username')).clear();
       browser.findElement(webdriver.By.id('username')).sendKeys(username);
       browser.findElement(webdriver.By.id('password')).clear();

--- a/src/test/platform/formulas/formulas.scripts.js
+++ b/src/test/platform/formulas/formulas.scripts.js
@@ -53,11 +53,6 @@ suite.forPlatform('formulas', null, schema, (test) => {
     .should.supportCd();
 
   test
-    .withName('should not allow creating a script without a return statement in the v1 engine')
-    .withJson(gen(genV1Step)(genGoodV2Script))
-    .should.return400OnPost();
-
-  test
     .withName('should allow creating a script with a helper function that has a return statement in the v2 engine')
     .withJson(gen(genV2Step)(genGoodV2ScriptWithFunction))
     .should.supportCd();


### PR DESCRIPTION
## Highlights
* no longer validate that `v1` scripts need a `return` statement - removing test

