### PR TITLE
CE-4219 WooCommerce newly added API tests

### DIFF
--- a/src/test/elements/woocommerce/assets/comments.json
+++ b/src/test/elements/woocommerce/assets/comments.json
@@ -1,0 +1,4 @@
+{
+    "note": "Order ok!!!",
+    "customer_note": false
+}

--- a/src/test/elements/woocommerce/ordersComments.js
+++ b/src/test/elements/woocommerce/ordersComments.js
@@ -26,14 +26,6 @@ const createOrder = (customerId, productId) => {
   return newOrder;
 };
 
-const commentsApi = (orderId, commentId) => {
-  if(commentId === null || commentId === undefined) {
-    return '/hubs/ecommerce/orders/' + orderId+ '/comments';
-  }
-
-  return '/hubs/ecommerce/orders/' + orderId+ '/comments/'+commentId;
-};
-
 suite.forElement('ecommerce', 'ordersComments', { payload: order }, (test) => {
   it('should allow CRUDS for ' + test.api, () => {
     let customerId, productId, orderId;
@@ -43,10 +35,7 @@ suite.forElement('ecommerce', 'ordersComments', { payload: order }, (test) => {
       .then(r => productId = r.body.id)
       .then(r => cloud.post('/hubs/ecommerce/orders', createOrder(customerId, productId)))
       .then(r => orderId = r.body.id)
-      .then(r => cloud.post(commentsApi(orderId), comment))
-      .then(r => cloud.get(commentsApi(orderId, r.body.id)))
-      .then(r => cloud.update(commentsApi(orderId, r.body.id), comment))
-      .then(r => cloud.delete(commentsApi(orderId, r.body.id)))
+      .then(r => test.withApi('/hubs/ecommerce/orders/' + orderId+ '/comments').should.supportCruds())
       .then(r => cloud.delete('/hubs/ecommerce/orders/' + orderId))
       .then(r => cloud.delete('/hubs/ecommerce/customers/' + customerId))
       .then(r => cloud.delete('/hubs/ecommerce/products/' + productId));

--- a/src/test/elements/woocommerce/ordersComments.js
+++ b/src/test/elements/woocommerce/ordersComments.js
@@ -5,7 +5,6 @@ const tools = require('core/tools');
 const cloud = require('core/cloud');
 const order = require('./assets/orders');
 const product = require('./assets/products');
-const comment = require('./assets/comments');
 
 const customer = () => ({
   first_name: 'Bill',


### PR DESCRIPTION
## Highlights
* Added /orders/{id}/comments
* Added /product/{id}/orders

## Examples
```
  customers
    ✓ should allow CRUDS for /hubs/ecommerce/customers (1949ms)
    ✓ should allow paginating with page and pageSize /hubs/ecommerce/customers (462ms)

  discounts
    ✓ should allow CRUDS for /hubs/ecommerce/discounts (1678ms)
    ✓ should allow paginating with page and pageSize /hubs/ecommerce/discounts (252ms)

  orders
    ✓ should allow CRUDS for /hubs/ecommerce/orders (2817ms)
    ✓ should allow paginating with page and pageSize /hubs/ecommerce/orders (405ms)

  ordersComments
    ✓ should allow CRUDS for /hubs/ecommerce/ordersComments (4833ms)

  products
    ✓ should allow CRUDS for /hubs/ecommerce/products (3301ms)
    ✓ should allow paginating with page and pageSize /hubs/ecommerce/products (690ms)

  reports
    ✓ should allow retrieval of reports and report names (945ms)

  shops
    ✓ should allow retrieval of shops (329ms)


  11 passing (20s)
```
