### PR TITLE
External Auth Flag

### DIFF
--- a/src/cli/churros-test.js
+++ b/src/cli/churros-test.js
@@ -23,7 +23,8 @@ const fromOptions = (url, options) => {
       load: options.load,
       loadElement: options.element,
       browser: options.browser,
-      verbose: options.verbose === undefined ? false : options.verbose // hack...i can't figure out why it's not default to false
+      verbose: options.verbose === undefined ? false : options.verbose, // hack...i can't figure out why it's not default to false
+      externalAuth: options.externalAuth
     });
   });
 };
@@ -93,6 +94,7 @@ const run = (suite, options, cliArgs) => {
   if (cliArgs.loadElement) args += ` --loadElement ${cliArgs.loadElement}`;
   if (cliArgs.verbose) args += ` --verbose ${cliArgs.verbose}`;
   if (cliArgs.browser) args += ` --browser ${cliArgs.browser}`;
+  if (cliArgs.externalAuth) args += ` --externalAuth`;
 
   let cmd = `${rootDir}/../../node_modules/.bin/mocha ${mochaPaths.join(' ')} ${args}`;
   process.exit(shell.exec(cmd).code); // execute the cmd and make our exit code the same as 'churros test' code
@@ -118,6 +120,7 @@ commander
   .option('-r, --url [url]', 'overrides the default URL setup during initialization')
   .option('-u, --user <user>', 'overrides the default user setup during initialization')
   .option('-p, --password', 'overrides the default password setup during initialization (this will prompt you for your password)')
+  .option('-x, --externalAuth', 'provision using external authentication. only for elements tests')
   .option('-b, --browser <name>', 'browser to use during the selenium OAuth process', 'firefox') // will change this to phantomjs as churros becomes more mature
   .option('-V, --verbose', 'logging verbose mode')
   .on('--help', () => {

--- a/src/core/provisioner.js
+++ b/src/core/provisioner.js
@@ -7,6 +7,7 @@ const props = require('core/props');
 const urlParser = require('url');
 const logger = require('winston');
 const o = require('core/oauth');
+const r = require('request');
 const defaults = require('core/defaults');
 
 var exports = module.exports = {};
@@ -49,10 +50,54 @@ const createInstance = (element, config, providerData, baseApi) => {
     .then(r => {
       expect(r).to.have.statusCode(200);
       logger.debug('Created %s element instance with ID: %s', element, r.body.id);
-      defaults.token(r.body.token);
       return r;
     })
     .catch(r => tools.logAndThrow('Failed to create an instance of %s', r, element));
+};
+
+const createExternalInstance = (element, config, providerData) => {
+  const tokenUrl = config.tokenUrl;
+  const apiKey = config['oauth.api.key'];
+  const apiSecret = config['oauth.api.secret'];
+  const callbackUrl = props.get('oauth.callback.url');
+  const code = providerData.code;
+  let instanceBody;
+
+  if (!tokenUrl) {
+    throw Error("Token URL must be present in the element props as 'tokenUrl'");
+  }
+
+  return new Promise((res, rej) => {
+    r.post({
+      url: tokenUrl,
+      form: {
+        client_id: apiKey,
+        client_secret: apiSecret,
+        grant_type: 'authorization_code',
+        redirect_uri: callbackUrl,
+        code: code
+      }
+    }, (e, r, b) => {
+      let body = JSON.parse(b);
+      let refreshToken = body.refresh_token;
+      instanceBody = {
+        "element": {
+          "key": element
+        },
+        "configuration": {
+          "oauth.user.refresh_token": refreshToken,
+          "oauth.api.key": apiKey,
+          "oauth.api.secret": apiSecret,
+          "oauth.resource.url": props.getOptionalForKey(element, 'site.address'),
+          "site.url": props.getOptionalForKey(element, 'site.address'),
+          "site.address": props.getOptionalForKey(element, 'site.address')
+        },
+        "name": `${element} external auth churros`,
+        "externalAuthentication": "initial"
+      };
+      res(chakram.post('/instances', instanceBody));
+    });
+  });
 };
 
 const oauth = (element, args, config) => {
@@ -96,6 +141,7 @@ const oauth1 = (element, args) => {
 
 exports.create = (element, args, baseApi) => {
   const type = props.getOptionalForKey(element, 'provisioning');
+  const external = props.getOptionalForKey(element, 'external');
   const config = genConfig(props.all(element), args);
 
   logger.debug('Attempting to provision %s using the %s provisioning flow', element, type ? type : 'standard');
@@ -110,11 +156,19 @@ exports.create = (element, args, baseApi) => {
       return parseProps(element)
         .then(r => (type === 'oauth1') ? oauth1(element, r) : r)
         .then(r => oauth(element, r, config))
-        .then(r => createInstance(element, config, r, baseApi));
+        .then(r => {
+          if (external && type === 'oauth2') {
+            return createExternalInstance(element, config, r);
+          } else if (external && type === 'oauth1') {
+            throw Error('External Authentication via churros is not yet implemented for OAuth1');
+          } else {
+            return createInstance(element, config, r, baseApi);
+          }
+        });
     case 'custom':
-      // looks for the custom provisioner in the test directory
       const cp = `${__dirname}/../test/elements/${element}/provisioner`;
-      return require(cp);
+      const customProvisioner = require(cp);
+      return customProvisioner.create(config);
     default:
       return createInstance(element, config, undefined, baseApi);
   }

--- a/src/core/provisioner.js
+++ b/src/core/provisioner.js
@@ -167,8 +167,7 @@ exports.create = (element, args, baseApi) => {
         });
     case 'custom':
       const cp = `${__dirname}/../test/elements/${element}/provisioner`;
-      const customProvisioner = require(cp);
-      return customProvisioner.create(config);
+      return require(cp).create(config);
     default:
       return createInstance(element, config, undefined, baseApi);
   }

--- a/src/test/elements/lifecycle.js
+++ b/src/test/elements/lifecycle.js
@@ -7,6 +7,7 @@ const provisioner = require('core/provisioner');
 const argv = require('optimist').demand('element').argv;
 const fs = require('fs');
 const logger = require('winston');
+let defaults = require('core/defaults');
 
 const createAll = (urlTemplate, list) => {
   let promises = [];
@@ -30,6 +31,7 @@ before(done => {
     .then(r => {
       expect(r).to.have.statusCode(200);
       instanceId = r.body.id;
+      defaults.token(r.body.token);
       // object definitions file exists? create the object definitions on the instance
       const objectDefinitionsFile = `${__dirname}/assets/object.definitions`;
       if (fs.existsSync(objectDefinitionsFile + '.json')) {

--- a/src/test/lifecycle.js
+++ b/src/test/lifecycle.js
@@ -22,13 +22,19 @@ config.password = (argv.password || config.password);
 config.url = (argv.url || config.url);
 config.browser = (argv.browser || 'firefox'); // long term, want to change this to phantom...this is helpful for debugging now in the early stages of churros
 
+// this happens once
+const props = require('core/props')(config);
+
+if (argv.externalAuth) {
+  const element = argv.element;
+  props.setForKey(element, 'provisioning', 'custom');
+}
+
 if (!config.events) config.events = {};
 config.events.wait = (argv.wait || config.events.wait);
 config.events.load = (argv.load || config.events.load);
 config.events.element = (argv.loadElement || config.events.element);
 
-// this happens once
-const props = require('core/props')(config);
 
 before(() => {
   const url = props.get('url');

--- a/src/test/lifecycle.js
+++ b/src/test/lifecycle.js
@@ -27,7 +27,7 @@ const props = require('core/props')(config);
 
 if (argv.externalAuth) {
   const element = argv.element;
-  props.setForKey(element, 'provisioning', 'custom');
+  props.setForKey(element, 'external', true);
 }
 
 if (!config.events) config.events = {};

--- a/test/core/provisioner.test.js
+++ b/test/core/provisioner.test.js
@@ -45,6 +45,32 @@ const setupProps = () => {
       'password': 'ricard',
       'oauth.api.key': 'he gon do one',
       'oauth.api.secret': 'fill it up again'
+    },
+    'myoauth2external': {
+      'provisioning': 'oauth2',
+      'external': true,
+      'username': 'frank',
+      'password': 'ricard',
+      'oauth.api.key': 'he gon do one',
+      'oauth.api.secret': 'fill it up again',
+      'tokenUrl': 'http://pvenkman.ghostbuster.com/token'
+    },
+    'myoauth1external': {
+      'provisioning': 'oauth1',
+      'external': true,
+      'username': 'frank',
+      'password': 'ricard',
+      'oauth.api.key': 'he gon do one',
+      'oauth.api.secret': 'fill it up again',
+      'tokenUrl': 'http://pvenkman.ghostbuster.com/token'
+    },
+    'noTokenUrl': {
+      'provisioning': 'oauth2',
+      'external': true,
+      'username': 'frank',
+      'password': 'ricard',
+      'oauth.api.key': 'he gon do one',
+      'oauth.api.secret': 'fill it up again'
     }
   });
 };
@@ -96,6 +122,41 @@ describe('provisioner', () => {
       .reply(200, () => new Object({
         oauthUrl: 'http://frankthetanksoauthurl.com'
       }));
+
+    nock(baseUrl, headers())
+      .get('/elements/myoauth2external/oauth/url')
+      .query(true)
+      .reply(200, () => new Object({
+        oauthUrl: 'http://frankthetanksoauthurl.com'
+      }));
+
+    nock(baseUrl, headers())
+      .get('/elements/myoauth1external/oauth/token')
+      .query(true)
+      .reply(200, () => new Object({
+        oauthUrl: 'http://frankthetanksoauthurl.com'
+      }));
+
+    nock(baseUrl, headers())
+      .get('/elements/myoauth1external/oauth/url')
+      .query(true)
+      .reply(200, () => new Object({
+        oauthUrl: 'http://frankthetanksoauthurl.com'
+      }));
+
+    nock(baseUrl, headers())
+      .get('/elements/noTokenUrl/oauth/url')
+      .query(true)
+      .reply(200, () => new Object({
+        oauthUrl: 'http://frankthetanksoauthurl.com'
+      }));
+
+    nock('http://pvenkman.ghostbuster.com')
+      .post('/token')
+      .reply(200, () => new Object({
+        refresh_token: 'peters refresh token'
+      }));
+
   });
 
   it('should allow creating a standard element instance', () => {
@@ -144,6 +205,39 @@ describe('provisioner', () => {
         expect(r.body.providerData.code).to.equal('speakercity');
       })
       .then(r => mockery.disable());
+  });
+
+  it('should allow creating an oauth2 external instance', () => {
+    setupProps();
+    return provisioner.create('myoauth2external')
+      .then(r => {
+        expect(r).not.to.be.null;
+        expect(r.body).not.to.be.null;
+        expect(r.body.id).to.equal(123);
+        expect(r.body.configuration).to.not.be.null;
+        expect(r.body.configuration['oauth.api.key']).to.equal('he gon do one');
+        expect(r.body.configuration['oauth.api.secret']).to.equal('fill it up again');
+        expect(r.body.configuration['oauth.user.refresh_token']).to.equal('peters refresh token');
+      })
+      .then(r => mockery.disable());
+  });
+
+  it('should throw an error for provisioning an oauth1 element with external', () => {
+    setupProps();
+    return provisioner.create('myoauth1external')
+      .catch(e => {
+        expect(e).to.not.be.null;
+        expect(e.message).to.equal('External Authentication via churros is not yet implemented for OAuth1');
+      });
+  });
+
+  it('should throw an error for provisioning an oauth2 element with no token url', () => {
+    setupProps();
+    return provisioner.create('noTokenUrl')
+      .catch(e => {
+        expect(e).to.not.be.null;
+        expect(e.message).to.equal(`Token URL must be present in the element props as 'tokenUrl'`);
+      });
   });
 
   it('should throw an error if creating an element instance does not return a 200', () => {


### PR DESCRIPTION
## Highlights
* implement the `--externalAuth` flag for oauth2 elements to run through the full oauth2 flow prior to provisioning
* add tests to cover new functionality
* `tokenUrl` prop must be added to `sauce.json` for support

## Examples
```
churros test elements/sfdc --externalAuth
churros test elements/box --externalAuth
```