### PR TITLE
changing the way that default request headers get set in chakram

### DIFF
--- a/src/core/provisioner.js
+++ b/src/core/provisioner.js
@@ -9,6 +9,7 @@ const logger = require('winston');
 const o = require('core/oauth');
 const r = require('request');
 const defaults = require('core/defaults');
+const cloud = require('core/cloud');
 
 var exports = module.exports = {};
 
@@ -46,7 +47,7 @@ const createInstance = (element, config, providerData, baseApi) => {
 
   if (providerData) instance.providerData = providerData;
 
-  return chakram.post(baseApi, instance)
+  return cloud.post(baseApi, instance)
     .then(r => {
       expect(r).to.have.statusCode(200);
       logger.debug('Created %s element instance with ID: %s', element, r.body.id);
@@ -95,7 +96,7 @@ const createExternalInstance = (element, config, providerData) => {
         "name": `${element} external auth churros`,
         "externalAuthentication": "initial"
       };
-      res(chakram.post('/instances', instanceBody));
+      res(cloud.post('/instances', instanceBody));
     });
   });
 };
@@ -103,7 +104,7 @@ const createExternalInstance = (element, config, providerData) => {
 const oauth = (element, args, config) => {
   const url = `/elements/${element}/oauth/url`;
   logger.debug('GET %s with options %s', url, args.options);
-  return chakram.get(url, args.options)
+  return cloud.withOptions(args.options).get(url)
     .then(r => {
       expect(r).to.have.statusCode(200);
       return o(element, r, args.username, args.password, config);
@@ -130,7 +131,7 @@ const oauth = (element, args, config) => {
 
 const oauth1 = (element, args) => {
   const oauthTokenUrl = `/elements/${element}/oauth/token`;
-  return chakram.get(oauthTokenUrl, args.options)
+  return cloud.withOptions(args.options).get(oauthTokenUrl)
     .then(r => {
       expect(r).to.have.statusCode(200);
       args.options.qs.requestToken = r.body.token;
@@ -139,7 +140,15 @@ const oauth1 = (element, args) => {
     });
 };
 
-exports.create = (element, args, baseApi) => {
+/**
+ * Handles orchestrating this create, which can flow different ways depending on what type of
+ * provisioning this element support
+ * @param  {string} element  The element key
+ * @param  {object} args     The args to pass on the create instance call
+ * @param  {string} baseApi  The base API
+ * @return {Promise}         JS promise that resolves to the instance created
+ */
+const orchestrateCreate = (element, args, baseApi) => {
   const type = props.getOptionalForKey(element, 'provisioning');
   const external = props.getOptionalForKey(element, 'external');
   const config = genConfig(props.all(element), args);
@@ -172,9 +181,18 @@ exports.create = (element, args, baseApi) => {
   }
 };
 
+exports.create = (element, args, baseApi) => {
+  return orchestrateCreate(element, args, baseApi)
+    .then(r => {
+      console.log(r.body.token);
+      defaults.token(r.body.token); // update defaults with token to add to requests
+      return r;
+    });
+};
+
 exports.delete = (id, baseApi) => {
   baseApi = (baseApi) ? baseApi : '/instances';
-  return chakram.delete(baseApi + '/' + id)
+  return cloud.delete(`${baseApi}/${id}`)
     .then(r => {
       expect(r).to.have.statusCode(200);
       logger.debug('Deleted element instance with ID: ' + id);

--- a/src/test/elements/lifecycle.js
+++ b/src/test/elements/lifecycle.js
@@ -7,7 +7,6 @@ const provisioner = require('core/provisioner');
 const argv = require('optimist').demand('element').argv;
 const fs = require('fs');
 const logger = require('winston');
-let defaults = require('core/defaults');
 
 const createAll = (urlTemplate, list) => {
   let promises = [];
@@ -31,7 +30,6 @@ before(done => {
     .then(r => {
       expect(r).to.have.statusCode(200);
       instanceId = r.body.id;
-      defaults.token(r.body.token);
       // object definitions file exists? create the object definitions on the instance
       const objectDefinitionsFile = `${__dirname}/assets/object.definitions`;
       if (fs.existsSync(objectDefinitionsFile + '.json')) {

--- a/src/test/platform/formulas/assets/common.js
+++ b/src/test/platform/formulas/assets/common.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const tools = require('core/tools');
-const chakram = require('chakram');
 const util = require('util');
 const logger = require('winston');
 const provisioner = require('core/provisioner');
@@ -28,23 +27,23 @@ exports.genInstance = (opts) => new Object({
 });
 
 const deleteFormulaInstance = (fId, fiId) =>
-  chakram.delete(util.format('/formulas/%s/instances/%s', fId, fiId));
+  cloud.delete(util.format('/formulas/%s/instances/%s', fId, fiId));
 
 const getInstancesForFormula = (fId) =>
-  chakram.get(util.format('/formulas/%s/instances', fId))
+  cloud.get(util.format('/formulas/%s/instances', fId))
   .then(r => r.body);
 
 const getInstancesForFormulas = (fs) =>
   Promise.all(fs.map(f => getInstancesForFormula(f.id)));
 
 const deleteFormula = (fId) =>
-  chakram.delete(util.format('/formulas/%s', fId));
+  cloud.delete(util.format('/formulas/%s', fId));
 
 const deleteFormulas = (fs) =>
   Promise.all(fs.map(f => deleteFormula(f.id)));
 
 const getFormulasByName = (api, name) =>
-  chakram.get(api)
+  cloud.get(api)
   .then(r => r.body.filter(f => f.name === name));
 
 const deleteInstancesForFormulas = (is) =>
@@ -60,10 +59,10 @@ const deleteFormulasByName = (api, name) =>
 exports.deleteFormulasByName = deleteFormulasByName;
 
 exports.getFormulaInstanceExecutions = (fId, fiId) =>
-  chakram.get(util.format('/formulas/%s/instances/%s/executions', fId, fiId));
+  cloud.get(util.format('/formulas/%s/instances/%s/executions', fId, fiId));
 
 exports.getFormulaInstanceExecution = (fId, fiId, fieId) =>
-  chakram.get(util.format('/formulas/%s/instances/%s/executions/%s', fId, fiId, fieId));
+  cloud.get(util.format('/formulas/%s/instances/%s/executions/%s', fId, fiId, fieId));
 
 exports.deleteFormulaInstance = deleteFormulaInstance;
 exports.deleteFormula = deleteFormula;

--- a/test/core/provisioner.test.js
+++ b/test/core/provisioner.test.js
@@ -270,7 +270,7 @@ describe('provisioner', () => {
   it('should allow creating an element instance with custom provisioning', () => {
     setupProps();
     const mockProvisioner = {
-      create: (config) => new Promise((res, rej) => res({ token: 123 }))
+      create: (config) => new Promise((res, rej) => res({ body: { token: 123 } }))
     };
     const s = `${__dirname}`.split('/');
     const root = s.filter((i) => i !== 'test' && i !== 'core').reduce((fullPath, item) => fullPath + '/' + item);


### PR DESCRIPTION
## Highlights
* the default headers need to be set in the `provisioner` or else tests using the `provisioner` have to set them, which kind of sucks ... 
* also, some minor updates to `executions` tests to use `cloud` instead of `chakram` so we get better logging as to what API calls are being made
