### PR TITLE
suite "options" object support and linting requirement

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,3 +1,19 @@
+## Branching Model
+
+[GitHub Flow](https://guides.github.com/introduction/flow) branching workflow model.
+
+## Core Changes
+
+Whenever adding any new code to the `src/core` directory, ensure that these changes are unit-tested in `test/core`.
+
+## Pull Requests
+
+Before submitting a PR, make sure to run `npm test` locally to ensure that all tests pass, code coverage remains the same or is higher, and that all JS complies with our `.jshintrc` file.
+
+All PRs submitted to the `churros` repository will have *all* of the unit tests run before they're able to be merged into `master`.  When creating a PR, please refrain from assigning it to someone else until all GitHub status checks have been completed and you have that nice little :white_check_mark:.
+
+> __NOTE:__ When all tests have passed then you can assign the PR out.  Make sure the label at this point is `in review`.
+
 ## Best Practices
 In order to keep `churros` consistent, here are some common patterns that are followed in `churros`:
 * need to make tests as resilient as possible.  some common mistakes to avoid:
@@ -59,41 +75,18 @@ Whenever building out new test cases, it is good to leverage as much functionali
 
 ### `test`
 
-For examples on what is available in the `test` object that is passed in at the top of your test file, look at the unit tests in `suite.test.js`.  Here are some basic examples of how to use it:
-```javascript
-// The payload and schema passed in here are what will be used if not overridden for a given test.
-suite.forPlatform('foo', {payload: payload, schema: schema}, (test) => {
-  // NOTE: these first five are all equivalent
-  test.should.return200OnPost(); // using the default api, payload and schema
-  test.withApi('/foo').should.return200OnPost(); // customizing the api, but using default payload and schema
-  test.withJson(payload).should.return200OnPost(); // get it by now?
-  test.withValidation(schema).should.return200OnPost(); // now?
-  test.withApi('/foo').withJson(payload).withValidation(schema).should.return200OnPost(); // customize them all
+For examples on what is available in the `test` object that is passed in at the top of your test file, look at the unit tests in `suite.test.js`.  These tests exercise everything available and are the most up-to-date documentation.
 
-  test.should.return404OnPatch(456);
-  test.should.return404OnGet(456);
-  test.should.return200OnPost();
-  test.should.supportCruds();
-  test.should.supportCruds(chakram.put);
-  test.should.supportCrud();
-  test.should.supportCrd();
-  test.should.supportCrds();
-  test.should.supportPagination();
-  test.should.supportCeqlSearch('id');
-  test.withApi('/foo/bad').should.return400OnPost();
-});
-```
-
-> __PROPTIP:__ All of these functions create the `mocha` `it(...)` BDD function for you so you do *not* need to wrap these functions in an `it` block yourself.
+> __PROPTIP:__ All of the `.should` functions in the `test` object, create the `mocha` `it(...)` BDD function for you so you do *not* need to wrap these functions in an `it` block yourself.
 
 #### Adding a New Test to `test`
 If something is missing from `test` that seems like it could be a re-usable test in other suites, feel free to contribute to this library of tests.  All of the functions underneath `test` are simply using the utility functions in the `cloud` module and wrapping them in an `it(...)` `mocha` BDD function.  For example, here is the implementation for `test.should.supportCruds`:
 ```javascript
 const cloud = require('core/cloud');
 
-const itCruds = (api, payload, schema, updateCb) => {
-  const name = util.format('should allow CRUDS for %s', api);
-  it(name, () => cloud.cruds(api, payload, schema, updateCb));
+const itCruds = (name, api, payload, schema, updateCb) => {
+  const n = name || `should allow CRUDS for ${api}`;
+  it(n, () => cloud.cruds(api, payload, schema, updateCb));
 };
 ```
 
@@ -119,26 +112,10 @@ it('should allow CRUDS for ' + api, () => {
     // Runs a full CRUDs cycle on a contact
     .then(r => cloud.cruds(api, gen({ lead_id: accountId }), schema))
     // Cleans up the created account
-    .then(r => cloud.delete('/hubs/crm/accounts/' + accountId));
+    .then(r => cloud.delete(`/hubs/crm/accounts/${accountId}`));
 });
 ```
 
 > __PROTIP:__ Each test should be self-contained and should *not* rely on anything from a previous test.
 
 > __PROTIP:__ Validate JSON payloads against JSON schemas as opposed to validating each field individually, etc.  These JSON schemas are then what we will use to feed our developer docs so when we use them to validate our APIs, we are not only testing our APIs but also testing our documentation.
-
-## Branching Model
-
-[GitHub Flow](https://guides.github.com/introduction/flow) branching workflow model.
-
-## Core Changes
-
-Whenever adding any new code to the `src/core` directory, ensure that these changes are unit-tested in `test/core`.
-
-## Pull Requests
-
-Before submitting a PR, make sure to run `npm test` locally to ensure that all tests pass, code coverage remains the same or is higher, and that all JS complies with our `.jshintrc` file.
-
-All PRs submitted to the `churros` repository will have *all* of the unit tests run before they're able to be merged into `master`.  When creating a PR, please refrain from assigning it to someone else until all GitHub status checks have been completed and you have that nice little :white_check_mark:.
-
-> __NOTE:__ When all tests have passed then you can assign the PR out.  Make sure the label at this point is `in review`.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -62,7 +62,7 @@ Whenever building out new test cases, it is good to leverage as much functionali
 For examples on what is available in the `test` object that is passed in at the top of your test file, look at the unit tests in `suite.test.js`.  Here are some basic examples of how to use it:
 ```javascript
 // The payload and schema passed in here are what will be used if not overridden for a given test.
-suite.forPlatform('foo', payload, schema, (test) => {
+suite.forPlatform('foo', {payload: payload, schema: schema}, (test) => {
   // NOTE: these first five are all equivalent
   test.should.return200OnPost(); // using the default api, payload and schema
   test.withApi('/foo').should.return200OnPost(); // customizing the api, but using default payload and schema
@@ -136,6 +136,8 @@ it('should allow CRUDS for ' + api, () => {
 Whenever adding any new code to the `src/core` directory, ensure that these changes are unit-tested in `test/core`.
 
 ## Pull Requests
+
+Before submitting a PR, make sure to run `npm test` locally to ensure that all tests pass, code coverage remains the same or is higher, and that all JS complies with our `.jshintrc` file.
 
 All PRs submitted to the `churros` repository will have *all* of the unit tests run before they're able to be merged into `master`.  When creating a PR, please refrain from assigning it to someone else until all GitHub status checks have been completed and you have that nice little :white_check_mark:.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## v0.6.0 <sub><sup>(TBD)</sup></sub>
+#### Highlights
+
 ## v0.5.0 <sub><sup>(2016-03-25)</sup></sub>
 #### Highlights
 * element tests:

--- a/package.json
+++ b/package.json
@@ -10,11 +10,14 @@
   },
   "scripts": {
     "postinstall": "node -e \"var srcpath='../src/core'; var dstpath='node_modules/core';var fs=require('fs'); fs.exists(dstpath,function(exists){if(!exists){fs.symlinkSync(srcpath, dstpath,'dir');}});\"",
-    "test": "test/cli/tests.sh && istanbul cover -x '**/src/core/oauth.js' _mocha test/core -- --reporter spec --ui bdd",
+    "lintsrc": "./node_modules/.bin/jshint --config .jshintrc src/.",
+    "linttest": "./node_modules/.bin/jshint --config .jshintrc test/.",
+    "lintall": "npm run lintsrc && npm run linttest",
     "testnc": "test/cli/tests.sh && mocha test/core --reporter spec --ui bdd",
     "testcli": "test/cli/tests.sh",
     "testcore": "istanbul cover -x '**/src/core/oauth.js' _mocha test/core -- --reporter spec --ui bdd",
     "testcorenc": "mocha test/core --reporter spec --ui bdd",
+    "test": "npm run lintall && npm run testcli && npm run testcore",
     "coveralls": "cat ./coverage/lcov.info | coveralls"
   },
   "bin": {
@@ -40,6 +43,7 @@
     "winston": "^2.1.1"
   },
   "devDependencies": {
-    "bats": "^0.4.2"
+    "bats": "^0.4.2",
+    "jshint": "^2.9.1"
   }
 }

--- a/src/cli/assets/element.suite.template.js
+++ b/src/cli/assets/element.suite.template.js
@@ -3,7 +3,7 @@
 const suite = require('core/suite');
 const payload = require('./assets/%resource');
 
-suite.forElement('%hub', '%resource', payload, (test) => {
+suite.forElement('%hub', '%resource', { payload: payload }, (test) => {
   // checkout functions available under test.should which provide a lot of pre-canned tests
   //   more information here: https://github.com/cloud-elements/churros/blob/master/CONTRIBUTING.md#adding-tests-to-an-existing-suite
 

--- a/src/cli/assets/platform.suite.template.js
+++ b/src/cli/assets/platform.suite.template.js
@@ -4,7 +4,7 @@ const suite = require('core/suite');
 const payload = require('./assets/%name');
 const schema = require('./assets/%name.schema');
 
-suite.forPlatform('%name', schema, payload, (test) => {
+suite.forPlatform('%name', { schema: schema, payload: payload }, (test) => {
   // checkout functions available under test.should which provide a lot of pre-canned tests
   //   more information here: https://github.com/cloud-elements/churros/blob/master/CONTRIBUTING.md#adding-tests-to-an-existing-suite
 

--- a/src/cli/assets/resource.schema.template.json
+++ b/src/cli/assets/resource.schema.template.json
@@ -1,5 +1,5 @@
 {
-  "type": ["array", "object"],
+  "type": "object",
   "properties": {
     "id": {
       "type": "number"

--- a/src/cli/assets/sauce.template.json
+++ b/src/cli/assets/sauce.template.json
@@ -1,486 +1,519 @@
+
 {
-  "user": "",
-  "password": "",
-  "url": "",
-  "oauth.callback.url": "",
-  "events": {
-    "load": "5",
-    "wait": "60",
-    "element": "",
-    "port": 8999
-  },
-  "woocommerce": {
-    "oauth.api.key": "",
-    "oauth.api.secret": "",
-    "store.url": ""
-  },
-  "box": {
-    "oauth.api.key": "",
-    "oauth.api.secret": "",
-    "username": "",
+    "user": "",
     "password": "",
-    "provisioning": "oauth2"
-  },
-  "sfdc": {
-    "oauth.api.key": "",
-    "oauth.api.secret": "",
-    "username": "",
-    "password": "",
-    "provisioning": "oauth2"
-  },
-  "sfdcservicecloud": {
-    "oauth.api.key": "",
-    "oauth.api.secret": "",
-    "username": "",
-    "password": "",
-    "provisioning": "oauth2"
-  },
-  "sfdcmarketingcloud": {
-    "oauth.api.key": "",
-    "oauth.api.secret": "",
-    "username": "",
-    "password": "",
-    "provisioning": "oauth2"
-  },
-  "sfdcdocuments": {
-    "oauth.api.key": "",
-    "oauth.api.secret": "",
-    "username": "",
-    "password": "",
-    "provisioning": "oauth2"
-  },
-  "sugarcrmv2": {
-    "username": "",
-    "password": "",
-    "oauth.api.key": "",
-    "oauth.api.secret": "",
-    "site.url": "",
-    "oauth.callback.url": ""
-  },
-  "zohocrm": {
-    "crm.zohocrm.username": "",
-    "crm.zohocrm.password": "",
-    "password": "",
-    "username": ""
-  },
-  "abbyy": {
-    "username": "",
-    "password": ""
-  },
-  "allbound": {
-    "apikey": "",
-    "apiinstance": ""
-  },
-  "amazons3": {
-    "document.tagging": "",
-    "filemanagement.provider.access_key": "",
-    "filemanagement.provider.secret_key": "",
-    "filemanagement.provider.bucket_name": "",
-    "filemanagement.provider.region_name": ""
-  },
-  "autotaskcrm": {
-    "crm.autotask.server.url": "",
-    "crm.autotask.username": "",
-    "crm.autotask.password": ""
-  },
-  "autotaskhelpdesk": {
-    "helpdesk.autotask.server.url": "",
-    "helpdesk.autotask.username": "",
-    "helpdesk.autotask.password": ""
-  },
-  "brighttalk": {
-    "brighttalk.api.key": "",
-    "brighttalk.api.secret": "",
-    "brighttalk.isstaging": ""
-  },
-  "cherwell": {
-    "crm.cherwell.username": "",
-    "crm.cherwell.password": ""
-  },
-  "closeio": {
-    "password": "",
-    "username": ""
-  },
-  "dropbox": {
-    "oauth.api.key": "",
-    "oauth.api.secret": "",
-    "password": "",
-    "username": "",
-    "provisioning": "oauth2"
-  },
-  "connectwisecrm": {
-    "helpdesk.connectwise.server.url": "",
-    "helpdesk.connectwise.company": "",
-    "helpdesk.connectwise.username": "",
-    "helpdesk.connectwise.password": "",
-    "helpdesk.connectwise.wsdl.path": ""
-  },
-  "connectwisehd": {
-    "helpdesk.connectwise.server.url": "",
-    "helpdesk.connectwise.company": "",
-    "helpdesk.connectwise.username": "",
-    "helpdesk.connectwise.password": "",
-    "helpdesk.connectwise.wsdl.path": ""
-  },
-  "docusign": {
-    "username": "",
-    "password": "",
-    "oauth.api.key": "",
-    "docusign.environment": ""
-  },
-  "dynamicscrm": {
-    "dynamics.tenant": "",
-    "user.username": "",
-    "user.password": ""
-  },
-  "ecwid": {
-    "ecwid.order.key": "",
-    "ecwid.product.key": "",
-    "ecwid.store.id": ""
-  },
-  "facebooksocial": {
-    "oauth.api.key": "",
-    "oauth.api.secret": "",
-    "username": "",
-    "password": "",
-    "provisioning": "oauth2"
-  },
-  "dynamicscrmadfs": {
-    "user.password": "",
-    "user.username": "",
-    "dynamics.tenant": ""
-  },
-  "freshdesk": {
-    "subdomain": "",
-    "username": "",
-    "password": ""
-  },
-  "freshservice": {
-    "username": "",
-    "password": "",
-    "subdomain": ""
-  },
-  "greatplains": {
-    "greatplains.service.url": "",
-    "greatplains.domain": "",
-    "greatplains.user.name": "",
-    "greatplains.user.password": "",
-    "greatplains.company.name": ""
-  },
-  "hireright": {
-    "hireright.endpoint.url": "",
-    "hireright.password": "",
-    "hireright.username": "",
-    "hireright.account.id": "",
-    "hireright.company.login": "",
-    "hireright.user.ref.id": "",
-    "hireright.wsdl.location": ""
-  },
-  "jira": {
-    "username": "",
-    "password": "",
-    "base.url": ""
-  },
-  "mailjet": {
-    "mailjet.api.key": "",
-    "mailjet.api.secret": ""
-  },
-  "mailjetmarketing": {
-    "mailjet.api.key": "",
-    "mailjet.api.secret": ""
-  },
-  "netsuitecrm": {
-    "user.username": "",
-    "user.password": "",
-    "netsuite.accountId": ""
-  },
-  "netsuiteerp": {
-    "user.username": "",
-    "user.password": "",
-    "netsuite.accountId": ""
-  },
-  "netsuitefinance": {
-    "netsuite.accountId": "",
-    "user.password": "",
-    "user.username": ""
-  },
-  "netsuitehc": {
-    "user.username": "",
-    "user.password": "",
-    "netsuite.accountId": "",
-    "netsuite.sandbox": ""
-  },
-  "pardot": {
-    "apikey.user.key": "",
-    "apikey.user.name": "",
-    "apikey.user.password": ""
-  },
-  "pipedrive": {
-    "pipedrive.email": "",
-    "pipedrive.password": ""
-  },
-  "questbackefs": {
-    "efs.token": "",
-    "base.url": "",
-    "efs.handler": ""
-  },
-  "quickbooksonprem": {
-    "app.name": "",
-    "host.ip": ""
-  },
-  "readytalk": {
-    "username": "",
-    "password": ""
-  },
-  "sailthru": {
-    "sailthru.api.key": "",
-    "sailthru.api.secret": ""
-  },
-  "salescloud": {
-    "crm.salescloud.username": "",
-    "crm.salescloud.password": "",
-    "crm.salescloud.server.url": ""
-  },
-  "servicecloud": {
-    "helpdesk.servicecloud.username": "",
-    "helpdesk.servicecloud.password": "",
-    "helpdesk.servicecloud.endpointurl": "",
-    "helpdesk.servicecloud.fetchallvalues": ""
-  },
-  "servicenow": {
-    "username": "",
-    "password": "",
-    "servicenow.subdomain": ""
-  },
-  "stormpath": {
-    "api.key": "",
-    "api.secret": "",
-    "stormpath.application.name": ""
-  },
-  "vcloud": {
-    "infrastructure.vcloud.example_value": "",
-    "vcloud.server.url": "",
-    "vcloud.username": "",
-    "vcloud.password": "",
-    "vcloud.rabbitmq.server.host": "",
-    "vcloud.rabbitmq.server.port": "",
-    "vcloud.rabbitmq.server.username": "",
-    "vcloud.server.password": ""
-  },
-  "volusion": {
-    "volusion.store.url": "",
-    "volusion.login.email": "",
-    "volusion.encrypted.password": ""
-  },
-  "instagram": {
-    "oauth.api.key": "",
-    "oauth.api.secret": "",
-    "username": "",
-    "password": "",
-    "provisioning": "oauth2"
-  },
-  "zendesk": {
-    "oauth.api.key": "",
-    "oauth.api.secret": "",
-    "zendesk.subdomain": "",
-    "username": "",
-    "password": "",
-    "oauth.site.address": "",
-    "provisioning": "oauth2",
-    "site.address": ""
-  },
-  "shopify": {
-    "provisioning": "oauth2",
-    "site.address": "",
-    "siteAddress": "",
-    "oauth.api.key": "",
-    "oauth.api.secret": "",
-    "oauth.scope": "",
-    "username": "",
-    "password": ""
-  },
-  "etsy": {
-    "password": "",
-    "oauth.api.key": "",
-    "oauth.api.secret": "",
-    "username": "",
-    "oauth.request.url": "",
-    "shop.id": "",
-    "provisioning": "oauth1"
-  },
-  "acton": {
-    "oauth.api.key": "",
-    "oauth.api.secret": "",
+    "url": "",
     "oauth.callback.url": "",
-    "password": "",
-    "username": "",
-    "provisioning": "oauth2"
-  },
-  "taxify": {
-    "api.key": ""
-  },
-  "desk": {
-    "oauth.request.url": "",
-    "oauth.api.key": "",
-    "oauth.api.secret": "",
-    "username": "",
-    "password": "",
-    "provisioning": "oauth2"
-  },
-  "eloqua": {
-    "provisioning": "oauth2",
-    "username": "",
-    "password": "",
-    "oauth.api.key": "",
-    "oauth.api.secret": "",
-    "company.name": ""
-  },
-  "evernote": {
-    "oauth.api.key": "",
-    "oauth.api.secret": "",
-    "username": "",
-    "password": "",
-    "document.tagging": "",
-    "provisioning": "oauth1",
-    "evernote.sandbox": ""
-  },
-  "flickr": {
-    "oauth.api.key": "",
-    "oauth.api.secret": "",
-    "password": "",
-    "provisioning": "oauth1",
-    "username": "",
-    "oauth.request.url": ""
-  },
-  "freshbooks": {
-    "oauth.api.secret": "",
-    "username": "",
-    "oauth.api.key": "",
-    "password": "",
-    "provisioning": "oauth1"
-  },
-  "googledrive": {
-    "oauth.api.key": "",
-    "oauth.api.secret": "",
-    "username": "",
-    "password": "",
-    "provisioning": "oauth2"
-  },
-  "hubspot": {
-    "provisioning": "oauth2",
-    "oauth.api.key": "",
-    "oauth.api.secret": "",
-    "username": "",
-    "password": "",
-    "oauth.scope": "",
-    "create.bulk.properties": ""
-  },
-  "hubspotcrm": {
-    "provisioning": "oauth2",
-    "oauth.api.key": "",
-    "oauth.api.secret": "",
-    "username": "",
-    "password": "",
-    "oauth.scope": "",
-    "create.bulk.properties": ""
-  },
-  "infusionsoftcrm": {
-    "oauth.api.key": "",
-    "oauth.api.secret": "",
-    "username": "",
-    "password": "",
-    "infusionsoft.private.key": "",
-    "provisioning": "oauth2"
-  },
-  "infusionsoftmarketing": {
-    "oauth.api.key": "",
-    "oauth.api.secret": "",
-    "username": "",
-    "password": "",
-    "infusionsoft.private.key": "",
-    "provisioning": "oauth2"
-  },
-  "mailchimp3": {
-    "provisioning": "oauth2",
-    "oauth.api.key": "",
-    "oauth.api.secret": "",
-    "username": "",
-    "password": ""
-  },
-  "marketo": {
-    "marketo.identity.url": "",
-    "base.url": "",
-    "oauth.api.key": "",
-    "oauth.api.secret": "",
-    "provisioning": "oauth2",
-    "username": "",
-    "password": "",
-    "code": ""
-  },
-  "namely": {
-    "provisioning": "oauth2",
-    "oauth.api.key": "",
-    "oauth.api.secret": "",
-    "username": "",
-    "password": "",
-    "subdomain": ""
-  },
-  "onedrivebusiness": {
-    "provisioning": "oauth2",
-    "oauth.api.key": "",
-    "oauth.api.secret": "",
-    "username": "",
-    "password": "",
-    "sharepoint.document.library": "",
-    "document.tagging": "",
-    "sharepoint.site.address": "",
-    "site.address": "",
-    "oauth.scope": "",
-    "onedrivebusiness.site.address": ""
-  },
-  "onedrivev2": {
-    "oauth.api.key": "",
-    "oauth.api.secret": "",
-    "username": "",
-    "password": "",
-    "provisioning": "oauth2",
-    "event.config.path": "",
-    "document.tagging": "",
-    "oauth.scope": ""
-  },
-  "quickbooks": {
-    "provisioning": "oauth1",
-    "oauth.api.key": "",
-    "oauth.api.secret": "",
-    "username": "",
-    "password": ""
-  },
-  "servicemax": {
-    "oauth.api.key": "",
-    "oauth.api.secret": "",
-    "username": "",
-    "password": "",
-    "provisioning": "oauth2"
-  },
-  "sharepoint": {
-    "provisioning": "oauth2",
-    "oauth.api.key": "",
-    "oauth.api.secret": "",
-    "username": "",
-    "password": "",
-    "sharepoint.document.library": "",
-    "document.tagging": "",
-    "sharepoint.site.address": "",
-    "site.address": "",
-    "oauth.scope": ""
-  },
-  "magento": {
-    "provisioning": "oauth1",
-    "oauth.api.key": "",
-    "oauth.api.secret": "",
-    "username": "",
-    "password": "",
-    "site.address": "",
-    "store.url": ""
-  }
+    "events": {
+        "load": 5,
+        "wait": 45,
+        "element": "",
+        "port": 8999
+    },
+    "adobe-esign": {
+        "oauth.api.key": "",
+        "oauth.api.secret": "",
+        "username": "",
+        "password": "",
+        "provisioning": "",
+        "oauth.scope": ""
+    },
+    "woocommerce": {
+        "oauth.api.key": "",
+        "oauth.api.secret": "",
+        "store.url": ""
+    },
+    "box": {
+        "oauth.api.key": "",
+        "oauth.api.secret": "",
+        "username": "",
+        "password": "",
+        "provisioning": ""
+    },
+    "sfdc": {
+        "oauth.api.key": "",
+        "oauth.api.secret": "",
+        "username": "",
+        "password": "",
+        "provisioning": ""
+    },
+    "sfdcservicecloud": {
+        "oauth.api.key": "",
+        "oauth.api.secret": "",
+        "username": "",
+        "password": "",
+        "provisioning": ""
+    },
+    "sfdcmarketingcloud": {
+        "oauth.api.key": "",
+        "oauth.api.secret": "",
+        "username": "",
+        "password": "",
+        "provisioning": ""
+    },
+    "sfdcdocuments": {
+        "oauth.api.key": "",
+        "oauth.api.secret": "",
+        "username": "",
+        "password": "",
+        "provisioning": ""
+    },
+    "sugarcrmv2": {
+        "username": "",
+        "password": "",
+        "oauth.api.key": "",
+        "oauth.api.secret": "",
+        "site.url": "",
+        "oauth.callback.url": ""
+    },
+    "zohocrm": {
+        "crm.zohocrm.username": "",
+        "crm.zohocrm.password": "",
+        "password": "",
+        "username": ""
+    },
+    "abbyy": {
+        "username": "",
+        "password": ""
+    },
+    "allbound": {
+        "apikey": "",
+        "apiinstance": ""
+    },
+    "amazons3": {
+        "document.tagging": "",
+        "filemanagement.provider.access_key": "",
+        "filemanagement.provider.secret_key": "",
+        "filemanagement.provider.bucket_name": "",
+        "filemanagement.provider.region_name": ""
+    },
+    "autotaskcrm": {
+        "crm.autotask.server.url": "",
+        "crm.autotask.username": "",
+        "crm.autotask.password": ""
+    },
+    "autotaskhelpdesk": {
+        "helpdesk.autotask.server.url": "",
+        "helpdesk.autotask.username": "",
+        "helpdesk.autotask.password": ""
+    },
+    "brighttalk": {
+        "brighttalk.api.key": "",
+        "brighttalk.api.secret": "",
+        "brighttalk.isstaging": ""
+    },
+    "cherwell": {
+        "crm.cherwell.username": "",
+        "crm.cherwell.password": "",
+        "base.url": ""
+    },
+    "closeio": {
+        "password": "",
+        "username": ""
+    },
+    "dropbox": {
+        "oauth.api.key": "",
+        "oauth.api.secret": "",
+        "password": "",
+        "username": "",
+        "provisioning": ""
+    },
+    "dropboxbusiness": {
+        "oauth.api.key": "",
+        "oauth.api.secret": "",
+        "username": "",
+        "password": "",
+        "provisioning": ""
+    },
+    "connectwisecrm": {
+        "helpdesk.connectwise.server.url": "",
+        "helpdesk.connectwise.company": "",
+        "helpdesk.connectwise.username": "",
+        "helpdesk.connectwise.password": "",
+        "helpdesk.connectwise.wsdl.path": ""
+    },
+    "connectwisehd": {
+        "helpdesk.connectwise.server.url": "",
+        "helpdesk.connectwise.company": "",
+        "helpdesk.connectwise.username": "",
+        "helpdesk.connectwise.password": "",
+        "helpdesk.connectwise.wsdl.path": ""
+    },
+    "docusign": {
+        "username": "",
+        "password": "",
+        "oauth.api.key": "",
+        "docusign.environment": ""
+    },
+    "dynamicscrm": {
+        "dynamics.tenant": "",
+        "user.username": "",
+        "user.password": ""
+    },
+    "ecwid": {
+        "ecwid.order.key": "",
+        "ecwid.product.key": "",
+        "ecwid.store.id": ""
+    },
+    "facebooksocial": {
+        "oauth.api.key": "",
+        "oauth.api.secret": "",
+        "username": "",
+        "password": "",
+        "provisioning": ""
+    },
+    "dynamicscrmadfs": {
+        "user.password": "",
+        "user.username": "",
+        "dynamics.tenant": ""
+    },
+    "freshdesk": {
+        "subdomain": "",
+        "username": "",
+        "password": ""
+    },
+    "freshservice": {
+        "username": "",
+        "password": "",
+        "subdomain": ""
+    },
+    "greatplains": {
+        "greatplains.service.url": "",
+        "greatplains.domain": "",
+        "greatplains.user.name": "",
+        "greatplains.user.password": "",
+        "greatplains.company.name": ""
+    },
+    "hireright": {
+        "hireright.endpoint.url": "",
+        "hireright.password": "",
+        "hireright.username": "",
+        "hireright.account.id": "",
+        "hireright.company.login": "",
+        "hireright.user.ref.id": "",
+        "hireright.wsdl.location": ""
+    },
+    "jira": {
+        "username": "",
+        "password": "",
+        "base.url": ""
+    },
+    "mailjet": {
+        "mailjet.api.key": "",
+        "mailjet.api.secret": ""
+    },
+    "mailjetmarketing": {
+        "mailjet.api.key": "",
+        "mailjet.api.secret": ""
+    },
+    "netsuitecrm": {
+        "user.username": "",
+        "user.password": "",
+        "netsuite.accountId": ""
+    },
+    "netsuiteerp": {
+        "user.username": "",
+        "user.password": "",
+        "netsuite.accountId": ""
+    },
+    "netsuitefinance": {
+        "netsuite.accountId": "",
+        "user.password": "",
+        "user.username": ""
+    },
+    "netsuitehc": {
+        "user.username": "",
+        "user.password": "",
+        "netsuite.accountId": "",
+        "netsuite.sandbox": ""
+    },
+    "pardot": {
+        "apikey.user.key": "",
+        "apikey.user.name": "",
+        "apikey.user.password": ""
+    },
+    "pipedrive": {
+        "pipedrive.email": "",
+        "pipedrive.password": ""
+    },
+    "questbackefs": {
+        "efs.token": "",
+        "base.url": "",
+        "efs.handler": ""
+    },
+    "quickbooksonprem": {
+        "app.name": "",
+        "host.ip": ""
+    },
+    "readytalk": {
+        "username": "",
+        "password": ""
+    },
+    "sailthru": {
+        "sailthru.api.key": "",
+        "sailthru.api.secret": ""
+    },
+    "salescloud": {
+        "crm.salescloud.username": "",
+        "crm.salescloud.password": "",
+        "crm.salescloud.server.url": ""
+    },
+    "servicecloud": {
+        "helpdesk.servicecloud.username": "",
+        "helpdesk.servicecloud.password": "",
+        "helpdesk.servicecloud.endpointurl": "",
+        "helpdesk.servicecloud.fetchallvalues": ""
+    },
+    "servicenow": {
+        "username": "",
+        "password": "",
+        "servicenow.subdomain": ""
+    },
+    "stormpath": {
+        "api.key": "",
+        "api.secret": "",
+        "stormpath.application.name": ""
+    },
+    "vcloud": {
+        "infrastructure.vcloud.example_value": "",
+        "vcloud.server.url": "",
+        "vcloud.username": "",
+        "vcloud.password": "",
+        "vcloud.rabbitmq.server.host": "",
+        "vcloud.rabbitmq.server.port": "",
+        "vcloud.rabbitmq.server.username": "",
+        "vcloud.server.password": ""
+    },
+    "volusion": {
+        "volusion.store.url": "",
+        "volusion.login.email": "",
+        "volusion.encrypted.password": ""
+    },
+    "instagram": {
+        "oauth.api.key": "",
+        "oauth.api.secret": "",
+        "username": "",
+        "password": "",
+        "provisioning": ""
+    },
+    "zendesk": {
+        "oauth.api.key": "",
+        "oauth.api.secret": "",
+        "zendesk.subdomain": "",
+        "username": "",
+        "password": "",
+        "oauth.site.address": "",
+        "provisioning": "",
+        "site.address": ""
+    },
+    "shopify": {
+        "provisioning": "",
+        "site.address": "",
+        "siteAddress": "",
+        "oauth.api.key": "",
+        "oauth.api.secret": "",
+        "oauth.scope": "",
+        "username": "",
+        "password": "",
+        "oauth.callback.url": ""
+    },
+    "etsy": {
+        "password": "",
+        "oauth.api.key": "",
+        "oauth.api.secret": "",
+        "username": "",
+        "oauth.request.url": "",
+        "shop.id": "",
+        "provisioning": ""
+    },
+    "acton": {
+        "oauth.api.key": "",
+        "oauth.api.secret": "",
+        "oauth.callback.url": "",
+        "password": "",
+        "username": "",
+        "provisioning": ""
+    },
+    "taxify": {
+        "api.key": ""
+    },
+    "desk": {
+        "oauth.request.url": "",
+        "oauth.token.url": "",
+        "oauth.authorization.url": "",
+        "base.url": "",
+        "oauth.api.key": "",
+        "oauth.api.secret": "",
+        "username": "",
+        "password": "",
+        "subdomain": "",
+        "provisioning": ""
+    },
+    "eloqua": {
+        "provisioning": "",
+        "username": "",
+        "password": "",
+        "oauth.api.key": "",
+        "oauth.api.secret": "",
+        "company.name": ""
+    },
+    "evernote": {
+        "oauth.api.key": "",
+        "oauth.api.secret": "",
+        "username": "",
+        "password": "",
+        "document.tagging": "",
+        "provisioning": "",
+        "evernote.sandbox": ""
+    },
+    "flickr": {
+        "oauth.api.key": "",
+        "oauth.api.secret": "",
+        "password": "",
+        "provisioning": "",
+        "username": "",
+        "oauth.request.url": ""
+    },
+    "freshbooks": {
+        "oauth.api.secret": "",
+        "username": "",
+        "oauth.api.key": "",
+        "password": "",
+        "provisioning": ""
+    },
+    "googledrive": {
+        "oauth.api.key": "",
+        "oauth.api.secret": "",
+        "username": "",
+        "password": "",
+        "provisioning": ""
+    },
+    "hubspot": {
+        "provisioning": "",
+        "oauth.api.key": "",
+        "oauth.api.secret": "",
+        "username": "",
+        "password": "",
+        "oauth.scope": "",
+        "create.bulk.properties": ""
+    },
+    "hubspotcrm": {
+        "provisioning": "",
+        "oauth.api.key": "",
+        "oauth.api.secret": "",
+        "username": "",
+        "password": "",
+        "oauth.scope": "",
+        "create.bulk.properties": ""
+    },
+    "infusionsoftcrm": {
+        "oauth.api.key": "",
+        "oauth.api.secret": "",
+        "username": "",
+        "password": "",
+        "infusionsoft.private.key": "",
+        "provisioning": ""
+    },
+    "infusionsoftmarketing": {
+        "oauth.api.key": "",
+        "oauth.api.secret": "",
+        "username": "",
+        "password": "",
+        "infusionsoft.private.key": "",
+        "provisioning": ""
+    },
+    "mailchimp3": {
+        "provisioning": "",
+        "oauth.api.key": "",
+        "oauth.api.secret": "",
+        "username": "",
+        "password": ""
+    },
+    "marketo": {
+        "marketo.identity.url": "",
+        "base.url": "",
+        "oauth.api.key": "",
+        "oauth.api.secret": "",
+        "provisioning": "",
+        "username": "",
+        "password": "",
+        "code": ""
+    },
+    "namely": {
+        "provisioning": "",
+        "oauth.api.key": "",
+        "oauth.api.secret": "",
+        "username": "",
+        "password": "",
+        "subdomain": ""
+    },
+    "onedrivebusiness": {
+        "provisioning": "",
+        "oauth.api.key": "",
+        "oauth.api.secret": "",
+        "username": "",
+        "password": "",
+        "sharepoint.document.library": "",
+        "document.tagging": "",
+        "sharepoint.site.address": "",
+        "site.address": "",
+        "oauth.scope": "",
+        "onedrivebusiness.site.address": ""
+    },
+    "onedrivev2": {
+        "oauth.api.key": "",
+        "oauth.api.secret": "",
+        "username": "",
+        "password": "",
+        "provisioning": "",
+        "event.config.path": "",
+        "document.tagging": "",
+        "oauth.scope": ""
+    },
+    "quickbooks": {
+        "provisioning": "",
+        "oauth.api.key": "",
+        "oauth.api.secret": "",
+        "username": "",
+        "password": ""
+    },
+    "servicemax": {
+        "oauth.api.key": "",
+        "oauth.api.secret": "",
+        "username": "",
+        "password": "",
+        "provisioning": ""
+    },
+    "sharepoint": {
+        "provisioning": "",
+        "oauth.api.key": "",
+        "oauth.api.secret": "",
+        "username": "",
+        "password": "",
+        "sharepoint.document.library": "",
+        "document.tagging": "",
+        "sharepoint.site.address": "",
+        "site.address": "",
+        "oauth.scope": ""
+    },
+    "magento": {
+        "oauth.api.key": "",
+        "oauth.api.secret": "",
+        "username": "",
+        "password": "",
+        "provisioning": "",
+        "site.address": "",
+        "store.url": ""
+    },
+    "sage200": {
+        "oauth.api.key": "",
+        "oauth.api.secret": "",
+        "username": "",
+        "password": "",
+        "provisioning": "",
+        "oauth.scope": "",
+        "subscription.key": "",
+        "signing.key": "",
+        "company.name": ""
+    }
 }

--- a/src/core/oauth.js
+++ b/src/core/oauth.js
@@ -4,11 +4,7 @@ const webdriver = require('selenium-webdriver');
 const logger = require('winston');
 const props = require('core/props');
 
-const wait = (browser, ms) => {
-  browser.wait(() => {
-    return false;
-  }, ms);
-};
+const wait = (browser, ms) => browser.wait(() => false, ms);
 
 const manipulateDom = (element, browser, r, username, password, config) => {
   switch (element) {

--- a/src/core/oauth.js
+++ b/src/core/oauth.js
@@ -4,6 +4,7 @@ const webdriver = require('selenium-webdriver');
 const logger = require('winston');
 const props = require('core/props');
 
+/* jshint unused:false */
 const wait = (browser, ms) => browser.wait(() => false, ms);
 
 const manipulateDom = (element, browser, r, username, password, config) => {

--- a/src/core/suite.js
+++ b/src/core/suite.js
@@ -202,7 +202,7 @@ const run = (api, resource, options, defaultValidation, tests) => {
 
  * @param  {string} hub       The hub that this element is in (i.e. crm, marketing, etc.)
  * @param  {string} resource  The name of the elements API resource this test suite is for
- * @param  {object} options   The suite options object
+ * @param  {object} options   The, optional, suite options
  * @param  {function} tests   A function, containing all test
  */
 exports.forElement = (hub, resource, options, tests) => run(`/hubs/${hub}/${resource}`, resource, options, (r) => expect(r).to.have.statusCode(200), tests);
@@ -212,7 +212,7 @@ exports.forElement = (hub, resource, options, tests) => run(`/hubs/${hub}/${reso
  * provides a bunch of convenience functions inside of the given tests under the 'test' object.
 
  * @param  {string} resource     The name of the platform API resource this test suite is for
- * @param  {object} options      The suite options object
+ * @param  {object} options      The, optional, suite options
  * @param  {function} tests      A function, containing all tests
  */
-exports.forPlatform = (resource, options, tests) => run(`${resource}`, resource, options, options.schema, tests);
+exports.forPlatform = (resource, options, tests) => run(`/${resource}`, resource, options, options.schema, tests);

--- a/src/core/suite.js
+++ b/src/core/suite.js
@@ -202,7 +202,12 @@ const run = (api, resource, options, defaultValidation, tests) => {
 
  * @param  {string} hub       The hub that this element is in (i.e. crm, marketing, etc.)
  * @param  {string} resource  The name of the elements API resource this test suite is for
- * @param  {object} options   The, optional, suite options
+ * @param  {object} options   The, optional, suite options:
+ * {
+ *   name: mochaDescribeNameThatOverridesTheResourceName,
+ *   payload: defaultPaylodThatWillBeUsedOnPostCalls,
+ *   schema: defaultValidationThatWillHappenOnAllApiCallsExceptDeletes
+ * }
  * @param  {function} tests   A function, containing all test
  */
 exports.forElement = (hub, resource, options, tests) => run(`/hubs/${hub}/${resource}`, resource, options, (r) => expect(r).to.have.statusCode(200), tests);
@@ -212,7 +217,12 @@ exports.forElement = (hub, resource, options, tests) => run(`/hubs/${hub}/${reso
  * provides a bunch of convenience functions inside of the given tests under the 'test' object.
 
  * @param  {string} resource     The name of the platform API resource this test suite is for
- * @param  {object} options      The, optional, suite options
+ * @param  {object} options      The, optional, suite options:
+ * {
+ *   name: mochaDescribeNameThatOverridesTheResourceName,
+ *   payload: defaultPaylodThatWillBeUsedOnPostCalls,
+ *   schema: defaultValidationThatWillHappenOnAllApiCallsExceptDeletes
+ * }
  * @param  {function} tests      A function, containing all tests
  */
 exports.forPlatform = (resource, options, tests) => run(`/${resource}`, resource, options, options.schema, tests);

--- a/src/test/elements/adobe-esign/agreement-asset-events.js
+++ b/src/test/elements/adobe-esign/agreement-asset-events.js
@@ -1,13 +1,8 @@
 'use strict';
 
 const suite = require('core/suite');
-const payload = require('./assets/groups');
-const chakram = require('chakram');
-const cloud = require('core/cloud');
-const tools = require('core/tools');
-const expect = chakram.expect;
 
-suite.forElement('esignature', 'agreement-asset-events', null, (test) => {
+suite.forElement('esignature', 'agreement-asset-events', (test) => {
   let date = new Date();
   let startIndex = 0;
   let endIndex = 19;
@@ -16,11 +11,7 @@ suite.forElement('esignature', 'agreement-asset-events', null, (test) => {
   let oldDate = new Date(startDate);
   startDate = oldDate.toISOString().substring(startIndex, endIndex);
 
-  it(`should allow GET for ${test.api}`, () => {
-    return cloud.withOptions({
-      qs: {
-        where: `startDate = '${startDate}' and endDate = '${currentDate}'`
-      }
-    }).get(test.api);
-  });
+  test
+    .withOptions({ qs: { where: `startDate = '${startDate}' and endDate = '${currentDate}'` } })
+    .should.return200OnGet();
 });

--- a/src/test/elements/adobe-esign/groups.js
+++ b/src/test/elements/adobe-esign/groups.js
@@ -1,23 +1,21 @@
 'use strict';
 
 const suite = require('core/suite');
-const payload = require('./assets/groups');
 const chakram = require('chakram');
 const cloud = require('core/cloud');
 const tools = require('core/tools');
-const expect = chakram.expect;
 
 const group = () => ({
   groupName: tools.random()
 });
 
-suite.forElement('esignature', 'groups', group(), (test) => {
+suite.forElement('esignature', 'groups', { payload: group() }, (test) => {
   test.should.supportCruds(chakram.put);
   it(`should allow GET for ${test.api}/{groupId}/users`, () => {
     let groupId;
     return cloud.post(test.api, group())
       .then(r => groupId = r.body.id)
       .then(r => cloud.get(`${test.api}/${groupId}/users`))
-      .then(r => cloud.delete(`${test.api}/${groupId}`))
+      .then(r => cloud.delete(`${test.api}/${groupId}`));
   });
 });

--- a/src/test/elements/adobe-esign/library-documents.js
+++ b/src/test/elements/adobe-esign/library-documents.js
@@ -4,6 +4,7 @@ const suite = require('core/suite');
 const cloud = require('core/cloud');
 const tools = require('core/tools');
 
+/* jshint unused:false */
 const createLibraryDocuments = (transientDocumentId) => ({
   "libraryDocumentCreationInfo": {
     "libraryTemplateTypes": "DOCUMENT",

--- a/src/test/elements/adobe-esign/library-documents.js
+++ b/src/test/elements/adobe-esign/library-documents.js
@@ -3,7 +3,6 @@
 const suite = require('core/suite');
 const cloud = require('core/cloud');
 const tools = require('core/tools');
-const sleep = require('sleep');
 
 const createLibraryDocuments = (transientDocumentId) => ({
   "libraryDocumentCreationInfo": {
@@ -21,7 +20,7 @@ const createLibraryDocuments = (transientDocumentId) => ({
   }
 });
 
-suite.forElement('esignature', 'library-documents', null, (test) => {
+suite.forElement('esignature', 'library-documents', (test) => {
   /*
   // Commented the POST for this resource to avoid creation of new Library Documents, since the code
   // might break for GET /libraryDocuments due to time-out. Also there is no DELETE API for libraryDocuments
@@ -31,17 +30,16 @@ suite.forElement('esignature', 'library-documents', null, (test) => {
       .then(r => cloud.post(test.api, createLibraryDocuments(transientDocumentId)));
     });
   */
-/*
-//Commented out this block to avoid all posts, instead hardcoded the libraryDocumentId of a Library Document
-//in the Adobe Esign UI named "DoNotDeleteThisLibraryDocumentThisIsForChurrosTesting".
-  let transientDocumentId, libraryDocumentId;
-  before(() => cloud.postFile(`/hubs/esignature/transient-documents`, `${__dirname}/assets/attach.txt`)
-    .then(r => transientDocumentId = r.body.id)
-    .then(r => cloud.post(test.api, createLibraryDocuments(transientDocumentId)))
-    .then(r => libraryDocumentId = r.body.id))
-*/
+  /*
+  //Commented out this block to avoid all posts, instead hardcoded the libraryDocumentId of a Library Document
+  //in the Adobe Esign UI named "DoNotDeleteThisLibraryDocumentThisIsForChurrosTesting".
+    let transientDocumentId, libraryDocumentId;
+    before(() => cloud.postFile(`/hubs/esignature/transient-documents`, `${__dirname}/assets/attach.txt`)
+      .then(r => transientDocumentId = r.body.id)
+      .then(r => cloud.post(test.api, createLibraryDocuments(transientDocumentId)))
+      .then(r => libraryDocumentId = r.body.id))
+  */
   let libraryDocumentId = "3AAABLblqZhClHK1fioPebGw8EMx-PrHOTwkxSZMn6hfb0y3T95CA9ScNV7XZytrJM2gHPHMR0DgdY3simUO62FIYJnetl25d";
-    sleep.sleep(60);
 
   test.should.return200OnGet();
   it(`should allow GET for ${test.api}/{libraryDocumentId}`, () => {

--- a/src/test/elements/adobe-esign/transient-documents.js
+++ b/src/test/elements/adobe-esign/transient-documents.js
@@ -2,11 +2,9 @@
 
 const suite = require('core/suite');
 const cloud = require('core/cloud');
-const chakram = require('chakram');
-const expect = chakram.expect;
 
-suite.forElement('esignature', 'transient-documents', null, (test) => {
+suite.forElement('esignature', 'transient-documents', (test) => {
   it(`should allow POST for /transient-documents`, () => {
-    return cloud.postFile(test.api, `${__dirname}/assets/attach.txt`)
+    return cloud.postFile(test.api, `${__dirname}/assets/attach.txt`);
   });
 });

--- a/src/test/elements/adobe-esign/uris.js
+++ b/src/test/elements/adobe-esign/uris.js
@@ -1,10 +1,7 @@
 'use strict';
 
 const suite = require('core/suite');
-const chakram = require('chakram');
-const cloud = require('core/cloud');
-const expect = chakram.expect;
 
-suite.forElement('esignature', 'uris', null, (test) => {
+suite.forElement('esignature', 'uris', (test) => {
   test.should.return200OnGet();
 });

--- a/src/test/elements/adobe-esign/users.js
+++ b/src/test/elements/adobe-esign/users.js
@@ -34,6 +34,6 @@ suite.forElement('esignature', 'users', (test) => {
     let userId;
     return cloud.get(test.api)
       .then(r => userId = r.body[0].id)
-      .then(r => cloud.put(`${test.api}/${userId}`, updateUsers()))
+      .then(r => cloud.put(`${test.api}/${userId}`, updateUsers()));
   });
 });

--- a/src/test/elements/adobe-esign/users.js
+++ b/src/test/elements/adobe-esign/users.js
@@ -1,16 +1,13 @@
 'use strict';
 
 const suite = require('core/suite');
-const chakram = require('chakram');
 const cloud = require('core/cloud');
 const tools = require('core/tools');
-const expect = chakram.expect;
 
 const createUsers = () => ({
   "lastName": tools.random(),
   "email": tools.randomEmail(),
   "firstName": tools.random()
-
 });
 
 const updateUsers = (groupId) => ({
@@ -27,11 +24,11 @@ const updateUsers = (groupId) => ({
   "firstName": "Greg"
 });
 
-suite.forElement('esignature', 'users', null, (test) => {
-/*
-//  Commented out POST /users, since there is no DELETE API for that.
-  test.withJson(createUsers()).should.supportCrs();
-*/
+suite.forElement('esignature', 'users', (test) => {
+  /*
+  //  Commented out POST /users, since there is no DELETE API for that.
+    test.withJson(createUsers()).should.supportCrs();
+  */
   test.withJson(createUsers()).should.supportSr();
   it(`should allow PUT for ${test.api}/{userId}`, () => {
     let userId;

--- a/src/test/elements/adobe-esign/widgets.js
+++ b/src/test/elements/adobe-esign/widgets.js
@@ -2,8 +2,6 @@
 
 const suite = require('core/suite');
 const cloud = require('core/cloud');
-const chakram = require('chakram');
-const expect = chakram.expect;
 const tools = require('core/tools');
 
 const createWidget = (transientDocumentId) => ({
@@ -25,20 +23,20 @@ const updateWidgetStatus = () => ({
   "value": "ENABLE"
 });
 
-suite.forElement('esignature', 'widgets', null, (test) => {
+suite.forElement('esignature', 'widgets', (test) => {
   /*
   // This script breaks, as there are over 700 widgets which leads to time-out
     test.should.return200OnGet();
   */
-/*
-//Commented out this block to avoid all posts, instead hardcoded the widgetId of a widget in the Adobe Esign
-// named "DoNotDeleteThisWidgetThisIsForChurrosTesting".
-  let transientDocumentId, widgetId;
-  before(() => cloud.postFile(`/hubs/esignature/transient-documents`, `${__dirname}/assets/attach.txt`)
-    .then(r => transientDocumentId = r.body.id)
-    .then(r => cloud.post(test.api, createWidget(transientDocumentId)))
-    .then(r => widgetId = r.body.id));
-*/
+  /*
+  //Commented out this block to avoid all posts, instead hardcoded the widgetId of a widget in the Adobe Esign
+  // named "DoNotDeleteThisWidgetThisIsForChurrosTesting".
+    let transientDocumentId, widgetId;
+    before(() => cloud.postFile(`/hubs/esignature/transient-documents`, `${__dirname}/assets/attach.txt`)
+      .then(r => transientDocumentId = r.body.id)
+      .then(r => cloud.post(test.api, createWidget(transientDocumentId)))
+      .then(r => widgetId = r.body.id));
+  */
   let widgetId = "3AAABLblqZhA_ZRfpH6d0l0tD8pnUXG-UWi0Xe0gtQ8dRJCvFzbQyMxiEyzUXcUWIi-xrslmcBBTlqU0DOukS_31TmSaqCck9";
   /*
   // Commented the POST for this resource to avoid creation of new Widgets, since the code

--- a/src/test/elements/adobe-esign/widgets.js
+++ b/src/test/elements/adobe-esign/widgets.js
@@ -4,6 +4,7 @@ const suite = require('core/suite');
 const cloud = require('core/cloud');
 const tools = require('core/tools');
 
+/* jshint unused:false */
 const createWidget = (transientDocumentId) => ({
   "widgetCreationInfo": {
     "fileInfos": [{

--- a/src/test/elements/adobe-esign/workflows.js
+++ b/src/test/elements/adobe-esign/workflows.js
@@ -1,11 +1,8 @@
 'use strict';
 
 const suite = require('core/suite');
-const chakram = require('chakram');
 const cloud = require('core/cloud');
 const tools = require('core/tools');
-const expect = chakram.expect;
-
 
 const createWorkflows = (transientDocumentId) => ({
   "documentCreationInfo": {
@@ -28,7 +25,7 @@ const createWorkflows = (transientDocumentId) => ({
   }
 });
 
-suite.forElement('esignature', 'workflows', null, (test) => {
+suite.forElement('esignature', 'workflows', (test) => {
   test.should.supportSr();
   it(`should allow POST for ${test.api}/{workflowId}/agreements`, () => {
     let workflowId;
@@ -37,6 +34,6 @@ suite.forElement('esignature', 'workflows', null, (test) => {
       .then(r => workflowId = r.body[0].id)
       .then(r => cloud.postFile(`/hubs/esignature/transient-documents`, `${__dirname}/assets/attach.txt`))
       .then(r => transientDocumentId = r.body.id)
-      .then(r => cloud.post(`${test.api}/${workflowId}/agreements`, createWorkflows(transientDocumentId)))
+      .then(r => cloud.post(`${test.api}/${workflowId}/agreements`, createWorkflows(transientDocumentId)));
   });
 });

--- a/src/test/elements/box/files.js
+++ b/src/test/elements/box/files.js
@@ -5,7 +5,7 @@ const expect = require('chakram').expect;
 const suite = require('core/suite');
 const cloud = require('core/cloud');
 
-suite.forElement('documents', 'files', null, (test) => {
+suite.forElement('documents', 'files', (test) => {
   it('should allow uploading and downloading a file', () => {
     let fileId = -1;
     let query = { path: `/brady-${tools.random()}.jpg` };

--- a/src/test/elements/box/folders.js
+++ b/src/test/elements/box/folders.js
@@ -2,7 +2,7 @@
 
 const suite = require('core/suite');
 
-suite.forElement('documents', 'folders', null, (test) => {
+suite.forElement('documents', 'folders', (test) => {
   const contentsApi = test.api + '/contents';
   test.withOptions({ qs: { path: '/' } }).withApi(contentsApi).should.return200OnGet();
 });

--- a/src/test/elements/closeio/accounts.js
+++ b/src/test/elements/closeio/accounts.js
@@ -3,6 +3,6 @@
 const suite = require('core/suite');
 const account = require('./assets/account');
 
-suite.forElement('crm', 'accounts', account, (test) => {
+suite.forElement('crm', 'accounts', { payload: account }, (test) => {
   test.should.supportCruds();
 });

--- a/src/test/elements/closeio/contacts.js
+++ b/src/test/elements/closeio/contacts.js
@@ -14,7 +14,7 @@ const gen = (opts) => {
   });
 };
 
-suite.forElement('crm', 'contacts', gen(), (test) => {
+suite.forElement('crm', 'contacts', { payload: gen() }, (test) => {
   it('should allow CRUDS for ' + test.api, () => {
     let accountId;
     return cloud.post('/hubs/crm/accounts', { name: 'churros tmp account' })

--- a/src/test/elements/desk/attachments.js
+++ b/src/test/elements/desk/attachments.js
@@ -1,12 +1,11 @@
 'use strict';
 
 const suite = require('core/suite');
-const tools = require('core/tools');
 const cloud = require('core/cloud');
 const incidentsPayload = require('./assets/incidents');
 
 
-suite.forElement('helpdesk', 'attachments', incidentsPayload, (test) => {
+suite.forElement('helpdesk', 'attachments', { payload: incidentsPayload }, (test) => {
   let incidentId;
   let attachmentId;
   it('should create an incident and then an attachment for that id', () => {

--- a/src/test/elements/desk/comments.js
+++ b/src/test/elements/desk/comments.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const suite = require('core/suite');
-const tools = require('core/tools');
 const cloud = require('core/cloud');
 const incidentsPayload = require('./assets/incidents');
 const commentsPayload = require('./assets/comments');
@@ -11,7 +10,7 @@ const commentsUpdate = () => ({
   "status": "sent"
 });
 
-suite.forElement('helpdesk', 'comments', commentsPayload, (test) => {
+suite.forElement('helpdesk', 'comments', { payload: commentsPayload }, (test) => {
   let incidentId;
   let commentId;
   it('should create an incident and then comments for that id', () => {

--- a/src/test/elements/desk/contacts.js
+++ b/src/test/elements/desk/contacts.js
@@ -8,13 +8,9 @@ const contactUpdate = () => ({
   "last_name": "cloud"
 });
 
-const options = {
-  churros: {
-    updatePayload: contactUpdate()
-  }
-};
+const options = { churros: { updatePayload: contactUpdate() } };
 
-suite.forElement('helpdesk', 'contacts', payload, (test) => {
+suite.forElement('helpdesk', 'contacts', { payload: payload }, (test) => {
   test.withOptions(options).should.supportCrus();
   test.should.supportPagination();
   test.withOptions({ qs: { where: 'email=\'support@desk.com\'' } }).should.return200OnGet();

--- a/src/test/elements/desk/incidents.js
+++ b/src/test/elements/desk/incidents.js
@@ -11,13 +11,9 @@ const incidentsUpdate = () => ({
   }
 });
 
-const options = {
-  churros: {
-    updatePayload: incidentsUpdate()
-  }
-};
+const options = { churros: { updatePayload: incidentsUpdate() } };
 
-suite.forElement('helpdesk', 'incidents', payload, (test) => {
+suite.forElement('helpdesk', 'incidents', { payload: payload }, (test) => {
   test.withOptions(options).should.supportCruds();
   test.should.supportPagination();
   test.withOptions({ qs: { where: 'email=\'support@desk.com\'' } }).should.return200OnGet();

--- a/src/test/elements/desk/organizations.js
+++ b/src/test/elements/desk/organizations.js
@@ -3,7 +3,6 @@
 const suite = require('core/suite');
 const tools = require('core/tools');
 const cloud = require('core/cloud');
-const winston = require('winston');
 
 const organizationsUpdate = (rando) => ({
   "name": "Cloud-Elements update" + rando,
@@ -19,9 +18,9 @@ const organizationsCreate = (rando) => ({
     "acmeinc.com",
     "acmeinc.net"
   ]
-})
+});
 
-suite.forElement('helpdesk', 'organizations', organizationsCreate(), (test) => {
+suite.forElement('helpdesk', 'organizations', { payload: organizationsCreate() }, (test) => {
   let organiztionId;
   it('should allow CRUS for organizations', () => {
     return cloud.post(test.api, organizationsCreate(tools.randomInt().toString()))

--- a/src/test/elements/desk/users.js
+++ b/src/test/elements/desk/users.js
@@ -2,7 +2,7 @@
 
 const suite = require('core/suite');
 
-suite.forElement('helpdesk', 'users', null, (test) => {
+suite.forElement('helpdesk', 'users', (test) => {
   test.should.supportSr();
   test.should.supportPagination();
 });

--- a/src/test/elements/dropboxbusiness/members.js
+++ b/src/test/elements/dropboxbusiness/members.js
@@ -5,21 +5,18 @@ const payload = require('./assets/members');
 const cloud = require('core/cloud');
 
 // member is unsuspended twice to make sure it's in a state where it can be tested next time.
-suite.forElement('documents', 'members', payload, (test) => {
-  it('should support CRUDS for members', () =>{
-  	let memberId;
+suite.forElement('documents', 'members', { payload: payload }, (test) => {
+  it('should support CRUDS for members', () => {
+    let memberId;
     return cloud.post(test.api, payload)
-    .then(r => memberId = r.body.complete[0].profile.team_member_id)
-    .then(r => cloud.delete(`${test.api}/${memberId}`))
-    .then (r => cloud.get(test.api))
-    .then(r => {
-    	let record = r.body[r.body.length-1];
-    	memberId = record.profile.team_member_id;
-    })
-    .then(r => cloud.get(`${test.api}/${memberId}`))
-    .then(r => cloud.patch(`${test.api}/${memberId}/suspend/false`))
-    .then(r => cloud.patch(`${test.api}/${memberId}/unsuspend`))
-    .then(r => cloud.patch(`${test.api}/${memberId}/suspend/true`))
-    .then(r => cloud.patch(`${test.api}/${memberId}/unsuspend`))
+      .then(r => memberId = r.body.complete[0].profile.team_member_id)
+      .then(r => cloud.delete(`${test.api}/${memberId}`))
+      .then(r => cloud.get(test.api))
+      .then(r => memberId = r.body[r.body.length - 1].profile.team_member_id)
+      .then(r => cloud.get(`${test.api}/${memberId}`))
+      .then(r => cloud.patch(`${test.api}/${memberId}/suspend/false`))
+      .then(r => cloud.patch(`${test.api}/${memberId}/unsuspend`))
+      .then(r => cloud.patch(`${test.api}/${memberId}/suspend/true`))
+      .then(r => cloud.patch(`${test.api}/${memberId}/unsuspend`))
   });
 });

--- a/src/test/elements/dropboxbusiness/members.js
+++ b/src/test/elements/dropboxbusiness/members.js
@@ -17,6 +17,6 @@ suite.forElement('documents', 'members', { payload: payload }, (test) => {
       .then(r => cloud.patch(`${test.api}/${memberId}/suspend/false`))
       .then(r => cloud.patch(`${test.api}/${memberId}/unsuspend`))
       .then(r => cloud.patch(`${test.api}/${memberId}/suspend/true`))
-      .then(r => cloud.patch(`${test.api}/${memberId}/unsuspend`))
+      .then(r => cloud.patch(`${test.api}/${memberId}/unsuspend`));
   });
 });

--- a/src/test/elements/hubspotcrm/accounts.js
+++ b/src/test/elements/hubspotcrm/accounts.js
@@ -3,7 +3,7 @@
 const suite = require('core/suite');
 const payload = require('./assets/accounts');
 
-suite.forElement('crm', 'accounts', payload, (test) => {
+suite.forElement('crm', 'accounts', { payload: payload }, (test) => {
   test.should.supportCruds();
   test.should.supportPagination();
 });

--- a/src/test/elements/hubspotcrm/activities.js
+++ b/src/test/elements/hubspotcrm/activities.js
@@ -3,6 +3,6 @@
 const suite = require('core/suite');
 const payload = require('./assets/activities');
 
-suite.forElement('crm', 'activities', payload, (test) => {
+suite.forElement('crm', 'activities', { payload: payload }, (test) => {
   test.should.supportCrud();
 });

--- a/src/test/elements/hubspotcrm/contacts.js
+++ b/src/test/elements/hubspotcrm/contacts.js
@@ -3,7 +3,7 @@
 const suite = require('core/suite');
 const payload = require('./assets/contacts');
 
-suite.forElement('crm', 'contacts', payload, (test) => {
+suite.forElement('crm', 'contacts', { payload: payload }, (test) => {
   test.should.supportCruds();
   test.should.supportPagination();
 });

--- a/src/test/elements/hubspotcrm/leads.js
+++ b/src/test/elements/hubspotcrm/leads.js
@@ -3,7 +3,7 @@
 const suite = require('core/suite');
 const payload = require('./assets/leads');
 
-suite.forElement('crm', 'leads', payload, (test) => {
+suite.forElement('crm', 'leads', { payload: payload }, (test) => {
   test.should.supportCruds();
   test.should.supportPagination();
 });

--- a/src/test/elements/hubspotcrm/opportunities.js
+++ b/src/test/elements/hubspotcrm/opportunities.js
@@ -3,7 +3,7 @@
 const suite = require('core/suite');
 const payload = require('./assets/opportunities');
 
-suite.forElement('crm', 'opportunities', payload, (test) => {
+suite.forElement('crm', 'opportunities', { payload: payload }, (test) => {
   test.should.supportCruds();
   test.should.supportPagination();
 });

--- a/src/test/elements/hubspotcrm/owners.js
+++ b/src/test/elements/hubspotcrm/owners.js
@@ -3,7 +3,7 @@
 const suite = require('core/suite');
 const payload = require('./assets/owners');
 
-suite.forElement('crm', 'owners', payload, (test) => {
+suite.forElement('crm', 'owners', { payload: payload }, (test) => {
   test.should.supportCrus();
   test.should.supportPagination();
 });

--- a/src/test/elements/jira/incidents.js
+++ b/src/test/elements/jira/incidents.js
@@ -3,22 +3,21 @@
 const suite = require('core/suite');
 const cloud = require('core/cloud');
 const payload = require('./assets/incidents');
-const commentPayload = require('./assets/incidentComments')
+const commentPayload = require('./assets/incidentComments');
 
-suite.forElement('helpdesk', 'incidents', payload, (test) => {
+suite.forElement('helpdesk', 'incidents', { payload: payload }, (test) => {
 
   it('should allow CRUDS for /incidents/:id/comments', () => {
     let incidentId;
-    let commentId;
     return cloud.post('/hubs/helpdesk/incidents', payload)
       .then(r => incidentId = r.body.id)
       .then(r => cloud.cruds('/hubs/helpdesk/incidents/' + incidentId + '/comments', commentPayload))
       .then(r => cloud.delete('/hubs/helpdesk/incidents/' + incidentId));
   });
+
   it('should allow CRUDS for /incidents/:id/attachments', () => {
-    let incidentId;
-    let attachmentId;
-    let query = {fileName : "testfile.txt"}
+    let query = { fileName: "testfile.txt" };
+    let incidentId, attachmentId;
     return cloud.post('/hubs/helpdesk/incidents', payload)
       .then(r => incidentId = r.body.id)
       .then(r => cloud.postFile('hubs/helpdesk/incidents/' + incidentId + '/attachments', __dirname + '/assets/attach.txt', { qs: query }))
@@ -26,7 +25,7 @@ suite.forElement('helpdesk', 'incidents', payload, (test) => {
       .then(r => cloud.get('/hubs/helpdesk/attachments/' + attachmentId))
       .then(r => cloud.get('/hubs/helpdesk/incidents/' + incidentId + '/attachments'))
       .then(r => cloud.delete('/hubs/crm/attachments/' + attachmentId))
-      .then(r => cloud.delete(test.api + '/' + contactId));
+      .then(r => cloud.delete(test.api + '/' + incidentId));
   });
   test.should.supportCruds();
   test.should.supportCeqlSearch('id');

--- a/src/test/elements/magento/customers.js
+++ b/src/test/elements/magento/customers.js
@@ -2,7 +2,7 @@
 
 const suite = require('core/suite');
 const payload = require('./assets/customers');
-suite.forElement('ecommerce', 'customers', payload, (test) => {
+suite.forElement('ecommerce', 'customers', { payload: payload }, (test) => {
   test.should.return200OnGet();
   test.should.supportPagination();
   test.should.supportSr();

--- a/src/test/elements/magento/orders.js
+++ b/src/test/elements/magento/orders.js
@@ -3,7 +3,7 @@
 const suite = require('core/suite');
 const payload = require('./assets/orders');
 
-suite.forElement('ecommerce', 'orders', payload, (test) => {
+suite.forElement('ecommerce', 'orders', { payload: payload }, (test) => {
   test.should.return200OnGet();
   test.should.supportPagination();
   test.should.supportSr();

--- a/src/test/elements/magento/products.js
+++ b/src/test/elements/magento/products.js
@@ -1,12 +1,10 @@
 'use strict';
 
 const suite = require('core/suite');
-const payload = require('./assets/products');
 
-suite.forElement('ecommerce', 'products', null, (test) => {
+suite.forElement('ecommerce', 'products', (test) => {
   test.should.return200OnGet();
   test.should.supportPagination();
   test.should.return400OnPost();
   test.should.supportSr();
-
 });

--- a/src/test/elements/magento/query.js
+++ b/src/test/elements/magento/query.js
@@ -2,7 +2,7 @@
 
 const suite = require('core/suite');
 
-suite.forElement('ecommerce', 'bulk/query', null, (test) => {
+suite.forElement('ecommerce', 'bulk/query', (test) => {
   test.withOptions({ qs: { q: 'select * from customers' } }).should.return200OnPost();
   test.withOptions({ qs: { q: 'select id, email from customers' } }).should.return200OnPost();
   test.withOptions({ qs: { q: 'select * from orders' } }).should.return200OnPost();

--- a/src/test/elements/sage200/banks.js
+++ b/src/test/elements/sage200/banks.js
@@ -2,7 +2,7 @@
 
 const suite = require('core/suite');
 
-suite.forElement('finance', 'banks', null, (test) => {
+suite.forElement('finance', 'banks', (test) => {
   test.should.supportPagination();
   test.should.return200OnGet();
   test.withOptions({qs: {where: 'code=\'1200\''}}).should.return200OnGet();

--- a/src/test/elements/sage200/customers.js
+++ b/src/test/elements/sage200/customers.js
@@ -13,7 +13,7 @@ const options = {
   }
 };
 
-suite.forElement('finance', 'customers', payload, (test) => {
+suite.forElement('finance', 'customers', { payload: payload }, (test) => {
   test.withOptions(options).should.supportCruds();
   test.should.supportPagination();
   test.should.supportCeqlSearch('id');

--- a/src/test/elements/sage200/invoices.js
+++ b/src/test/elements/sage200/invoices.js
@@ -10,21 +10,19 @@ const createInvoices = (customerId) => ({
 });
 
 const createCustomer = (rando) => ({
-  "reference": "CE"+ rando ,
+  "reference": "CE" + rando,
   "name": "CE Invoices"
-})
+});
 
-suite.forElement('finance', 'invoices', createInvoices(), (test) => {
-  let customerId;
-  let urnId;
-  let invoiceId;
+suite.forElement('finance', 'invoices', { payload: createInvoices() }, (test) => {
+  let customerId, urnId, invoiceId;
   it('should create a customer and then an invoice for that id', () => {
-    return cloud.post('/hubs/finance/customers',createCustomer(tools.randomInt().toString()))
+    return cloud.post('/hubs/finance/customers', createCustomer(tools.randomInt().toString()))
       .then(r => customerId = r.body.id)
       .then(r => cloud.get('/hubs/finance/customers/' + customerId))
-      .then(r => cloud.post(test.api,createInvoices(customerId)))
+      .then(r => cloud.post(test.api, createInvoices(customerId)))
       .then(r => urnId = r.body.urn)
-      .then(r => cloud.get(test.api),{qs: {where: 'urn=\''+urnId +'\''}})
+      .then(r => cloud.get(test.api), { qs: { where: 'urn=\'' + urnId + '\'' } })
       .then(r => invoiceId = r.body[0].id)
       .then(r => cloud.get(test.api + '/' + invoiceId));
   });

--- a/src/test/elements/sage200/payments.js
+++ b/src/test/elements/sage200/payments.js
@@ -11,30 +11,26 @@ const createPayment = (customerId, bankId) => ({
 });
 
 const createCustomer = (rando) => ({
-  "reference": "CE"+ rando ,
+  "reference": "CE" + rando,
   "name": "CE Payments"
-})
+});
 
-suite.forElement('finance', 'payments', createPayment(), (test) => {
-  let customerId;
-  let bankId;
-  let urnId;
-  let paymentId;
-  let receiptId;
+suite.forElement('finance', 'payments', { payload: createPayment() }, (test) => {
+  let customerId, bankId, urnId, paymentId, receiptId;
   it('should create a customer and then payments for that id', () => {
-    return cloud.post('/hubs/finance/customers',createCustomer(tools.randomInt().toString()))
+    return cloud.post('/hubs/finance/customers', createCustomer(tools.randomInt().toString()))
       .then(r => customerId = r.body.id)
       .then(r => cloud.get('/hubs/finance/customers/' + customerId))
       .then(r => cloud.get('/hubs/finance/banks'))
       .then(r => bankId = r.body[0].id)
-      .then(r => cloud.post(test.api,createPayment(customerId, bankId)))
+      .then(r => cloud.post(test.api, createPayment(customerId, bankId)))
       .then(r => urnId = r.body.urn)
-      .then(r => cloud.get(test.api),{qs: {where: 'urn=\''+urnId +'\''}})
+      .then(r => cloud.get(test.api), { qs: { where: 'urn=\'' + urnId + '\'' } })
       .then(r => paymentId = r.body[0].id)
       .then(r => cloud.get(test.api + '/' + paymentId))
-      .then(r => cloud.post(test.api + '/receipts',createPayment(customerId, bankId)))
+      .then(r => cloud.post(test.api + '/receipts', createPayment(customerId, bankId)))
       .then(r => urnId = r.body.urn)
-      .then(r => cloud.get(test.api),{qs: {where: 'urn=\''+urnId +'\''}})
+      .then(r => cloud.get(test.api), { qs: { where: 'urn=\'' + urnId + '\'' } })
       .then(r => receiptId = r.body[0].id)
       .then(r => cloud.get(test.api + '/' + receiptId))
       .then(r => cloud.get(test.api));

--- a/src/test/elements/sage200/products.js
+++ b/src/test/elements/sage200/products.js
@@ -9,9 +9,8 @@ const createProducts = (productGroupId) => ({
   "code": "CE006"
 });
 
-suite.forElement('finance', 'products', createProducts(), (test) => {
-  let productGroupId;
-  let productId;
+suite.forElement('finance', 'products', { payload: createProducts() }, (test) => {
+  let productGroupId, productId;
   it('should create a product', () => {
     return cloud.get(test.api + '/groups')
       .then(r => productGroupId = r.body[0].id)
@@ -23,7 +22,7 @@ suite.forElement('finance', 'products', createProducts(), (test) => {
       .then(r => cloud.delete(test.api + '/' + productId));
   });
   test.should.supportPagination();
-  test.withApi(test.api +'/prices').should.supportPagination();
-  test.withApi(test.api +'/groups').should.supportPagination();
-  test.withOptions({qs: {where: 'date_time_updated>\'2015-10-22T16:40:09.563\''}}).should.return200OnGet();
+  test.withApi(test.api + '/prices').should.supportPagination();
+  test.withApi(test.api + '/groups').should.supportPagination();
+  test.withOptions({ qs: { where: 'date_time_updated>\'2015-10-22T16:40:09.563\'' } }).should.return200OnGet();
 });

--- a/src/test/elements/sage200/transactions.js
+++ b/src/test/elements/sage200/transactions.js
@@ -3,13 +3,13 @@
 const suite = require('core/suite');
 const cloud = require('core/cloud');
 
-suite.forElement('finance', 'transactions', null, (test) => {
+suite.forElement('finance', 'transactions', (test) => {
   let transactionsId;
   it('should support GET', () => {
     return cloud.get(test.api)
       .then(r => transactionsId = r.body[0].id)
-      .then(r => cloud.get(test.api + '/' + transactionsId))
+      .then(r => cloud.get(test.api + '/' + transactionsId));
   });
   test.should.supportPagination();
-  test.withOptions({qs: {where: 'date_time_updated>\'2016-03-04T17:35:41.453\''}}).should.return200OnGet();
+  test.withOptions({ qs: { where: 'date_time_updated>\'2016-03-04T17:35:41.453\'' } }).should.return200OnGet();
 });

--- a/src/test/elements/sfdc/accounts.js
+++ b/src/test/elements/sfdc/accounts.js
@@ -3,7 +3,7 @@
 const suite = require('core/suite');
 const payload = require('./assets/accounts');
 
-suite.forElement('crm', 'accounts', payload, (test) => {
+suite.forElement('crm', 'accounts', { payload: payload }, (test) => {
   test.should.supportCruds();
   test.should.supportPagination();
 });

--- a/src/test/elements/sfdc/contacts.js
+++ b/src/test/elements/sfdc/contacts.js
@@ -12,7 +12,7 @@ const contact = () => ({
 });
 
 
-suite.forElement('crm', 'contacts', payload, (test) => {
+suite.forElement('crm', 'contacts', { payload: payload }, (test) => {
   test.should.supportCruds();
   test.should.supportCeqlSearch('id');
 

--- a/src/test/elements/sfdc/leads.js
+++ b/src/test/elements/sfdc/leads.js
@@ -3,7 +3,7 @@
 const suite = require('core/suite');
 const payload = require('./assets/leads');
 
-suite.forElement('crm', 'leads', payload, (test) => {
+suite.forElement('crm', 'leads', { payload: payload }, (test) => {
   test.should.supportCruds();
   test.should.supportPagination();
 });

--- a/src/test/elements/sfdc/opportunities.js
+++ b/src/test/elements/sfdc/opportunities.js
@@ -3,7 +3,7 @@
 const suite = require('core/suite');
 const payload = require('./assets/opportunities');
 
-suite.forElement('crm', 'opportunities', payload, (test) => {
+suite.forElement('crm', 'opportunities', { payload: payload }, (test) => {
   test.should.supportCruds();
   test.should.supportPagination();
 });

--- a/src/test/elements/sfdc/users.js
+++ b/src/test/elements/sfdc/users.js
@@ -3,7 +3,7 @@
 const suite = require('core/suite');
 const payload = require('./assets/users');
 
-suite.forElement('crm', 'users', payload, (test) => {
+suite.forElement('crm', 'users', { payload: payload }, (test) => {
   test.should.supportSr();
   test.should.supportPagination();
 });

--- a/src/test/elements/shopify/customers.js
+++ b/src/test/elements/shopify/customers.js
@@ -9,6 +9,6 @@ const customer = (custom) => ({
   email: custom.email || tools.randomEmail()
 });
 
-suite.forElement('ecommerce', 'customers', customer({}), (test) => {
+suite.forElement('ecommerce', 'customers', { payload: customer({}) }, (test) => {
   test.should.supportCruds();
 });

--- a/src/test/elements/shopify/discounts.js
+++ b/src/test/elements/shopify/discounts.js
@@ -10,6 +10,6 @@ const discount = (custom) => ({
   value: custom.value || 100
 });
 
-suite.forElement('ecommerce', 'discounts', discount({}), (test) => {
+suite.forElement('ecommerce', 'discounts', { payload: discount({}) }, (test) => {
   test.should.supportCrds();
 });

--- a/src/test/elements/shopify/images.js
+++ b/src/test/elements/shopify/images.js
@@ -4,33 +4,30 @@ const suite = require('core/suite');
 const cloud = require('core/cloud');
 const payload = require('./assets/products.json');
 const variantPayload = require('./assets/variants.json');
-const imageUpdate = {"src":"http://petsfans.com/wp-content/uploads/2014/11/edfsaf.jpg"};
+const imageUpdate = { "src": "http://petsfans.com/wp-content/uploads/2014/11/edfsaf.jpg" };
 
-suite.forElement('ecommerce', 'images', payload, (test) => {
+suite.forElement('ecommerce', 'images', { payload: payload }, (test) => {
 
   it('should allow CRUDS for /products/:id/images', () => {
-    let productId;
-    let imageId;
-    let imagePayload;
-    let variantId;
+    let productId, imageId, imagePayload, variantId;
     return cloud.post('/hubs/ecommerce/products', payload)
       .then(r => productId = r.body.id)
-      .then(r => cloud.post('/hubs/ecommerce/products/'+ productId + '/variants', variantPayload))
+      .then(r => cloud.post('/hubs/ecommerce/products/' + productId + '/variants', variantPayload))
       .then(r => variantId = r.body.id)
       .then(r => imagePayload = {
-          "src": "https://cdn.shopify.com/s/files/1/0655/4311/products/maxresdefault_f2cd1654-dc20-4c33-8be8-03b157763958.jpeg?v=1457997527",
-          "product_id": productId,
-          "variant_ids": [
-            variantId
-          ],
-          "position": 1
-        })
+        "src": "https://cdn.shopify.com/s/files/1/0655/4311/products/maxresdefault_f2cd1654-dc20-4c33-8be8-03b157763958.jpeg?v=1457997527",
+        "product_id": productId,
+        "variant_ids": [
+          variantId
+        ],
+        "position": 1
+      })
       .then(r => cloud.post('/hubs/ecommerce/products/' + productId + '/images', imagePayload))
       .then(r => imageId = r.body.id)
       .then(r => cloud.get('/hubs/ecommerce/products/' + productId + '/images'))
       .then(r => cloud.get('/hubs/ecommerce/products/' + productId + '/images/' + imageId))
       .then(r => cloud.patch('/hubs/ecommerce/products/' + productId + '/images/' + imageId, imageUpdate))
       .then(r => cloud.delete('/hubs/ecommerce/products/' + productId + '/images/' + imageId))
-      .then(r => cloud.delete('/hubs/ecommerce/products/' + productId))
+      .then(r => cloud.delete('/hubs/ecommerce/products/' + productId));
   });
 });

--- a/src/test/elements/shopify/orders.js
+++ b/src/test/elements/shopify/orders.js
@@ -10,6 +10,6 @@ const order = (custom) => ({
   }]
 });
 
-suite.forElement('ecommerce', 'orders', order({}), (test) => {
+suite.forElement('ecommerce', 'orders', { payload: order({}) }, (test) => {
   test.should.supportCruds();
 });

--- a/src/test/elements/shopify/products.js
+++ b/src/test/elements/shopify/products.js
@@ -8,6 +8,6 @@ const products = (custom) => ({
   product_type: custom.product_type || tools.random()
 });
 
-suite.forElement('ecommerce', 'products', products({}), (test) => {
+suite.forElement('ecommerce', 'products', { payload: products({}) }, (test) => {
   test.should.supportCruds();
 });

--- a/src/test/elements/shopify/query.js
+++ b/src/test/elements/shopify/query.js
@@ -2,7 +2,7 @@
 
 const suite = require('core/suite');
 
-suite.forElement('ecommerce', 'query', null, (test) => {
+suite.forElement('ecommerce', 'query', (test) => {
   test.withOptions({ qs: { q: 'select * from customers' } }).should.return200OnGet();
   test.withOptions({ qs: { q: 'select id, email from customers' } }).should.return200OnGet();
 });

--- a/src/test/elements/shopify/shops.js
+++ b/src/test/elements/shopify/shops.js
@@ -2,6 +2,6 @@
 
 const suite = require('core/suite');
 
-suite.forElement('ecommerce', 'shops', null, (test) => {
+suite.forElement('ecommerce', 'shops', (test) => {
   test.should.return200OnGet();
 });

--- a/src/test/elements/shopify/variants.js
+++ b/src/test/elements/shopify/variants.js
@@ -4,9 +4,9 @@ const suite = require('core/suite');
 const cloud = require('core/cloud');
 const payload = require('./assets/products.json');
 const variantPayload = require('./assets/variants.json');
-const variantUpdate = {"price":"2.00"};
+const variantUpdate = { "price": "2.00" };
 
-suite.forElement('ecommerce', 'variants', payload, (test) => {
+suite.forElement('ecommerce', 'variants', { payload: payload }, (test) => {
 
   it('should allow CRUDS for /products/:id/variants', () => {
     let productId;
@@ -19,6 +19,6 @@ suite.forElement('ecommerce', 'variants', payload, (test) => {
       .then(r => cloud.get('/hubs/ecommerce/variants/' + variantId))
       .then(r => cloud.patch('/hubs/ecommerce/variants/' + variantId, variantUpdate))
       .then(r => cloud.delete('/hubs/ecommerce/products/' + productId + '/variants/' + variantId))
-      .then(r => cloud.delete('/hubs/ecommerce/products/' + productId))
+      .then(r => cloud.delete('/hubs/ecommerce/products/' + productId));
   });
 });

--- a/src/test/elements/sugarcrmv2/accounts.js
+++ b/src/test/elements/sugarcrmv2/accounts.js
@@ -8,19 +8,19 @@ const note = {
   "description": "I am a test note"
 };
 
-suite.forElement('crm', 'accounts', payload, (test) => {
+suite.forElement('crm', 'accounts', { payload: payload }, (test) => {
   test.should.supportCruds();
   test.should.supportPagination();
   let accountId;
   let noteId;
-  it('should support CRUDS for accounts/notes', () =>{
+  it('should support CRUDS for accounts/notes', () => {
     return cloud.post(test.api, payload)
-    .then(r => accountId = r.body.id)
-    .then(r => cloud.post(`${test.api}/${accountId}/notes`, note))
-    .then(r => noteId = r.body.id)
-    .then(r => cloud.get(`${test.api}/${accountId}/notes/${noteId}`))
-    .then(r => cloud.patch(`${test.api}/${accountId}/notes/${noteId}`, {"description":"this is an updated note"}))
-    .then(r => cloud.delete(`${test.api}/${accountId}/notes/${noteId}`))
-    .then(r => cloud.delete(`${test.api}/${accountId}`));
+      .then(r => accountId = r.body.id)
+      .then(r => cloud.post(`${test.api}/${accountId}/notes`, note))
+      .then(r => noteId = r.body.id)
+      .then(r => cloud.get(`${test.api}/${accountId}/notes/${noteId}`))
+      .then(r => cloud.patch(`${test.api}/${accountId}/notes/${noteId}`, { "description": "this is an updated note" }))
+      .then(r => cloud.delete(`${test.api}/${accountId}/notes/${noteId}`))
+      .then(r => cloud.delete(`${test.api}/${accountId}`));
   });
 });

--- a/src/test/elements/sugarcrmv2/activities.js
+++ b/src/test/elements/sugarcrmv2/activities.js
@@ -4,7 +4,7 @@ const suite = require('core/suite');
 const payload = require('./assets/activities');
 const chakram = require('chakram');
 
-suite.forElement('crm', 'activities', payload, (test) => {
+suite.forElement('crm', 'activities', { payload: payload }, (test) => {
   const opts = { qs: { type: 'calls' } };
   test.withOptions(opts).should.supportCruds(chakram.put);
   test.withOptions(opts).should.supportPagination();

--- a/src/test/elements/sugarcrmv2/activitiesCalls.js
+++ b/src/test/elements/sugarcrmv2/activitiesCalls.js
@@ -3,7 +3,7 @@
 const suite = require('core/suite');
 const payload = require('./assets/activitiesCalls');
 
-suite.forElement('crm', 'activitiesCalls', payload, (test) => {
+suite.forElement('crm', 'activitiesCalls', { payload: payload }, (test) => {
   test.should.supportCruds();
   test.should.supportPagination();
 });

--- a/src/test/elements/sugarcrmv2/activitiesEmails.js
+++ b/src/test/elements/sugarcrmv2/activitiesEmails.js
@@ -3,7 +3,7 @@
 const suite = require('core/suite');
 const payload = require('./assets/activitiesEmails');
 
-suite.forElement('crm', 'activitiesEmails', payload, (test) => {
+suite.forElement('crm', 'activitiesEmails', { payload: payload }, (test) => {
   test.should.supportCruds();
   test.should.supportPagination();
 });

--- a/src/test/elements/sugarcrmv2/activitiesEvents.js
+++ b/src/test/elements/sugarcrmv2/activitiesEvents.js
@@ -3,7 +3,7 @@
 const suite = require('core/suite');
 const payload = require('./assets/activitiesEvents');
 
-suite.forElement('crm', 'activitiesEvents', payload, (test) => {
+suite.forElement('crm', 'activitiesEvents', { payload: payload }, (test) => {
   test.should.supportCruds();
   test.should.supportPagination();
 });

--- a/src/test/elements/sugarcrmv2/campaigns.js
+++ b/src/test/elements/sugarcrmv2/campaigns.js
@@ -8,19 +8,18 @@ const note = {
   "description": "I am a test note"
 };
 
-suite.forElement('crm', 'campaigns', payload, (test) => {
+suite.forElement('crm', 'campaigns', { payload: payload }, (test) => {
   test.should.supportCruds();
   test.should.supportPagination();
-  let campaignId;
-  let noteId;
-  it('should support CRUDS for campaigns/notes', () =>{
+  let campaignId, noteId;
+  it('should support CRUDS for campaigns/notes', () => {
     return cloud.post(test.api, payload)
-    .then(r => campaignId = r.body.id)
-    .then(r => cloud.post(`${test.api}/${campaignId}/notes`, note))
-    .then(r => noteId = r.body.id)
-    .then(r => cloud.get(`${test.api}/${campaignId}/notes/${noteId}`))
-    .then(r => cloud.patch(`${test.api}/${campaignId}/notes/${noteId}`, {"description":"this is an updated note"}))
-    .then(r => cloud.delete(`${test.api}/${campaignId}/notes/${noteId}`))
-    .then(r => cloud.delete(`${test.api}/${campaignId}`));
+      .then(r => campaignId = r.body.id)
+      .then(r => cloud.post(`${test.api}/${campaignId}/notes`, note))
+      .then(r => noteId = r.body.id)
+      .then(r => cloud.get(`${test.api}/${campaignId}/notes/${noteId}`))
+      .then(r => cloud.patch(`${test.api}/${campaignId}/notes/${noteId}`, { "description": "this is an updated note" }))
+      .then(r => cloud.delete(`${test.api}/${campaignId}/notes/${noteId}`))
+      .then(r => cloud.delete(`${test.api}/${campaignId}`));
   });
 });

--- a/src/test/elements/sugarcrmv2/contacts.js
+++ b/src/test/elements/sugarcrmv2/contacts.js
@@ -8,19 +8,18 @@ const note = {
   "description": "I am a test note"
 };
 
-suite.forElement('crm', 'contacts', payload, (test) => {
+suite.forElement('crm', 'contacts', { payload: payload }, (test) => {
   test.should.supportCruds();
   test.should.supportPagination();
-  let contactId;
-  let noteId;
-  it('should support CRUDS for contacts/notes', () =>{
+  let contactId, noteId;
+  it('should support CRUDS for contacts/notes', () => {
     return cloud.post(test.api, payload)
-    .then(r => contactId = r.body.id)
-    .then(r => cloud.post(`${test.api}/${contactId}/notes`, note))
-    .then(r => noteId = r.body.id)
-    .then(r => cloud.get(`${test.api}/${contactId}/notes/${noteId}`))
-    .then(r => cloud.patch(`${test.api}/${contactId}/notes/${noteId}`, {"description":"this is an updated note"}))
-    .then(r => cloud.delete(`${test.api}/${contactId}/notes/${noteId}`))
-    .then(r => cloud.delete(`${test.api}/${contactId}`));
+      .then(r => contactId = r.body.id)
+      .then(r => cloud.post(`${test.api}/${contactId}/notes`, note))
+      .then(r => noteId = r.body.id)
+      .then(r => cloud.get(`${test.api}/${contactId}/notes/${noteId}`))
+      .then(r => cloud.patch(`${test.api}/${contactId}/notes/${noteId}`, { "description": "this is an updated note" }))
+      .then(r => cloud.delete(`${test.api}/${contactId}/notes/${noteId}`))
+      .then(r => cloud.delete(`${test.api}/${contactId}`));
   });
 });

--- a/src/test/elements/sugarcrmv2/incidents.js
+++ b/src/test/elements/sugarcrmv2/incidents.js
@@ -8,19 +8,18 @@ const note = {
   "description": "I am a test note"
 };
 
-suite.forElement('crm', 'incidents', payload, (test) => {
+suite.forElement('crm', 'incidents', { payload: payload }, (test) => {
   test.should.supportCruds();
   test.should.supportPagination();
-  let incidentId;
-  let noteId;
-  it('should support CRUDS for incidents/notes', () =>{
+  let incidentId, noteId;
+  it('should support CRUDS for incidents/notes', () => {
     return cloud.post(test.api, payload)
-    .then(r => incidentId = r.body.id)
-    .then(r => cloud.post(`${test.api}/${incidentId}/notes`, note))
-    .then(r => noteId = r.body.id)
-    .then(r => cloud.get(`${test.api}/${incidentId}/notes/${noteId}`))
-    .then(r => cloud.patch(`${test.api}/${incidentId}/notes/${noteId}`, {"description":"this is an updated note"}))
-    .then(r => cloud.delete(`${test.api}/${incidentId}/notes/${noteId}`))
-    .then(r => cloud.delete(`${test.api}/${incidentId}`));
+      .then(r => incidentId = r.body.id)
+      .then(r => cloud.post(`${test.api}/${incidentId}/notes`, note))
+      .then(r => noteId = r.body.id)
+      .then(r => cloud.get(`${test.api}/${incidentId}/notes/${noteId}`))
+      .then(r => cloud.patch(`${test.api}/${incidentId}/notes/${noteId}`, { "description": "this is an updated note" }))
+      .then(r => cloud.delete(`${test.api}/${incidentId}/notes/${noteId}`))
+      .then(r => cloud.delete(`${test.api}/${incidentId}`));
   });
 });

--- a/src/test/elements/sugarcrmv2/leads.js
+++ b/src/test/elements/sugarcrmv2/leads.js
@@ -8,19 +8,18 @@ const note = {
   "description": "I am a test note"
 };
 
-suite.forElement('crm', 'leads', payload, (test) => {
+suite.forElement('crm', 'leads', { payload: payload }, (test) => {
   test.should.supportCruds();
   test.should.supportPagination();
-  let leadId;
-  let noteId;
-  it('should support CRUDS for leads/notes', () =>{
+  let leadId, noteId;
+  it('should support CRUDS for leads/notes', () => {
     return cloud.post(test.api, payload)
-    .then(r => leadId = r.body.id)
-    .then(r => cloud.post(`${test.api}/${leadId}/notes`, note))
-    .then(r => noteId = r.body.id)
-    .then(r => cloud.get(`${test.api}/${leadId}/notes/${noteId}`))
-    .then(r => cloud.patch(`${test.api}/${leadId}/notes/${noteId}`, {"description":"this is an updated note"}))
-    .then(r => cloud.delete(`${test.api}/${leadId}/notes/${noteId}`))
-    .then(r => cloud.delete(`${test.api}/${leadId}`));
+      .then(r => leadId = r.body.id)
+      .then(r => cloud.post(`${test.api}/${leadId}/notes`, note))
+      .then(r => noteId = r.body.id)
+      .then(r => cloud.get(`${test.api}/${leadId}/notes/${noteId}`))
+      .then(r => cloud.patch(`${test.api}/${leadId}/notes/${noteId}`, { "description": "this is an updated note" }))
+      .then(r => cloud.delete(`${test.api}/${leadId}/notes/${noteId}`))
+      .then(r => cloud.delete(`${test.api}/${leadId}`));
   });
 });

--- a/src/test/elements/sugarcrmv2/opportunities.js
+++ b/src/test/elements/sugarcrmv2/opportunities.js
@@ -8,19 +8,18 @@ const note = {
   "description": "I am a test note"
 };
 
-suite.forElement('crm', 'opportunities', payload, (test) => {
+suite.forElement('crm', 'opportunities', { payload: payload }, (test) => {
   test.should.supportCruds();
   test.should.supportPagination();
-  let opportunityId;
-  let noteId;
-  it('should support CRUDS for opportunities/notes', () =>{
+  let opportunityId, noteId;
+  it('should support CRUDS for opportunities/notes', () => {
     return cloud.post(test.api, payload)
-    .then(r => opportunityId = r.body.id)
-    .then(r => cloud.post(`${test.api}/${opportunityId}/notes`, note))
-    .then(r => noteId = r.body.id)
-    .then(r => cloud.get(`${test.api}/${opportunityId}/notes/${noteId}`))
-    .then(r => cloud.patch(`${test.api}/${opportunityId}/notes/${noteId}`, {"description":"this is an updated note"}))
-    .then(r => cloud.delete(`${test.api}/${opportunityId}/notes/${noteId}`))
-    .then(r => cloud.delete(`${test.api}/${opportunityId}`));
+      .then(r => opportunityId = r.body.id)
+      .then(r => cloud.post(`${test.api}/${opportunityId}/notes`, note))
+      .then(r => noteId = r.body.id)
+      .then(r => cloud.get(`${test.api}/${opportunityId}/notes/${noteId}`))
+      .then(r => cloud.patch(`${test.api}/${opportunityId}/notes/${noteId}`, { "description": "this is an updated note" }))
+      .then(r => cloud.delete(`${test.api}/${opportunityId}/notes/${noteId}`))
+      .then(r => cloud.delete(`${test.api}/${opportunityId}`));
   });
 });

--- a/src/test/elements/sugarcrmv2/tasks.js
+++ b/src/test/elements/sugarcrmv2/tasks.js
@@ -3,7 +3,7 @@
 const suite = require('core/suite');
 const payload = require('./assets/tasks');
 
-suite.forElement('crm', 'tasks', payload, (test) => {
+suite.forElement('crm', 'tasks', { payload: payload }, (test) => {
   test.should.supportCruds();
   test.should.supportPagination();
 });

--- a/src/test/elements/sugarcrmv2/users.js
+++ b/src/test/elements/sugarcrmv2/users.js
@@ -4,7 +4,7 @@ const suite = require('core/suite');
 const payload = require('./assets/users');
 
 
-suite.forElement('crm', 'users', payload, (test) => {
+suite.forElement('crm', 'users', { payload: payload }, (test) => {
   test.should.supportCruds();
   test.should.supportPagination();
 });

--- a/src/test/elements/taxify/taxes.js
+++ b/src/test/elements/taxify/taxes.js
@@ -4,7 +4,7 @@ const suite = require('core/suite');
 const payload = require('./assets/taxes.create');
 const badPayload = require('./assets/taxes.bad.create');
 
-suite.forElement('finance', 'taxes', payload, (test) => {
+suite.forElement('finance', 'taxes', { payload: payload }, (test) => {
   test.should.supportCd();
   test.withJson(badPayload).should.return400OnPost();
   test.withJson({}).should.return400OnPost();

--- a/src/test/elements/woocommerce/customers.js
+++ b/src/test/elements/woocommerce/customers.js
@@ -11,7 +11,7 @@ const customer = (custom) => ({
   password: tools.random()
 });
 
-suite.forElement('ecommerce', 'customers', customer({}), (test) => {
+suite.forElement('ecommerce', 'customers', { payload: customer({}) }, (test) => {
   test.should.supportCruds();
   test.should.supportPagination();
 });

--- a/src/test/elements/woocommerce/discounts.js
+++ b/src/test/elements/woocommerce/discounts.js
@@ -3,7 +3,7 @@
 const suite = require('core/suite');
 const payload = require('./assets/discounts');
 
-suite.forElement('ecommerce', 'discounts', payload, (test) => {
+suite.forElement('ecommerce', 'discounts', { payload: payload }, (test) => {
   test.should.supportCruds();
   test.should.supportPagination();
 });

--- a/src/test/elements/woocommerce/orders.js
+++ b/src/test/elements/woocommerce/orders.js
@@ -25,10 +25,9 @@ const createOrder = (customerId, productId) => {
   return newOrder;
 };
 
-suite.forElement('ecommerce', 'orders', order, (test) => {
+suite.forElement('ecommerce', 'orders', { payload: order }, (test) => {
   it('should allow CRUDS for ' + test.api, () => {
-    let customerId;
-    let productId;
+    let customerId, productId;
     return cloud.post('/hubs/ecommerce/customers', customer())
       .then(r => customerId = r.body.id)
       .then(r => cloud.post('/hubs/ecommerce/products', product))

--- a/src/test/elements/woocommerce/products.js
+++ b/src/test/elements/woocommerce/products.js
@@ -3,7 +3,7 @@
 const suite = require('core/suite');
 const payload = require('./assets/products');
 
-suite.forElement('ecommerce', 'products', payload, (test) => {
+suite.forElement('ecommerce', 'products', { payload: payload }, (test) => {
   test.should.supportCruds();
   test.should.supportPagination();
 });

--- a/src/test/elements/woocommerce/reports.js
+++ b/src/test/elements/woocommerce/reports.js
@@ -7,7 +7,7 @@ const options = {
   qs: {}
 };
 
-suite.forElement('ecommerce', 'reports', null, (test) => {
+suite.forElement('ecommerce', 'reports', (test) => {
   it('should allow retrieval of reports and report names', () => {
     let reportName;
     return cloud.get('/hubs/ecommerce/reports/names')

--- a/src/test/elements/woocommerce/shops.js
+++ b/src/test/elements/woocommerce/shops.js
@@ -4,12 +4,12 @@ const suite = require('core/suite');
 const cloud = require('core/cloud');
 const expect = require('chakram').expect;
 
-suite.forElement('ecommerce', 'shops', null, (test) => {
+suite.forElement('ecommerce', 'shops', (test) => {
   it('should allow retrieval of shops', () => {
     return cloud.get('/hubs/ecommerce/shops')
-    .then(r => {
-      expect(r).to.have.status(200);
-      expect(r.body).to.be.a('array');
-    });
+      .then(r => {
+        expect(r).to.have.status(200);
+        expect(r.body).to.be.a('array');
+      });
   });
 });

--- a/src/test/platform/elements/accounts.js
+++ b/src/test/platform/elements/accounts.js
@@ -24,7 +24,8 @@ const genAccount = () => ({
   externalId: 'churros'
 });
 
-suite.forPlatform('elements/parameters', common.genParameter({}), schema, (test) => {
+const opts = { payload: common.genParameter({}), schema: schema };
+suite.forPlatform('elements/parameters', opts, (test) => {
   let element, keyUrl, idUrl, subAccountId;
   before(() => common.deleteElementByKey('churros')
     .then(r => cloud.post('elements', common.genElement({})))

--- a/src/test/platform/elements/configuration.js
+++ b/src/test/platform/elements/configuration.js
@@ -15,7 +15,8 @@ const crudConfig = (idOrKey, payload, updatePayload, schema, listSchema) => {
     .then(r => cloud.delete('elements/' + idOrKey + '/configuration/' + config.key));
 };
 
-suite.forPlatform('elements/configuration', common.genConfig({}), schema, (test) => {
+const opts = { payload: common.genConfig({}), schema: schema };
+suite.forPlatform('elements/configuration', opts, (test) => {
   let element;
   before(() => common.deleteElementByKey('churros')
     .then(r => cloud.post('elements', common.genElement({})))

--- a/src/test/platform/elements/elements.js
+++ b/src/test/platform/elements/elements.js
@@ -46,7 +46,9 @@ const testOAuthUrl = (idOrKey) => {
   });
 };
 
-suite.forPlatform('elements', common.genElement({}), schema, (test) => {
+const opts = { payload: common.genElement({}), schema: schema };
+
+suite.forPlatform('elements', opts, (test) => {
 
   it('should support search', () => cloud.get('elements', listSchema));
   it('should support get keys', () => cloud.get('elements/keys', keysSchema));

--- a/src/test/platform/elements/hooks.js
+++ b/src/test/platform/elements/hooks.js
@@ -6,7 +6,9 @@ const common = require('./assets/common.js');
 const schema = require('./assets/element.hook.schema.json');
 const listSchema = require('./assets/element.hooks.schema.json');
 
-suite.forPlatform('elements/hooks', common.genHook({}), schema, (test) => {
+const opts = { payload: common.genHook({}), schema: schema };
+
+suite.forPlatform('elements/hooks', opts, (test) => {
   let element, keyUrl, idUrl;
   before(() => common.deleteElementByKey('churros')
     .then(r => cloud.post('elements', common.genElement({})))

--- a/src/test/platform/elements/instances.js
+++ b/src/test/platform/elements/instances.js
@@ -27,7 +27,9 @@ const crudInstance = (baseUrl, schema) => {
     .then(r => provisioner.delete(id, baseUrl));
 };
 
-suite.forPlatform('elements/instances', instanceSchema, null, (test) => {
+const opts = { schema: instanceSchema };
+
+suite.forPlatform('elements/instances', opts, (test) => {
   it('should support CRUD by key', () => crudInstance('elements/jira/instances', instanceSchema));
   it('should support CRUD by ID', () => {
     return cloud.get('elements/jira')

--- a/src/test/platform/elements/metadata.js
+++ b/src/test/platform/elements/metadata.js
@@ -5,7 +5,9 @@ const suite = require('core/suite');
 const cloud = require('core/cloud');
 const metadataSchema = require('./assets/element.metadata.schema.json');
 
-suite.forPlatform('elements/metadata', metadataSchema, null, (test) => {
+const opts = { schema: metadataSchema };
+
+suite.forPlatform('elements/metadata', opts, (test) => {
 
   it('should return element metadata', () => {
     return cloud.get('elements/sfdc')

--- a/src/test/platform/elements/parameters.js
+++ b/src/test/platform/elements/parameters.js
@@ -6,7 +6,9 @@ const common = require('./assets/common.js');
 const schema = require('./assets/element.parameter.schema.json');
 const listSchema = require('./assets/element.parameters.schema.json');
 
-suite.forPlatform('elements/parameters', common.genParameter({}), schema, (test) => {
+const opts = { payload: common.genParameter({}), schema: schema };
+
+suite.forPlatform('elements/parameters', opts, (test) => {
   let element, keyUrl, idUrl;
   before(() => common.deleteElementByKey('churros')
     .then(r => cloud.post('elements', common.genElement({})))

--- a/src/test/platform/elements/resourceHooks.js
+++ b/src/test/platform/elements/resourceHooks.js
@@ -6,7 +6,9 @@ const common = require('./assets/common.js');
 const schema = require('./assets/element.hook.schema.json');
 const listSchema = require('./assets/element.hooks.schema.json');
 
-suite.forPlatform('elements/resources/hooks', common.genHook({}), schema, (test) => {
+const opts = { payload: common.genHook({}), schema: schema };
+
+suite.forPlatform('elements/resources/hooks', opts, (test) => {
   let element, resource, keyUrl, idUrl;
   before(() => common.deleteElementByKey('churros')
     .then(r => cloud.post('elements', common.genElement({})))

--- a/src/test/platform/elements/resourceModels.js
+++ b/src/test/platform/elements/resourceModels.js
@@ -14,7 +14,9 @@ const crudModels = (url, schema) => {
     .then(r => cloud.delete(url));
 };
 
-suite.forPlatform('elements/resources/models', common.genParameter({}), schema, (test) => {
+const opts = { paylod: common.genParameter({}), schema: schema };
+
+suite.forPlatform('elements/resources/models', opts, (test) => {
   let element, resource, keyUrl, idUrl;
   before(() => common.deleteElementByKey('churros')
     .then(r => cloud.post('elements', common.genElement({})))

--- a/src/test/platform/elements/resourceParameters.js
+++ b/src/test/platform/elements/resourceParameters.js
@@ -6,7 +6,9 @@ const common = require('./assets/common.js');
 const schema = require('./assets/element.parameter.schema.json');
 const listSchema = require('./assets/element.parameters.schema.json');
 
-suite.forPlatform('elements/resources/parameters', common.genParameter({}), schema, (test) => {
+const opts = { paylod: common.genParameter({}), schema: schema };
+
+suite.forPlatform('elements/resources/parameters', opts, (test) => {
   let element, resource, keyUrl, idUrl;
   before(() => common.deleteElementByKey('churros')
     .then(r => cloud.post('elements', common.genElement({})))

--- a/src/test/platform/elements/resources.js
+++ b/src/test/platform/elements/resources.js
@@ -6,7 +6,9 @@ const common = require('./assets/common.js');
 const schema = require('./assets/element.resource.schema.json');
 const listSchema = require('./assets/element.resources.schema.json');
 
-suite.forPlatform('elements/resources', common.genResource({}), schema, (test) => {
+const opts = { payload: common.genResource({}), schema: schema };
+
+suite.forPlatform('elements/resources', opts, (test) => {
   let element, keyUrl, idUrl;
   before(() => common.deleteElementByKey('churros')
     .then(r => cloud.post('elements', common.genElement({})))

--- a/src/test/platform/events/events.js
+++ b/src/test/platform/events/events.js
@@ -27,7 +27,7 @@ const loadPayload = (element) => {
   }
 };
 
-suite.forPlatform('events', null, null, (test) => {
+suite.forPlatform('events', (test) => {
   let instanceId;
   const element = props.getForKey('events', 'element');
   before(done => provisioner.create(element, gen({}, props.getForKey('events', 'url')))

--- a/src/test/platform/formulas/executions.js
+++ b/src/test/platform/formulas/executions.js
@@ -99,7 +99,7 @@ const validateSimpleSuccessfulStepExecutions = {
   forScheduled: validateSimpleSuccessfulStepExecutionsForType(validateSimpleSuccessfulScheduledTrigger)
 };
 
-suite.forPlatform('formulas', null, null, (test) => {
+suite.forPlatform('formulas', { name: 'formula executions' }, (test) => {
   let sfdcId;
   before(done => provisionSfdcWithPolling().then(r => {
     sfdcId = r.body.id;

--- a/src/test/platform/formulas/formula.instances.js
+++ b/src/test/platform/formulas/formula.instances.js
@@ -13,7 +13,9 @@ const cleanup = (eiId, fId, fiId) => {
     .then(r => provisioner.delete(eiId));
 };
 
-suite.forPlatform('formulas', common.genFormula({}), schema, (test) => {
+const opts = { name: 'formula instances', payload: common.genFormula({}), schema: schema };
+
+suite.forPlatform('formulas', opts, (test) => {
   /* Create a formula instance to use in the tests below */
   let elementInstanceId, formulaId, formulaInstanceId;
   before(() => {

--- a/src/test/platform/formulas/formulas.js
+++ b/src/test/platform/formulas/formulas.js
@@ -12,7 +12,9 @@ const triggerSchema = require('./assets/formula.trigger.schema');
 const instanceSchema = require('./assets/formula.instance.schema');
 const common = require('./assets/common');
 
-suite.forPlatform('formulas', common.genFormula({}), schema, (test) => {
+const opts = { payload: common.genFormula({}), schema: schema };
+
+suite.forPlatform('formulas', opts, (test) => {
 
   test.should.supportCrud(chakram.put);
 

--- a/src/test/platform/formulas/formulas.scripts.js
+++ b/src/test/platform/formulas/formulas.scripts.js
@@ -41,7 +41,7 @@ const gen = (genStep) => (genScript) => {
  * Handles validating that formula script steps that are trying to be created have the right error handling capabilities
  * around them
  */
-suite.forPlatform('formulas', null, schema, (test) => {
+suite.forPlatform('formulas', { name: 'formula script steps', schema: schema }, (test) => {
   test
     .withName('should allow creating a script step with the v1 engine')
     .withJson(gen(genV1Step)(genGoodV1Script))

--- a/src/test/platform/instances/instances.js
+++ b/src/test/platform/instances/instances.js
@@ -1,5 +1,5 @@
 'use strict';
-const expect = require('chakram').expect;
+
 const suite = require('core/suite');
 const payload = require('./assets/instances');
 const schema = require('./assets/instances.schema');
@@ -9,14 +9,16 @@ const transformationPayload = require('./assets/accountTransformation');
 const objDefPayload = require('./assets/accountObjectDefinition');
 const sfdcSwaggerSchema = require('./assets/sfdcSwagger.schema');
 
-suite.forPlatform('instances', schema, payload, (test) => {
+const opts = { schema: schema, payload: payload };
+
+suite.forPlatform('instances', opts, (test) => {
   /** before - provision element to use throughout */
   const elementKey = 'sfdc';
   let sfdcId;
   before(() => provisioner.create(elementKey)
     .then(r => {
-      sfdcId = r.body.id
-        //create the object definitions on the instance
+      sfdcId = r.body.id;
+      //create the object definitions on the instance
       return cloud.post(`instances/${sfdcId}/objects/myaccounts/definitions`, objDefPayload);
     })
     .then(r => {
@@ -29,5 +31,4 @@ suite.forPlatform('instances', schema, payload, (test) => {
   after(() => provisioner.delete(sfdcId));
 
   it('should support get instance specific docs', () => cloud.get(`instances/${sfdcId}/docs`, sfdcSwaggerSchema));
-
 });

--- a/src/test/platform/notifications/deliveries.js
+++ b/src/test/platform/notifications/deliveries.js
@@ -28,7 +28,9 @@ const genSub = (opts) => new Object({
 
 const genSettings = (policy) => ({ 'notification.webhook.failure.policy': policy });
 
-suite.forPlatform('notifications/subscriptions/deliveries', genSub({}), schema, (test) => {
+const opts = { payload: genSub({}), schema: schema };
+
+suite.forPlatform('notifications/subscriptions/deliveries', opts, (test) => {
   before(() => persister.snapshot());
   after(() => persister.restore());
 

--- a/src/test/platform/notifications/notifications.js
+++ b/src/test/platform/notifications/notifications.js
@@ -14,7 +14,9 @@ const genNotif = (opts) => new Object({
   from: (opts.from || 'churros')
 });
 
-suite.forPlatform('notifications', genNotif({}), schema, (test) => {
+const opts = { payload: genNotif({}), schema: schema };
+
+suite.forPlatform('notifications', opts, (test) => {
   test.should.supportCrd();
   test.should.return404OnGet(-1);
   test

--- a/src/test/platform/notifications/subscriptions.js
+++ b/src/test/platform/notifications/subscriptions.js
@@ -5,11 +5,13 @@ const schema = require('./assets/subscription.schema.json');
 
 const genSub = (opts) => new Object({
   channel: (opts.channel || 'webhook'),
-  topics: (opts.topics || [ 'churros-topic' ]),
+  topics: (opts.topics || ['churros-topic']),
   config: (opts.config || { url: 'http://fake.churros.api.com' })
 });
 
-suite.forPlatform('notifications/subscriptions', genSub({}), schema, (test) => {
+const opts = { payload: genSub({}), schema: schema };
+
+suite.forPlatform('notifications/subscriptions', opts, (test) => {
   test.should.supportCrd();
   test.withJson({}).should.return400OnPost();
   test.should.return404OnGet(-1);

--- a/src/test/platform/transformations/transformations.js
+++ b/src/test/platform/transformations/transformations.js
@@ -144,11 +144,12 @@ const testTransformationForInstance = (objectName, objDefUrl, transUrl) => {
 
 const testTransformation = (instanceId, objectName, objDefUrl, transUrl) => testTransformationForInstance(objectName, objDefUrl, transUrl);
 
-suite.forPlatform('transformations', schema, null, (test) => {
+suite.forPlatform('transformations', { schema: schema }, (test) => {
   /** before - provision element to use throughout */
   const elementKey = 'sfdc';
   let sfdcId, elementId;
-  before(() => provisioner.create(elementKey).then(r => { sfdcId = r.body.id; elementId = r.body.element.id; }));
+  before(() => provisioner.create(elementKey).then(r => { sfdcId = r.body.id;
+    elementId = r.body.element.id; }));
 
   /** after - clean up element */
   after(() => provisioner.delete(sfdcId));

--- a/test/core/assets/suite-helper.js
+++ b/test/core/assets/suite-helper.js
@@ -1,0 +1,166 @@
+'use strict';
+
+const nock = require('nock');
+
+var exports = module.exports = {};
+const genPayload = (opts) => {
+  opts = opts || {};
+  return new Object({
+    id: (opts.id || null),
+    foo: (opts.foo || 'bar')
+  });
+};
+exports.genPayload = genPayload;
+
+const genSchema = () => new Object({
+  type: ['object', 'array'],
+  properties: {
+    id: { type: "number" },
+    foo: { type: "string" }
+  },
+  required: ['id', 'foo']
+});
+exports.genSchema = genSchema;
+
+/** MOCKING OUT HTTP ENDPOINTS **/
+/** https://github.com/pgte/nock#specifying-hostname **/
+exports.mock = (baseUrl, headers, eventHeaders) => {
+  /** POST **/
+  nock(baseUrl, headers())
+    .post('/foo')
+    .reply(200, (uri, requestBody) => {
+      requestBody.id = 123;
+      return requestBody;
+    })
+    .post('/foo/bad')
+    .reply(400, (uri, requestBody) => {
+      return { message: 'Invalid JSON body' };
+    })
+    .post('/foo/file')
+    .reply(200, (uri, requestBody) => genPayload({ id: 123 }))
+    .post('/foo/bad/file')
+    .reply(404, (uri, requestBody) => {
+      return { message: 'No resource found at /foo/bad/file' };
+    });
+
+  nock(baseUrl, eventHeaders())
+    .post('/events/myelement')
+    .reply(200, (uri, requestBody) => requestBody);
+
+  /** GET **/
+  nock(baseUrl, headers())
+    .get('/foo/123')
+    .reply(200, () => genPayload({ id: 123 }))
+    .get('/foo/456')
+    .reply(404, () => {
+      return { message: 'No foo found with the given ID' };
+    })
+    .get('/foo/bad')
+    .reply(404, () => {
+      return { message: 'No resource found with name /foo/bad' };
+    })
+    .get('/foo')
+    .reply(200, (uri, requestBody) => [genPayload({ id: 123 }), genPayload({ id: 456 })])
+    .get('/foo')
+    .query({ page: '1', pageSize: '1' })
+    .reply(200, () => genPayload({ id: 123 }))
+    .get('/foo')
+    .query({ where: 'id=\'123\'' })
+    .reply(200, () => [genPayload({ id: 123 })])
+    .get('/foo/search')
+    .query({ foo: 'bar' })
+    .reply(200, () => [genPayload({ id: 123 })]);
+
+  /** PATCH && PUT **/
+  nock(baseUrl, headers())
+    .patch('/foo/123')
+    .reply(200, (uri, requestBody) => {
+      requestBody.id = 123;
+      return requestBody;
+    })
+    .patch('/foo/123')
+    .reply(200, (uri, requestBody) => {
+      requestBody.id = 123;
+      return requestBody;
+    })
+    .patch('/foo/456')
+    .reply(404, (uri, requestBody) => {
+      return { message: 'No foo found with the given ID' };
+    })
+    .put('/foo/123')
+    .reply(200, (uri, requestBody) => {
+      requestBody.id = 123;
+      return requestBody;
+    })
+    .put('/foo/456')
+    .reply(404, (uri, requestBody) => {
+      return { message: 'No foo found with the given ID' };
+    });
+
+  /** MOCKING OUT HTTP ENDPOINTS **/
+  /** https://github.com/pgte/nock#specifying-hostname **/
+
+  /** POST **/
+  nock(baseUrl, headers())
+    .post('/foo')
+    .reply(200, (uri, requestBody) => {
+      requestBody.id = 123;
+      return requestBody;
+    })
+    .post('/foo/bad')
+    .reply(400, (uri, requestBody) => ({ message: 'Invalid JSON body' }))
+    .post('/foo/file')
+    .reply(200, (uri, requestBody) => genPayload({ id: 123 }))
+    .post('/foo/bad/file')
+    .reply(404, (uri, requestBody) => ({ message: 'No resource found at /foo/bad/file' }))
+    .post('/events/myelement')
+    .reply(200, (uri, requestBody) => requestBody)
+    .post('/foo/pagination')
+    .reply(200, (uri, requestBody) => genPayload({ id: 123 }));
+
+  /** GET **/
+  nock(baseUrl, headers())
+    .get('/foo/123')
+    .reply(200, () => genPayload({ id: 123 }))
+    .get('/foo/456')
+    .reply(404, () => ({ message: 'No foo found with the given ID' }))
+    .get('/foo/bad')
+    .reply(404, () => ({ message: 'No resource found with name /foo/bad' }))
+    .get('/foo')
+    .reply(200, (uri, requestBody) => [genPayload({ id: 123 }), genPayload({ id: 456 })])
+    .get('/foo')
+    .query({ page: '1', pageSize: '1' })
+    .reply(200, () => genPayload({ id: 123 }))
+    .get('/foo')
+    .query({ where: 'id=\'123\'' })
+    .reply(200, () => [genPayload({ id: 123 })])
+    .get('/foo/pagination')
+    .query(true)
+    .reply(200, () => [genPayload({ id: 123 })]);
+
+  /** PATCH && PUT **/
+  nock(baseUrl, headers())
+    .patch('/foo/123')
+    .reply(200, (uri, requestBody) => {
+      requestBody.id = 123;
+      return requestBody;
+    })
+    .patch('/foo/456')
+    .reply(404, (uri, requestBody) => ({ message: 'No foo found with the given ID' }))
+    .put('/foo/123')
+    .reply(200, (uri, requestBody) => {
+      requestBody.id = 123;
+      return requestBody;
+    })
+    .put('/foo/456')
+    .reply(404, (uri, requestBody) => ({ message: 'No foo found with the given ID' }));
+
+  /** DELETE **/
+  nock(baseUrl, headers())
+    .delete('/foo/123')
+    .reply(200, (uri, requestBody) => ({}))
+    .delete('/foo/456')
+    .reply(404, (uri, requestBody) => ({ message: 'No foo found with the given ID' }))
+    .delete('/foo/pagination/123')
+    .reply(200, (uri, requestBody) => ({}));
+};

--- a/test/core/suite.test.js
+++ b/test/core/suite.test.js
@@ -186,63 +186,100 @@ describe('suite', () => {
       .reply(200, (uri, requestBody) => ({}));
   });
 
+  /* Not passing in any suite options */
   suite.forElement('fakehub', 'resource', (test) => {
     it('should support suite for element', () => expect(test.api).to.equal('/hubs/fakehub/resource'));
   });
 
+  /* Not passing in any suite options */
   suite.forPlatform('platformresource', (test) => {
     it('should support suite for platform', () => expect(test.api).to.equal('/platformresource'));
   });
 
+  /* Passing in payload and schema options, which are the defaults used, unless overridden, for all tests inside suite */
   suite.forPlatform('foo', { payload: genPayload(), schema: genSchema() }, (test) => {
-    // *****************************************
-    // NOTE: all of these are equivalent just as examples
-    // *****************************************
+    /* all of these are equivalent just as examples */
     test.should.return200OnPost();
-    test.withApi('/foo').should.return200OnPost();
-    test.withJson(genPayload()).should.return200OnPost();
-    test.withValidation(genSchema()).should.return200OnPost();
-    test.withApi('/foo').withJson(genPayload()).withValidation(genSchema()).should.return200OnPost();
-    test.withJson(genPayload()).withValidation(genSchema()).withApi('/foo').should.return200OnPost();
-    test.withOptions({}).should.return200OnPost();
-    test.withApi('/foo').withOptions({}).should.return200OnPost();
-    // *****************************************
+    test
+      .withApi('/foo')
+      .should.return200OnPost();
+    test
+      .withJson(genPayload())
+      .should.return200OnPost();
+    test
+      .withValidation(genSchema())
+      .should.return200OnPost();
+    test
+      .withApi('/foo')
+      .withJson(genPayload())
+      .withValidation(genSchema())
+      .should.return200OnPost();
+    test
+      .withJson(genPayload())
+      .withValidation(genSchema())
+      .withApi('/foo')
+      .should.return200OnPost();
+    test
+      .withOptions({})
+      .should.return200OnPost();
+    test
+      .withApi('/foo')
+      .withOptions({})
+      .should.return200OnPost();
 
-    // *****************************************
-    // NOTE: all of these are equivalent just as examples
-    // *****************************************
+    /* all of these are equivalent just as examples */
     test.should.return404OnPatch(456);
-    test.withApi(test.api + '/456').should.return404OnPatch();
-    // *****************************************
+    test
+      .withApi(`${test.api}/456`)
+      .should.return404OnPatch();
 
-    // with options, extends the request libraries options object
-    test.withOptions({ qs: { page: 1, pageSize: 1 } }).should.return200OnGet();
+    /* with options, extends the request libraries options object */
+    test
+      .withOptions({ qs: { page: 1, pageSize: 1 } })
+      .should.return200OnGet();
 
-    // no with... functions, which will just use the defaults that were passed in to the `suite.forPlatform` above
+    /* withApi overrides the default api that was passed in to the `suite.forPlatform` above */
+    test
+      .withApi(`${test.api}/456`)
+      .should.return404OnGet();
+    test
+      .withApi('/foo/456')
+      .should.return404OnPut();
+    test
+      .withApi('/foo/456')
+      .should.return404OnDelete();
+    test
+      .withApi('/foo/pagination')
+      .should.supportNextPagePagination(1);
+
+    /* no with... functions, which will just use the defaults that were passed in to the `suite.forPlatform` above */
     test.should.return200OnPost();
     test.should.return404OnGet(456);
-    test.withApi(test.api + '/456').should.return404OnGet();
-    test.withApi('/foo/456').should.return404OnPut();
-    test.withApi('/foo/456').should.return404OnDelete();
-    test.withOptions({ json: true }).should.supportSr();
-    test.withOptions({ json: true }).should.supportCruds();
-    test.withOptions({ json: true }).should.supportCruds(chakram.put);
-    test.withOptions({ json: true }).should.supportCrud();
-    test.withOptions({ json: true }).should.supportCrus();
-    test.withOptions({ json: true }).should.supportCrd();
-    test.withOptions({ json: true }).should.supportCd();
-    test.withOptions({ json: true }).should.supportCrds();
-    test.withOptions({ json: true }).should.supportCrs();
+    test.should.supportSr();
+    test.should.supportCruds();
+    test.should.supportCruds(chakram.put);
+    test.should.supportCrud();
+    test.should.supportCrus();
+    test.should.supportCrd();
+    test.should.supportCd();
+    test.should.supportCrds();
+    test.should.supportCrs();
     test.should.supportPagination();
     test.should.supportCeqlSearch('id');
-    test.withApi('/foo/pagination').should.supportNextPagePagination(1);
 
-    // overriding the default API that was passed in as the default in the `suite.forPlatform`
-    test.withApi('/foo/bad').should.return400OnPost();
+    /* overriding the default API that was passed in as the default in the `suite.forPlatform` */
+    test
+      .withApi('/foo/bad')
+      .should.return400OnPost();
 
-    // examples of using .withName(...) which will set the name of the test to be whatever string is passed in
-    test.withName('this should be the name of the test').should.return200OnPost();
-    test.withApi('/foo/bad').withName('this should be the name of the test').should.return400OnPost();
+    /* examples of using .withName(...) which will set the name of the test to be whatever string is passed in */
+    test
+      .withName('this should be the name of the test')
+      .should.return200OnPost();
+    test
+      .withApi('/foo/bad')
+      .withName('this should be the name of the test')
+      .should.return400OnPost();
 
     test
       .withName('should allow overriding the api and the options with new values')
@@ -252,8 +289,10 @@ describe('suite', () => {
   });
 });
 
-suite.forPlatform('foo', { name: 'custom describe mocha name' }, (test) => {
-  test
-    .withJson(genPayload())
-    .should.return200OnPost();
-});
+/* This test exercises all of the available optional suite options */
+const opts = {
+  name: 'this will override the resource that was passed in',
+  payload: genPayload(),
+  schema: genSchema()
+};
+suite.forPlatform('exampleResourceName', opts, (test) => {});

--- a/test/core/suite.test.js
+++ b/test/core/suite.test.js
@@ -251,3 +251,9 @@ describe('suite', () => {
       .should.return200OnGet();
   });
 });
+
+suite.forPlatform('foo', { name: 'custom describe mocha name' }, (test) => {
+  test
+    .withJson(genPayload())
+    .should.return200OnPost();
+});

--- a/test/core/suite.test.js
+++ b/test/core/suite.test.js
@@ -186,15 +186,15 @@ describe('suite', () => {
       .reply(200, (uri, requestBody) => ({}));
   });
 
-  suite.forElement('fakehub', 'resource', null, (test) => {
+  suite.forElement('fakehub', 'resource', (test) => {
     it('should support suite for element', () => expect(test.api).to.equal('/hubs/fakehub/resource'));
   });
 
-  suite.forPlatform('platformresource', null, null, (test) => {
+  suite.forPlatform('platformresource', (test) => {
     it('should support suite for platform', () => expect(test.api).to.equal('/platformresource'));
   });
 
-  suite.forPlatform('foo', genPayload(), genSchema(), (test) => {
+  suite.forPlatform('foo', { payload: genPayload(), schema: genSchema() }, (test) => {
     // *****************************************
     // NOTE: all of these are equivalent just as examples
     // *****************************************


### PR DESCRIPTION
## Highlights
* As part of `npm test`, all code in `src` and `test` directories is now run through a javascript linter (`jshint`) using the default `.jshintrc`.
* Re-factored `suite.forElement` and `suite.forPlatform` to no longer take in an optional `payload` and `schema`, but instead those functions now take an optional `options` object
* Currently, that `options` object supports the following fields:
```
{
  name: mochaDescribeNameThatOverridesTheResourceName,
  payload: defaultPaylodThatWillBeUsedOnPostPutorPatchCalls,
  schema: defaultValidationThatWillHappenOnAllApiCallsExceptDeletes
}
```

## Examples
#### `suite.forPlatform` examples:
```
// with all available options (but they're all optional)
const opts = { name: 'formula tests', payload: payload, schema: schema };
suite.forPlatform('formulas', opts, (test) => {
...
};

// with just payload and schema options and 'formulas' will be the name of this suite (as it was before)
const opts = { payload: payload, schema: schema };
suite.forPlatform('formulas', opts, (test) => {
...
};

// no options at all
suite.forPlatform('formulas', (test) => {
...
};
```

#### `suite.forElement` examples:
```
// with all available options
const opts = {name: 'helpdesk users test', payload: payload, schema: schema };
suite.forElement('helpdesk', 'users', opts, (test) => {
...
});

// no options at all
suite.forElement('helpdesk', 'users', (test) => {
...
});
```
## Closes
* Closes #150 