### PR TITLE
withOptions was not passing on the right api, validationCb or payload

### DIFF
--- a/src/core/suite.js
+++ b/src/core/suite.js
@@ -117,7 +117,7 @@ const itUpdate404 = (name, api, payload, invalidId, method, chakramUpdateCb) => 
 };
 
 const itPost400 = (name, api, payload) => {
-  let n = name || `should throw a 400 when trying to create a(n) ${api} with an`;
+  let n = name || `should throw a 400 when trying to create a(n) ${api} with an `;
   n += payload ? 'invalid JSON body' : 'empty JSON body';
   it(n, () => cloud.post(api, payload, (r) => expect(r).to.have.statusCode(400)));
 };
@@ -168,7 +168,7 @@ const runTests = (api, payload, validationCb, tests) => {
     withApi: (myApi) => using(myApi, myValidationCb, myPayload, myOptions, myName),
     withValidation: (myValidationCb) => using(myApi, myValidationCb, myPayload, myOptions, myName),
     withJson: (myPayload) => using(myApi, myValidationCb, myPayload, myOptions, myName),
-    withOptions: (myOptions) => using(api, validationCb, payload, myOptions, myName)
+    withOptions: (myOptions) => using(myApi, myValidationCb, myPayload, myOptions, myName)
   });
 
   const test = {

--- a/test/core/suite.test.js
+++ b/test/core/suite.test.js
@@ -87,6 +87,9 @@ describe('suite', () => {
       .reply(200, () => genPayload({ id: 123 }))
       .get('/foo')
       .query({ where: 'id=\'123\'' })
+      .reply(200, () => [genPayload({ id: 123 })])
+      .get('/foo/search')
+      .query({ foo: 'bar' })
       .reply(200, () => [genPayload({ id: 123 })]);
 
     /** PATCH && PUT **/
@@ -240,5 +243,11 @@ describe('suite', () => {
     // examples of using .withName(...) which will set the name of the test to be whatever string is passed in
     test.withName('this should be the name of the test').should.return200OnPost();
     test.withApi('/foo/bad').withName('this should be the name of the test').should.return400OnPost();
+
+    test
+      .withName('should allow overriding the api and the options with new values')
+      .withApi(`${test.api}/search`)
+      .withOptions({ qs: { foo: 'bar' } })
+      .should.return200OnGet();
   });
 });


### PR DESCRIPTION
## Highlights
* `test.withOptions` was not passing on the right `api`, `validationCb` or `payload` in `suite.js`

## Examples
new unit test to validate:
```
      ✓ should allow overriding the api and the options with new values
```

## Closes
* Closes #178 

