### PR TITLE
Sub formula tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## v0.6.0 <sub><sup>(TBD)</sup></sub>
 #### Highlights
+* added support for new `churros clean` sub-command utility to help clean up platform resources
+![CLIExample](http://cl.ly/1I0m290l1O0w/Screen%20Recording%202016-06-29%20at%2010.34%20AM.gif)
 
 ## v0.5.0 <sub><sup>(2016-03-25)</sup></sub>
 #### Highlights

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "optimist": "^0.6.1",
     "replacestream": "^4.0.0",
     "request": "^2.72.0",
-    "selenium-webdriver": "^2.48.2",
+    "selenium-webdriver": "^2.53.2",
     "shelljs": "^0.5.3",
     "sleep": "^3.0.1",
     "tv4": "^1.2.7",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "churros",
   "author": "jjwyse",
   "license": "ISC",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Test suite for all things cloud elements",
   "repository": {
     "type": "git",

--- a/src/cli/churros-clean.js
+++ b/src/cli/churros-clean.js
@@ -1,0 +1,56 @@
+'use strict';
+
+const commander = require('commander');
+const path = require('path');
+const shell = require('shelljs');
+
+const collect = (val, list) => {
+  list.push(val);
+  return list;
+};
+
+const terminate = (msg) => {
+  console.error(msg);
+  process.exit(1);
+};
+
+const clean = (resource, options) => {
+  if (options.name.length < 1) terminate(`Please provide at least one name of a ${resource} to cleanup by using the --name option`);
+
+  const rootDir = path.dirname(require.main.filename);
+  const rootTestDir = rootDir + '/../test';
+
+  // always pass the lifecycle file first.
+  const mochaPaths = [];
+  mochaPaths.push(rootTestDir + '/lifecycle');
+  mochaPaths.push(rootTestDir + '/clean');
+
+  // concat all names together
+  let names = '';
+  options.name.forEach(n => names += ` --name ${n}`);
+
+  // build our args
+  let args = `--timeout 600000 --reporter spec --ui bdd --resource ${resource} ${names}`;
+  if (options.verbose) args += ` --verbose ${options.verbose}`;
+
+  const cmd = `${rootDir}/../../node_modules/.bin/mocha ${mochaPaths.join(' ')} ${args}`;
+  process.exit(shell.exec(cmd).code); // execute the cmd and make our exit code the same as 'churros test' code
+};
+
+commander
+  .command('resource', 'platform resource to cleanup (formulas, elements)')
+  .action((resource, options) => clean(resource, options))
+  .option('-n, --name <name>', 'the resource name(s) to delete', collect, [])
+  .option('-V, --verbose', 'logging verbose mode')
+  .on('--help', () => {
+    console.log('  Examples:');
+    console.log('');
+    console.log('    # Cleanup Formulas');
+    console.log('    $ churros clean formulas --name my-formula-name');
+    console.log('    $ churros clean formulas --name my-formula-name --name my-other-formula-name');
+    console.log('');
+    console.log('    # Cleanup Elements');
+    console.log('    $ churros clean element --name my-element-name');
+    console.log('');
+  })
+  .parse(process.argv);

--- a/src/cli/churros.js
+++ b/src/cli/churros.js
@@ -5,7 +5,7 @@
 const commander = require('commander');
 
 commander
-  .version('1.0.0')
+  .version('0.6.0')
   .command('init', 'initalize churros')
   .command('add', 'add a new test suite')
   .command('test', 'run a test suite')

--- a/src/cli/churros.js
+++ b/src/cli/churros.js
@@ -5,9 +5,10 @@
 const commander = require('commander');
 
 commander
-  .version('0.5.0')
+  .version('1.0.0')
   .command('init', 'initalize churros')
   .command('add', 'add a new test suite')
   .command('test', 'run a test suite')
   .command('props', 'view/set properties')
+  .command('clean', 'clean up platform resources')
   .parse(process.argv);

--- a/src/core/cleaner.js
+++ b/src/core/cleaner.js
@@ -1,0 +1,75 @@
+'use strict';
+
+const cloud = require('core/cloud');
+const logger = require('winston');
+
+var exports = module.exports = {};
+
+/**
+ * Validator that validates absolutely nothing
+ */
+const ignore = (response) => {
+  logger.debug(`Ignoring HTTP response`);
+  return response;
+};
+
+/**
+ * Slowly deletes things as opposed to doing them all at once, which can be painful
+ */
+const deleteAll = (resource, ids) => {
+  if (!ids || ids.length <= 0) return;
+  logger.debug(`Attempting to delete ${resource} with id ${ids[0]}`);
+  return cloud.delete(`/${resource}/${ids[0]}`, ignore)
+    .then(r => ids.shift())
+    .then(r => deleteAll(resource, ids));
+};
+
+/**
+ * Cleans all formulas and formula instances based on a given field
+ */
+const cleanFormulas = (field, values) => {
+  logger.debug(`Cleaning formulas where ${field} is set to one of ${values}`);
+  return cloud.get(`/formulas`)
+    .then(rs => rs.body.filter(r => {
+      let isFound = false;
+      values.forEach(value => isFound = isFound || r[field] === value);
+      return isFound;
+    }))
+    .then(rs => {
+      return Promise.all(rs.map(r => cloud.get(`/formulas/${r.id}/instances`)))
+        .then(rs => {
+          // concat them all together
+          let instances = [];
+          rs.map(r => instances = instances.concat(r.body));
+          return instances;
+        })
+        .then(rs => Promise.all(rs.map(r => cloud.delete(`/formulas/${r.formula.id}/instances/${r.id}`))))
+        .then(() => Promise.all(rs.map(f => cloud.delete(`/formulas/${f.id}`))));
+    });
+};
+
+const cleanElements = (field, value) => {
+  logger.debug(`Cleaning elements where ${field} is set to ${value}`);
+  return cloud.get(`/instances`)
+    .then(rs => rs.body.filter(r => r[field] === value))
+    .then(rs => deleteAll('instances', rs.map(r => r.id)))
+    .catch(r => logger.debug(`Poop: ${r}`));
+};
+
+/**
+ * Clean up resources with a given field
+ */
+exports.formulas = {
+  withName: (name) => {
+    return cleanFormulas('name', [name]);
+  },
+  withNames: (names) => {
+    return cleanFormulas('name', names);
+  }
+};
+
+exports.elements = {
+  withName: (name) => {
+    return cleanElements('name', name);
+  }
+};

--- a/src/core/cloud.js
+++ b/src/core/cloud.js
@@ -17,7 +17,7 @@ const validator = (validationCb) => {
     };
   } else if (typeof validationCb === 'undefined' || (typeof validationCb === 'object' && validationCb === null)) {
     return (r) => {
-      logger.debug(`Validating that response is 200.  Response body: ${tools.stringify(r.body)}`);
+      if (typeof r.body === 'object') logger.debug(`Validating that response is 200.  Response body: ${tools.stringify(r.body)}`);
       expect(r).to.have.statusCode(200);
       return r;
     };

--- a/src/core/provisioner.js
+++ b/src/core/provisioner.js
@@ -190,11 +190,12 @@ exports.create = (element, args, baseApi) => {
 };
 
 exports.delete = (id, baseApi) => {
+  if (!id) return;
+
   baseApi = (baseApi) ? baseApi : '/instances';
   return cloud.delete(`${baseApi}/${id}`)
     .then(r => {
-      expect(r).to.have.statusCode(200);
-      logger.debug('Deleted element instance with ID: ' + id);
+      logger.debug(`Deleted element instance with ID: ${id}`);
       defaults.reset();
       return r.body;
     })

--- a/src/test/clean.js
+++ b/src/test/clean.js
@@ -1,0 +1,15 @@
+'use strict';
+
+const cleaner = require('core/cleaner');
+const argv = require('optimist').argv;
+
+it(`should clean up all ${argv.resource} with name(s): ${argv.name}`, () => {
+  switch (argv.resource) {
+    case 'formulas':
+      return cleaner.formulas.withName(argv.name);
+    case 'elements':
+      return cleaner.elements.withName(argv.name);
+    default:
+      throw Error(`Invalid resource name: ${argv.resource}`);
+  }
+});

--- a/src/test/platform/formulas/assets/common.js
+++ b/src/test/platform/formulas/assets/common.js
@@ -59,6 +59,9 @@ exports.generateSfdcPollingEvent = (instanceId, payload) => {
     .post('/events/sfdcPolling/' + encodedId, payload);
 };
 
+exports.deleteFormula = (fId) => cloud.delete(`/formulas/${fId}`);
+exports.deleteFormulaInstance = (fId, fiId) => cloud.delete(`/formulas/${fId}/instances/${fiId}`);
+
 const getAllExecutions = (fiId, nextPage, all) => {
   all = all || [];
   const options = { qs: { nextPage: nextPage, pageSize: 200 } };
@@ -69,6 +72,10 @@ const getAllExecutions = (fiId, nextPage, all) => {
       all = all.concat(r.body);
       const npt = r.response.headers['elements-next-page-token'];
       return npt === undefined ? all : getAllExecutions(fiId, npt, all);
+    })
+    .catch(e => {
+      logger.debug(`Failed to retrieve executions, returning current list.  Exception: ${e}`);
+      return all;
     });
 };
 exports.getAllExecutions = getAllExecutions;

--- a/src/test/platform/formulas/assets/common.js
+++ b/src/test/platform/formulas/assets/common.js
@@ -1,10 +1,10 @@
 'use strict';
 
+const cleaner = require('core/cleaner');
 const tools = require('core/tools');
 const b64 = tools.base64Encode;
 const chakram = require('chakram');
 const expect = chakram.expect;
-const util = require('util');
 const logger = require('winston');
 const provisioner = require('core/provisioner');
 const cloud = require('core/cloud');
@@ -59,38 +59,6 @@ exports.generateSfdcPollingEvent = (instanceId, payload) => {
     .post('/events/sfdcPolling/' + encodedId, payload);
 };
 
-const deleteFormulaInstance = (fId, fiId) =>
-  cloud.delete(util.format('/formulas/%s/instances/%s', fId, fiId));
-
-const getInstancesForFormula = (fId) =>
-  cloud.get(`/formulas/${fId}/instances`, r => r)
-  .then(r => r.body);
-
-const getInstancesForFormulas = (fs) =>
-  Promise.all(fs.map(f => getInstancesForFormula(f.id)));
-
-const deleteFormula = (fId) =>
-  cloud.delete(util.format('/formulas/%s', fId));
-
-const deleteFormulas = (fs) =>
-  Promise.all(fs.map(f => deleteFormula(f.id)));
-
-const getFormulasByName = (api, name) =>
-  cloud.get(api, r => r)
-  .then(r => r.body.filter(f => f.name === name));
-
-const deleteInstancesForFormulas = (is) =>
-  Promise.all(is.map(i => deleteFormulaInstance(i.formula.id, i.id)));
-
-const deleteFormulasByName = (api, name) =>
-  getFormulasByName(api, name)
-  .then(fs =>
-    getInstancesForFormulas(fs)
-    .then(fis => [].concat.apply([], fis))
-    .then(deleteInstancesForFormulas)
-    .then(() => deleteFormulas(fs)));
-exports.deleteFormulasByName = deleteFormulasByName;
-
 const getAllExecutions = (fiId, nextPage, all) => {
   all = all || [];
   const options = { qs: { nextPage: nextPage, pageSize: 200 } };
@@ -120,14 +88,11 @@ exports.getFormulaInstanceExecutionWithSteps = (fieId) => {
     });
 };
 
-exports.deleteFormulaInstance = deleteFormulaInstance;
-exports.deleteFormula = deleteFormula;
-
 exports.createFAndFI = (element, config) => {
   element = element || 'closeio';
   let elementInstanceId, formulaId, formulaInstanceId;
   const formula = require('./formulas/simple-successful-formula');
-  return deleteFormulasByName('/formulas', 'simple-successful')
+  return cleaner.formulas.withName('simple-successful')
     .then(r => cloud.post('/formulas', formula, fSchema))
     .then(r => formulaId = r.body.id)
     .then(r => provisioner.create(element, config))

--- a/src/test/platform/formulas/assets/formulas/filter-returns-false.json
+++ b/src/test/platform/formulas/assets/formulas/filter-returns-false.json
@@ -1,33 +1,22 @@
 {
-    "name": "filter-returns-false",
-    "steps": [
-        {
-            "onSuccess": [],
-            "onFailure": [],
-            "name": "return-false",
-            "type": "filter",
-            "properties": {
-                "body": "done(false);"
-            }
-        }
-    ],
-    "triggers": [
-        {
-            "type": "event",
-            "async": true,
-            "onSuccess": ["return-false"],
-            "onFailure": [],
-            "properties": {
-                "elementInstanceId": "${trigger-instance}"
-            }
-        }
-    ],
-    "configuration": [
-        {
-            "key": "trigger-instance",
-            "name": "trigger-instance",
-            "type": "elementInstance",
-            "required": true
-        }
-    ]
+  "name": "filter-returns-false",
+  "steps": [{
+    "name": "return-false",
+    "type": "filter",
+    "properties": {
+      "body": "done(false);"
+    }
+  }],
+  "triggers": [{
+    "type": "event",
+    "onSuccess": ["return-false"],
+    "properties": {
+      "elementInstanceId": "${trigger-instance}"
+    }
+  }],
+  "configuration": [{
+    "key": "trigger-instance",
+    "name": "trigger-instance",
+    "type": "elementInstance"
+  }]
 }

--- a/src/test/platform/formulas/assets/formulas/manual-trigger.json
+++ b/src/test/platform/formulas/assets/formulas/manual-trigger.json
@@ -1,0 +1,14 @@
+{
+  "name": "manual-trigger",
+  "triggers": [{
+    "type": "manual",
+    "onSuccess": ["end"]
+  }],
+  "steps": [{
+    "name": "end",
+    "type": "script",
+    "properties": {
+      "body": "done(trigger.args);"
+    }
+  }]
+}

--- a/src/test/platform/formulas/assets/formulas/simple-successful-formula.json
+++ b/src/test/platform/formulas/assets/formulas/simple-successful-formula.json
@@ -1,43 +1,23 @@
 {
-    "name": "simple-successful",
-    "steps": [
-        {
-            "onSuccess": [],
-            "onFailure": [],
-            "name": "simple-script",
-            "type": "script",
-            "properties": {
-                "scriptEngine": "v2",
-                "body": "'use strict'; const id = trigger.event.objectId; done({ 'integration-test-1': 1, 'integration-test-2': true, 'integration-test-3': 'integration-value', 'trigger-test': id });"
-            }
-        }
-    ],
-    "triggers": [
-        {
-            "type": "event",
-            "async": true,
-            "onSuccess": ["simple-script"],
-            "onFailure": [],
-            "properties": {
-                "elementInstanceId": "${trigger-instance}"
-            }
-        }
-    ],
-    "active": true,
-    "singleThreaded": false,
-    "configuration": [
-        {
-            "key": "notification.email",
-            "name": "Notification Email",
-            "type": "value",
-            "description": "Optional email where formula errors and notification steps will be sent (If more than one email is needed, separate each email with a comma)",
-            "required": false
-        },
-        {
-            "key": "trigger-instance",
-            "name": "trigger-instance",
-            "type": "elementInstance",
-            "required": true
-        }
-    ]
+  "name": "simple-successful",
+  "configuration": [{
+    "key": "trigger-instance",
+    "name": "trigger-instance",
+    "type": "elementInstance"
+  }],
+  "triggers": [{
+    "type": "event",
+    "onSuccess": ["simple-script"],
+    "properties": {
+      "elementInstanceId": "${trigger-instance}"
+    }
+  }],
+  "steps": [{
+    "name": "simple-script",
+    "type": "script",
+    "properties": {
+      "scriptEngine": "v2",
+      "body": "'use strict'; const id = trigger.event.objectId; done({ 'integration-test-1': 1, 'integration-test-2': true, 'integration-test-3': 'integration-value', 'trigger-test': id });"
+    }
+  }]
 }

--- a/src/test/platform/formulas/assets/formulas/sub-formula-executions/error-sub-formulas.json
+++ b/src/test/platform/formulas/assets/formulas/sub-formula-executions/error-sub-formulas.json
@@ -1,0 +1,42 @@
+[{
+  "name": "A-error-sub-formula",
+  "configuration": [{
+    "key": "crm.instance",
+    "name": "crm.instance",
+    "type": "elementInstance"
+  }],
+  "triggers": [{
+    "type": "event",
+    "onSuccess": ["A-sub-formula"],
+    "properties": {
+      "elementInstanceId": "${crm.instance}"
+    }
+  }],
+  "steps": [{
+    "name": "A-sub-formula",
+    "type": "formula",
+    "onFailure": ["A-end"],
+    "properties": {
+      "formulaId": "SUB_FORMULA_ID"
+    }
+  }, {
+    "name": "A-end",
+    "type": "script",
+    "properties": {
+      "body": "done({subFormulaValues:steps['A-sub-formula']});"
+    }
+  }]
+}, {
+  "name": "B-error-sub-formula",
+  "triggers": [{
+    "type": "manual",
+    "onSuccess": ["B-end"]
+  }],
+  "steps": [{
+    "name": "B-end",
+    "type": "script",
+    "properties": {
+      "body": "This is a bad script step;"
+    }
+  }]
+}]

--- a/src/test/platform/formulas/assets/formulas/sub-formula-executions/filter-sub-formulas.json
+++ b/src/test/platform/formulas/assets/formulas/sub-formula-executions/filter-sub-formulas.json
@@ -1,0 +1,57 @@
+[{
+  "name": "A-filter-sub-formula",
+  "configuration": [{
+    "key": "crm.instance",
+    "name": "crm.instance",
+    "type": "elementInstance"
+  }],
+  "triggers": [{
+    "type": "event",
+    "onSuccess": ["A-build-args"],
+    "properties": {
+      "elementInstanceId": "${crm.instance}"
+    }
+  }],
+  "steps": [{
+    "name": "A-build-args",
+    "type": "script",
+    "onSuccess": ["A-sub-formula"],
+    "properties": {
+      "body": "done( { boolean: false });"
+    }
+  }, {
+    "name": "A-sub-formula",
+    "type": "formula",
+    "onSuccess": ["A-end"],
+    "properties": {
+      "formulaId": "SUB_FORMULA_ID",
+      "args": "steps.A-build-args"
+    }
+  }, {
+    "name": "A-end",
+    "type": "script",
+    "properties": {
+      "body": "done();"
+    }
+  }]
+}, {
+  "name": "B-filter-sub-formula",
+  "triggers": [{
+    "type": "manual",
+    "onSuccess": ["B-filter"]
+  }],
+  "steps": [{
+    "name": "B-filter",
+    "type": "filter",
+    "onSuccess": ["B-end"],
+    "properties": {
+      "body": "done(trigger.args.boolean);"
+    }
+  }, {
+    "name": "B-end",
+    "type": "script",
+    "properties": {
+      "body": "done();"
+    }
+  }]
+}]

--- a/src/test/platform/formulas/assets/formulas/sub-formula-executions/filter-sub-formulas.json
+++ b/src/test/platform/formulas/assets/formulas/sub-formula-executions/filter-sub-formulas.json
@@ -17,7 +17,7 @@
     "type": "script",
     "onSuccess": ["A-sub-formula"],
     "properties": {
-      "body": "done( { boolean: false });"
+      "body": "done({boolean: false});"
     }
   }, {
     "name": "A-sub-formula",

--- a/src/test/platform/formulas/assets/formulas/sub-formula-executions/manual-sub-formulas.json
+++ b/src/test/platform/formulas/assets/formulas/sub-formula-executions/manual-sub-formulas.json
@@ -31,7 +31,7 @@
     "name": "A-end",
     "type": "script",
     "properties": {
-      "body": "const subFormulaValues = steps['A-sub-formula']; done({createdId: subFormulaValues.id})"
+      "body": "done({createdId: steps['A-sub-formula'].id});"
     }
   }]
 }, {

--- a/src/test/platform/formulas/assets/formulas/sub-formula-executions/manual-sub-formulas.json
+++ b/src/test/platform/formulas/assets/formulas/sub-formula-executions/manual-sub-formulas.json
@@ -1,0 +1,76 @@
+[{
+  "name": "A-manual-formula",
+  "configuration": [{
+    "key": "crm.instance",
+    "name": "crm.instance",
+    "type": "elementInstance"
+  }],
+  "triggers": [{
+    "type": "event",
+    "onSuccess": ["A-build-args"],
+    "properties": {
+      "elementInstanceId": "${crm.instance}"
+    }
+  }],
+  "steps": [{
+    "name": "A-build-args",
+    "type": "script",
+    "onSuccess": ["A-sub-formula"],
+    "properties": {
+      "body": "done( { resource: 'accounts', payload:{ Name: 'churros-test-name' }});"
+    }
+  }, {
+    "name": "A-sub-formula",
+    "type": "formula",
+    "onSuccess": ["A-end"],
+    "properties": {
+      "formulaId": "SUB_FORMULA_ID",
+      "args": "steps.A-build-args"
+    }
+  }, {
+    "name": "A-end",
+    "type": "script",
+    "properties": {
+      "body": "done({});"
+    }
+  }]
+}, {
+  "name": "B-manual-formula-create-resource",
+  "configuration": [{
+    "key": "crm.instance",
+    "name": "crm.instance",
+    "type": "elementInstance"
+  }],
+  "triggers": [{
+    "type": "manual",
+    "onSuccess": ["B-create-resource"]
+  }],
+  "steps": [{
+    "name": "B-create-resource",
+    "type": "elementRequest",
+    "onSuccess": ["B-aggregate-fields"],
+    "properties": {
+      "elementInstanceId": "${crm.instance}",
+      "api": "/hubs/crm/{resource}",
+      "method": "POST",
+      "path": "${trigger.args}",
+      "body": "${trigger.args.payload}"
+    }
+  }, {
+    "name": "B-aggregate-fields",
+    "onSuccess": ["B-retrieve-resource"],
+    "type": "script",
+    "properties": {
+      "body": "done({resource: trigger.args.resource, id: steps['B-create-resource'].response.body.Id});"
+    }
+  }, {
+    "name": "B-retrieve-resource",
+    "type": "elementRequest",
+    "properties": {
+      "elementInstanceId": "${crm.instance}",
+      "api": "/hubs/crm/{resource}/{id}",
+      "method": "GET",
+      "path": "${steps.B-aggregate-fields}"
+    }
+  }]
+}]

--- a/src/test/platform/formulas/assets/formulas/sub-formula-executions/manual-sub-formulas.json
+++ b/src/test/platform/formulas/assets/formulas/sub-formula-executions/manual-sub-formulas.json
@@ -31,7 +31,7 @@
     "name": "A-end",
     "type": "script",
     "properties": {
-      "body": "done({});"
+      "body": "const subFormulaValues = steps['A-sub-formula']; done({createdId: subFormulaValues.id})"
     }
   }]
 }, {
@@ -66,11 +66,18 @@
   }, {
     "name": "B-retrieve-resource",
     "type": "elementRequest",
+    "onSuccess": ["B-end"],
     "properties": {
       "elementInstanceId": "${crm.instance}",
       "api": "/hubs/crm/{resource}/{id}",
       "method": "GET",
       "path": "${steps.B-aggregate-fields}"
+    }
+  }, {
+    "name": "B-end",
+    "type": "script",
+    "properties": {
+      "body": "done({id: steps['B-aggregate-fields'].id});"
     }
   }]
 }]

--- a/src/test/platform/formulas/assets/formulas/sub-formula-executions/simple-sub-formulas.json
+++ b/src/test/platform/formulas/assets/formulas/sub-formula-executions/simple-sub-formulas.json
@@ -1,0 +1,53 @@
+[{
+    "name": "A-simple-formula",
+    "configuration": [{
+      "key": "crm.instance",
+      "name": "crm.instance",
+      "type": "elementInstance"
+    }],
+    "triggers": [{
+      "type": "event",
+      "onSuccess": ["A-build-args"],
+      "properties": {
+        "elementInstanceId": "${crm.instance}"
+      }
+    }],
+    "steps": [{
+      "name": "A-build-args",
+      "type": "script",
+      "onSuccess": ["A-sub-formula"],
+      "properties": {
+        "body": "done({foo: 'bar'});"
+      }
+    }, {
+      "name": "A-sub-formula",
+      "type": "formula",
+      "properties": {
+        "formulaId": "SUB_FORMULA_ID",
+        "args": "steps.A-build-args"
+      }
+    }]
+  },
+  {
+    "name": "B-simple-formula",
+    "configuration": [{
+      "key": "crm.instance",
+      "name": "crm.instance",
+      "type": "elementInstance"
+    }],
+    "triggers": [{
+      "type": "event",
+      "onSuccess": ["B-script"],
+      "properties": {
+        "elementInstanceId": "${crm.instance}"
+      }
+    }],
+    "steps": [{
+      "name": "B-script",
+      "type": "script",
+      "properties": {
+        "body": "done(trigger.args);"
+      }
+    }]
+  }
+]

--- a/src/test/platform/formulas/assets/formulas/sub-formula-executions/sub-formulas-no-steps-after.json
+++ b/src/test/platform/formulas/assets/formulas/sub-formula-executions/sub-formulas-no-steps-after.json
@@ -1,0 +1,90 @@
+[{
+    "name": "A-sub-formula-no-steps-after",
+    "configuration": [{
+      "key": "trigger-instance",
+      "name": "trigger-instance",
+      "type": "elementInstance"
+    }],
+    "triggers": [{
+      "type": "event",
+      "onSuccess": ["A-filter"],
+      "properties": {
+        "elementInstanceId": "${trigger-instance}"
+      }
+    }],
+    "steps": [{
+      "name": "A-filter",
+      "type": "filter",
+      "properties": {
+        "body": "done(true);"
+      },
+      "onSuccess": ["A-sub-formula"]
+    }, {
+      "name": "A-sub-formula",
+      "type": "formula",
+      "onSuccess": ["A-end"],
+      "properties": {
+        "formulaId": "SUB_FORMULA_ID",
+        "body": "steps.A1.response.body"
+      }
+    }, {
+      "name": "A-end",
+      "type": "filter",
+      "properties": {
+        "body": "done(true);"
+      }
+    }]
+  },
+  {
+    "name": "B-sub-formula-no-steps-after",
+    "configuration": [{
+      "key": "trigger-instance",
+      "name": "trigger-instance",
+      "type": "elementInstance"
+    }],
+    "triggers": [{
+      "type": "event",
+      "onSuccess": ["B-request"],
+      "properties": {
+        "elementInstanceId": "${trigger-instance}"
+      }
+    }],
+    "steps": [{
+      "name": "B-request",
+      "type": "elementRequest",
+      "onSuccess": ["B-sub-formula"],
+      "properties": {
+        "elementInstanceId": "${trigger-instance}",
+        "api": "/hubs/crm/contacts",
+        "method": "GET"
+      }
+    }, {
+      "name": "B-sub-formula",
+      "type": "formula",
+      "properties": {
+        "formulaId": "SUB_SUB_FORMULA_ID"
+      }
+    }]
+  }, {
+    "name": "C-sub-formula-no-steps-after",
+    "configuration": [{
+      "key": "trigger-instance",
+      "name": "trigger-instance",
+      "type": "elementInstance"
+    }],
+    "triggers": [{
+      "type": "event",
+      "onSuccess": ["C-end"],
+      "properties": {
+        "elementInstanceId": "${trigger-instance}"
+      }
+    }],
+    "steps": [{
+      "name": "C-end",
+      "type": "filter",
+      "properties": {
+        "body": "done(true);"
+      }
+    }]
+  }
+]

--- a/src/test/platform/formulas/assets/formulas/sub-formula-executions/sub-formulas.json
+++ b/src/test/platform/formulas/assets/formulas/sub-formula-executions/sub-formulas.json
@@ -1,0 +1,118 @@
+[{
+    "name": "A-sub-formula",
+    "configuration": [{
+      "key": "trigger-instance",
+      "name": "trigger-instance",
+      "type": "elementInstance"
+    }],
+    "triggers": [{
+      "type": "event",
+      "onSuccess": ["A-filter"],
+      "properties": {
+        "elementInstanceId": "${trigger-instance}"
+      }
+    }],
+    "steps": [{
+      "name": "A-filter",
+      "type": "filter",
+      "properties": {
+        "body": "done(true);"
+      },
+      "onSuccess": ["A-sub-formula"]
+    }, {
+      "name": "A-sub-formula",
+      "type": "formula",
+      "onSuccess": ["A-another-sub-formula"],
+      "properties": {
+        "formulaId": "SUB_FORMULA_ID"
+      }
+    }, {
+      "name": "A-another-sub-formula",
+      "type": "formula",
+      "onSuccess": ["A-end"],
+      "properties": {
+        "formulaId": "SUB_FORMULA_ID"
+      }
+    }, {
+      "name": "A-end",
+      "type": "filter",
+      "properties": {
+        "body": "done(true);"
+      }
+    }]
+  },
+  {
+    "name": "B-sub-formula",
+    "configuration": [{
+      "key": "trigger-instance",
+      "name": "trigger-instance",
+      "type": "elementInstance"
+    }],
+    "triggers": [{
+      "type": "event",
+      "onSuccess": ["B-build-query"],
+      "properties": {
+        "elementInstanceId": "${trigger-instance}"
+      }
+    }],
+    "steps": [{
+      "name": "B-build-query",
+      "type": "script",
+      "onSuccess": ["B-request"],
+      "properties": {
+        "body": "done({query: {page: 1, pageSize: 1}});"
+      }
+    }, {
+      "name": "B-request",
+      "type": "elementRequest",
+      "onSuccess": ["B-script"],
+      "properties": {
+        "elementInstanceId": "${trigger-instance}",
+        "api": "/hubs/crm/contacts",
+        "method": "GET",
+        "query": "steps.B-build-query.query"
+      }
+    }, {
+      "name": "B-script",
+      "type": "script",
+      "onSuccess": ["B-sub-formula"],
+      "properties": {
+        "body": "done();"
+      }
+    }, {
+      "name": "B-sub-formula",
+      "type": "formula",
+      "onSuccess": ["B-end"],
+      "properties": {
+        "formulaId": "SUB_SUB_FORMULA_ID"
+      }
+    }, {
+      "name": "B-end",
+      "type": "filter",
+      "properties": {
+        "body": "done(true);"
+      }
+    }]
+  }, {
+    "name": "C-sub-formulas",
+    "configuration": [{
+      "key": "trigger-instance",
+      "name": "trigger-instance",
+      "type": "elementInstance"
+    }],
+    "triggers": [{
+      "type": "event",
+      "onSuccess": ["C-end"],
+      "properties": {
+        "elementInstanceId": "${trigger-instance}"
+      }
+    }],
+    "steps": [{
+      "name": "C-end",
+      "type": "filter",
+      "properties": {
+        "body": "done(true);"
+      }
+    }]
+  }
+]

--- a/src/test/platform/formulas/assets/formulas/sub-formula-executions/two-sub-formulas-no-steps-after.json
+++ b/src/test/platform/formulas/assets/formulas/sub-formula-executions/two-sub-formulas-no-steps-after.json
@@ -1,15 +1,15 @@
 [{
     "name": "A-sub-formula-no-steps-after",
     "configuration": [{
-      "key": "trigger-instance",
-      "name": "trigger-instance",
+      "key": "crm.instance",
+      "name": "crm.instance",
       "type": "elementInstance"
     }],
     "triggers": [{
       "type": "event",
       "onSuccess": ["A-filter"],
       "properties": {
-        "elementInstanceId": "${trigger-instance}"
+        "elementInstanceId": "${crm.instance}"
       }
     }],
     "steps": [{
@@ -38,15 +38,15 @@
   {
     "name": "B-sub-formula-no-steps-after",
     "configuration": [{
-      "key": "trigger-instance",
-      "name": "trigger-instance",
+      "key": "crm.instance",
+      "name": "crm.instance",
       "type": "elementInstance"
     }],
     "triggers": [{
       "type": "event",
       "onSuccess": ["B-request"],
       "properties": {
-        "elementInstanceId": "${trigger-instance}"
+        "elementInstanceId": "${crm.instance}"
       }
     }],
     "steps": [{
@@ -54,7 +54,7 @@
       "type": "elementRequest",
       "onSuccess": ["B-sub-formula"],
       "properties": {
-        "elementInstanceId": "${trigger-instance}",
+        "elementInstanceId": "${crm.instance}",
         "api": "/hubs/crm/contacts",
         "method": "GET"
       }
@@ -68,15 +68,15 @@
   }, {
     "name": "C-sub-formula-no-steps-after",
     "configuration": [{
-      "key": "trigger-instance",
-      "name": "trigger-instance",
+      "key": "crm.instance",
+      "name": "crm.instance",
       "type": "elementInstance"
     }],
     "triggers": [{
       "type": "event",
       "onSuccess": ["C-end"],
       "properties": {
-        "elementInstanceId": "${trigger-instance}"
+        "elementInstanceId": "${crm.instance}"
       }
     }],
     "steps": [{

--- a/src/test/platform/formulas/assets/formulas/sub-formula-executions/two-sub-formulas.json
+++ b/src/test/platform/formulas/assets/formulas/sub-formula-executions/two-sub-formulas.json
@@ -1,15 +1,15 @@
 [{
-    "name": "A-sub-formula",
+    "name": "A-formula",
     "configuration": [{
-      "key": "trigger-instance",
-      "name": "trigger-instance",
+      "key": "crm.instance",
+      "name": "crm.instance",
       "type": "elementInstance"
     }],
     "triggers": [{
       "type": "event",
       "onSuccess": ["A-filter"],
       "properties": {
-        "elementInstanceId": "${trigger-instance}"
+        "elementInstanceId": "${crm.instance}"
       }
     }],
     "steps": [{
@@ -42,17 +42,17 @@
     }]
   },
   {
-    "name": "B-sub-formula",
+    "name": "B-formula",
     "configuration": [{
-      "key": "trigger-instance",
-      "name": "trigger-instance",
+      "key": "crm.instance",
+      "name": "crm.instance",
       "type": "elementInstance"
     }],
     "triggers": [{
       "type": "event",
       "onSuccess": ["B-build-query"],
       "properties": {
-        "elementInstanceId": "${trigger-instance}"
+        "elementInstanceId": "${crm.instance}"
       }
     }],
     "steps": [{
@@ -67,7 +67,7 @@
       "type": "elementRequest",
       "onSuccess": ["B-script"],
       "properties": {
-        "elementInstanceId": "${trigger-instance}",
+        "elementInstanceId": "${crm.instance}",
         "api": "/hubs/crm/contacts",
         "method": "GET",
         "query": "steps.B-build-query.query"
@@ -94,17 +94,17 @@
       }
     }]
   }, {
-    "name": "C-sub-formulas",
+    "name": "C-formula",
     "configuration": [{
-      "key": "trigger-instance",
-      "name": "trigger-instance",
+      "key": "crm.instance",
+      "name": "crm.instance",
       "type": "elementInstance"
     }],
     "triggers": [{
       "type": "event",
       "onSuccess": ["C-end"],
       "properties": {
-        "elementInstanceId": "${trigger-instance}"
+        "elementInstanceId": "${crm.instance}"
       }
     }],
     "steps": [{

--- a/src/test/platform/formulas/assets/formulas/sub-formula-executions/two-sub-formulas.json
+++ b/src/test/platform/formulas/assets/formulas/sub-formula-executions/two-sub-formulas.json
@@ -35,9 +35,9 @@
       }
     }, {
       "name": "A-end",
-      "type": "filter",
+      "type": "script",
       "properties": {
-        "body": "done(true);"
+        "body": "done({sub: steps['A-sub-formula']});"
       }
     }]
   },
@@ -88,9 +88,9 @@
       }
     }, {
       "name": "B-end",
-      "type": "filter",
+      "type": "script",
       "properties": {
-        "body": "done(true);"
+        "body": "done({b: 'iamb', c: steps['B-sub-formula'].c});"
       }
     }]
   }, {
@@ -109,9 +109,9 @@
     }],
     "steps": [{
       "name": "C-end",
-      "type": "filter",
+      "type": "script",
       "properties": {
-        "body": "done(true);"
+        "body": "done({c: 'iamc'});"
       }
     }]
   }

--- a/src/test/platform/formulas/config.js
+++ b/src/test/platform/formulas/config.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const cloud = require('core/cloud');
+const cleaner = require('core/cleaner');
 const common = require('./assets/common');
 const expect = require('chakram').expect;
 const invalid = require('./assets/formulas/formula-with-invalid-configs');
@@ -8,8 +9,7 @@ const suite = require('core/suite');
 const schema = require('./assets/schemas/formula.schema');
 
 suite.forPlatform('formulas', { name: 'formula config', schema: schema }, (test) => {
-  before(() => common.deleteFormulasByName(invalid.name)
-    .then(r => common.deleteFormulasByName('complex-successful')));
+  before(() => cleaner.formulas.withNames([invalid.name, 'complex-successful']));
 
   /* make sure config keys are being validated properly when creating a formula with config */
   test

--- a/src/test/platform/formulas/config.js
+++ b/src/test/platform/formulas/config.js
@@ -8,8 +8,8 @@ const suite = require('core/suite');
 const schema = require('./assets/schemas/formula.schema');
 
 suite.forPlatform('formulas', { name: 'formula config', schema: schema }, (test) => {
-  before(() => common.deleteFormulasByName('formulas', invalid.name)
-    .then(r => common.deleteFormulasByName('formulas', 'complex-successful')));
+  before(() => common.deleteFormulasByName(invalid.name)
+    .then(r => common.deleteFormulasByName('complex-successful')));
 
   /* make sure config keys are being validated properly when creating a formula with config */
   test

--- a/src/test/platform/formulas/config.js
+++ b/src/test/platform/formulas/config.js
@@ -9,7 +9,7 @@ const suite = require('core/suite');
 const schema = require('./assets/schemas/formula.schema');
 
 suite.forPlatform('formulas', { name: 'formula config', schema: schema }, (test) => {
-  before(() => cleaner.formulas.withNames([invalid.name, 'complex-successful']));
+  before(() => cleaner.formulas.withName([invalid.name, 'complex-successful']));
 
   /* make sure config keys are being validated properly when creating a formula with config */
   test

--- a/src/test/platform/formulas/executions.js
+++ b/src/test/platform/formulas/executions.js
@@ -909,7 +909,7 @@ suite.forPlatform('formulas', { name: 'formula executions', skip: false }, (test
     const formulaInstance3 = require('./assets/formulas/loop-successful-formula-instance');
 
     let formulaId1, formulaId2, formulaId3, formulaInstanceId1, formulaInstanceId2, formulaInstanceId3;
-    return cleaner.formulas.withNames(['simple-successful', 'element-request-successful', 'loop-successful'])
+    return cleaner.formulas.withName(['simple-successful', 'element-request-successful', 'loop-successful'])
       .then(r => {
         formulaInstance1.configuration['trigger-instance'] = sfdcId;
         formulaInstance2.configuration['trigger-instance'] = sfdcId;

--- a/src/test/platform/formulas/executions.js
+++ b/src/test/platform/formulas/executions.js
@@ -284,9 +284,7 @@ suite.forPlatform('formulas', { name: 'formula executions', skip: false }, (test
   let sfdcId;
   before(() => {
     return provisionSfdcWithPolling()
-      .then(r => {
-        sfdcId = r.body.id;
-      })
+      .then(r => sfdcId = r.body.id)
       .catch(r => {
         console.log(`Rats...${r}`);
         process.exit(1);
@@ -298,7 +296,7 @@ suite.forPlatform('formulas', { name: 'formula executions', skip: false }, (test
     const formulaInstance = require('./assets/formulas/simple-successful-formula-instance');
 
     let formulaId, formulaInstanceId;
-    return common.deleteFormulasByName(test.api, 'simple-successful')
+    return common.deleteFormulasByName('simple-successful')
       .then(r => formulaInstance.configuration['trigger-instance'] = sfdcId)
       .then(() => cloud.post(test.api, formula, fSchema))
       .then(r => formulaId = r.body.id)
@@ -322,7 +320,7 @@ suite.forPlatform('formulas', { name: 'formula executions', skip: false }, (test
     const formulaInstance = require('./assets/formulas/simple-successful-formula-instance');
 
     let formulaId, formulaInstanceId;
-    return common.deleteFormulasByName(test.api, 'simple-successful')
+    return common.deleteFormulasByName('simple-successful')
       .then(r => formulaInstance.configuration['trigger-instance'] = sfdcId)
       .then(() => cloud.post(test.api, formula, fSchema))
       .then(r => formulaId = r.body.id)
@@ -346,7 +344,7 @@ suite.forPlatform('formulas', { name: 'formula executions', skip: false }, (test
     const formulaInstance = require('./assets/formulas/script-context-successful-formula-instance');
 
     let formulaId, formulaInstanceId;
-    return common.deleteFormulasByName(test.api, 'script-context-successful')
+    return common.deleteFormulasByName('script-context-successful')
       .then(r => formulaInstance.configuration['trigger-instance'] = sfdcId)
       .then(() => cloud.post(test.api, formula, fSchema))
       .then(r => formulaId = r.body.id)
@@ -370,7 +368,7 @@ suite.forPlatform('formulas', { name: 'formula executions', skip: false }, (test
     const formulaInstance = require('./assets/formulas/simple-successful-formula-instance');
 
     let formulaId, formulaInstanceId;
-    return common.deleteFormulasByName(test.api, 'simple-successful')
+    return common.deleteFormulasByName('simple-successful')
       .then(r => {
         formula.singleThreaded = true;
         formulaInstance.configuration['trigger-instance'] = sfdcId;
@@ -397,7 +395,7 @@ suite.forPlatform('formulas', { name: 'formula executions', skip: false }, (test
     const formulaInstance = require('./assets/formulas/simple-timeout-formula-instance');
 
     let formulaId, formulaInstanceId;
-    return common.deleteFormulasByName(test.api, 'simple-timeout')
+    return common.deleteFormulasByName('simple-timeout')
       .then(r => formulaInstance.configuration['trigger-instance'] = sfdcId)
       .then(() => cloud.post(test.api, formula, fSchema))
       .then(r => formulaId = r.body.id)
@@ -421,7 +419,7 @@ suite.forPlatform('formulas', { name: 'formula executions', skip: false }, (test
     const formulaInstance = require('./assets/formulas/simple-no-return-formula-instance');
 
     let formulaId, formulaInstanceId;
-    return common.deleteFormulasByName(test.api, 'simple-no-return')
+    return common.deleteFormulasByName('simple-no-return')
       .then(r => formulaInstance.configuration['trigger-instance'] = sfdcId)
       .then(() => cloud.post(test.api, formula, fSchema))
       .then(r => formulaId = r.body.id)
@@ -445,7 +443,7 @@ suite.forPlatform('formulas', { name: 'formula executions', skip: false }, (test
     const formulaInstance = require('./assets/formulas/simple-error-formula-instance');
 
     let formulaId, formulaInstanceId;
-    return common.deleteFormulasByName(test.api, 'simple-error')
+    return common.deleteFormulasByName('simple-error')
       .then(r => formulaInstance.configuration['trigger-instance'] = sfdcId)
       .then(() => cloud.post(test.api, formula, fSchema))
       .then(r => formulaId = r.body.id)
@@ -469,7 +467,7 @@ suite.forPlatform('formulas', { name: 'formula executions', skip: false }, (test
     const formulaInstance = require('./assets/formulas/simple-error-formula-instance');
 
     let formulaId, formulaInstanceId;
-    return common.deleteFormulasByName(test.api, 'simple-error')
+    return common.deleteFormulasByName('simple-error')
       .then(r => {
         formula.singleThreaded = true;
         formulaInstance.configuration['trigger-instance'] = sfdcId;
@@ -496,7 +494,7 @@ suite.forPlatform('formulas', { name: 'formula executions', skip: false }, (test
     const formulaInstance = require('./assets/formulas/simple-successful-formula-instance');
 
     let formulaId, formulaInstanceId;
-    return common.deleteFormulasByName(test.api, 'simple-successful')
+    return common.deleteFormulasByName('simple-successful')
       .then(r => {
 
         formula.singleThreaded = true;
@@ -527,7 +525,7 @@ suite.forPlatform('formulas', { name: 'formula executions', skip: false }, (test
     const formulaInstance = require('./assets/formulas/simple-successful-formula-instance');
 
     let formulaId, formulaInstanceId;
-    return common.deleteFormulasByName(test.api, 'simple-successful')
+    return common.deleteFormulasByName('simple-successful')
       .then(r => {
         formula.singleThreaded = true;
         formulaInstance.configuration['trigger-instance'] = sfdcId;
@@ -554,7 +552,7 @@ suite.forPlatform('formulas', { name: 'formula executions', skip: false }, (test
     const formulaInstance = require('./assets/formulas/simple-successful-formula-instance');
 
     let formulaId, formulaInstanceId;
-    return common.deleteFormulasByName(test.api, 'simple-successful')
+    return common.deleteFormulasByName('simple-successful')
       .then(r => cloud.get('/hubs/crm/ping'))
       .then(r => {
         const currentDt = r.body.dateTime;
@@ -585,7 +583,7 @@ suite.forPlatform('formulas', { name: 'formula executions', skip: false }, (test
     const formulaInstance = require('./assets/formulas/loop-successful-formula-instance');
 
     let formulaId, formulaInstanceId;
-    return common.deleteFormulasByName(test.api, 'loop-successful')
+    return common.deleteFormulasByName('loop-successful')
       .then(r => formulaInstance.configuration['trigger-instance'] = sfdcId)
       .then(() => cloud.post(test.api, formula, fSchema))
       .then(r => formulaId = r.body.id)
@@ -609,7 +607,7 @@ suite.forPlatform('formulas', { name: 'formula executions', skip: false }, (test
     const formulaInstance = require('./assets/formulas/element-request-successful-formula-instance');
 
     let formulaId, formulaInstanceId;
-    return common.deleteFormulasByName(test.api, 'element-request-successful')
+    return common.deleteFormulasByName('element-request-successful')
       .then(r => formulaInstance.configuration['trigger-instance'] = sfdcId)
       .then(() => cloud.post(test.api, formula, fSchema))
       .then(r => formulaId = r.body.id)
@@ -633,7 +631,7 @@ suite.forPlatform('formulas', { name: 'formula executions', skip: false }, (test
     const formulaInstance = require('./assets/formulas/large-payload-successful-formula-instance');
 
     let formulaId, formulaInstanceId;
-    return common.deleteFormulasByName(test.api, 'large-payload-successful')
+    return common.deleteFormulasByName('large-payload-successful')
       .then(r => formulaInstance.configuration['trigger-instance'] = sfdcId)
       .then(() => cloud.post(test.api, formula, fSchema))
       .then(r => formulaId = r.body.id)
@@ -688,7 +686,7 @@ suite.forPlatform('formulas', { name: 'formula executions', skip: false }, (test
     };
 
     let formulaId, formulaInstanceId, formulaInstanceExecutionId;
-    return common.deleteFormulasByName(test.api, 'loop-formula')
+    return common.deleteFormulasByName('loop-formula')
       .then(() => cloud.post(test.api, formula, fSchema))
       .then(r => formulaId = r.body.id)
       .then(() => cloud.post(`/formulas/${formulaId}/instances`, formulaInstance, fiSchema))
@@ -712,7 +710,7 @@ suite.forPlatform('formulas', { name: 'formula executions', skip: false }, (test
     const formulaInstance = require('./assets/formulas/simple-successful-formula-instance');
 
     let formulaId, formulaInstanceId1, formulaInstanceId2, formulaInstanceId3;
-    return common.deleteFormulasByName(test.api, 'simple-successful')
+    return common.deleteFormulasByName('simple-successful')
       .then(r => formulaInstance.configuration['trigger-instance'] = sfdcId)
       .then(() => cloud.post(test.api, formula, fSchema))
       .then(r => formulaId = r.body.id)
@@ -762,9 +760,9 @@ suite.forPlatform('formulas', { name: 'formula executions', skip: false }, (test
     const formulaInstance3 = require('./assets/formulas/loop-successful-formula-instance');
 
     let formulaId1, formulaId2, formulaId3, formulaInstanceId1, formulaInstanceId2, formulaInstanceId3;
-    return common.deleteFormulasByName(test.api, 'simple-successful')
-      .then(() => common.deleteFormulasByName(test.api, 'element-request-successful'))
-      .then(() => common.deleteFormulasByName(test.api, 'loop-successful'))
+    return common.deleteFormulasByName('simple-successful')
+      .then(() => common.deleteFormulasByName('element-request-successful'))
+      .then(() => common.deleteFormulasByName('loop-successful'))
       .then(r => {
         formulaInstance1.configuration['trigger-instance'] = sfdcId;
         formulaInstance2.configuration['trigger-instance'] = sfdcId;
@@ -818,7 +816,7 @@ suite.forPlatform('formulas', { name: 'formula executions', skip: false }, (test
     const formulaInstance = require('./assets/formulas/simple-successful-formula-instance');
 
     let formulaId, formulaInstanceId;
-    return common.deleteFormulasByName(test.api, 'simple-successful')
+    return common.deleteFormulasByName('simple-successful')
       .then(r => formulaInstance.configuration['trigger-instance'] = sfdcId)
       .then(() => cloud.post(test.api, formula, fSchema))
       .then(r => formulaId = r.body.id)
@@ -842,7 +840,7 @@ suite.forPlatform('formulas', { name: 'formula executions', skip: false }, (test
     const formulaInstance = require('./assets/formulas/complex-successful-formula-instance');
 
     let formulaId, formulaInstanceId;
-    return common.deleteFormulasByName(test.api, 'complex-successful')
+    return common.deleteFormulasByName('complex-successful')
       .then(r => formulaInstance.configuration['trigger-instance'] = sfdcId)
       .then(() => cloud.post(test.api, formula, fSchema))
       .then(r => formulaId = r.body.id)
@@ -866,7 +864,7 @@ suite.forPlatform('formulas', { name: 'formula executions', skip: false }, (test
     const formulaInstance = require('./assets/formulas/script-with-on-failure-successful-formula-instance');
 
     let formulaId, formulaInstanceId;
-    return common.deleteFormulasByName(test.api, 'script-with-on-failure-successful')
+    return common.deleteFormulasByName('script-with-on-failure-successful')
       .then(r => formulaInstance.configuration['trigger-instance'] = sfdcId)
       .then(() => cloud.post(test.api, formula, fSchema))
       .then(r => formulaId = r.body.id)
@@ -890,7 +888,7 @@ suite.forPlatform('formulas', { name: 'formula executions', skip: false }, (test
     const formulaInstance = require('./assets/formulas/filter-returns-false-instance');
 
     let formulaId, formulaInstanceId;
-    return common.deleteFormulasByName(test.api, 'filter-returns-false')
+    return common.deleteFormulasByName('filter-returns-false')
       .then(r => formulaInstance.configuration['trigger-instance'] = sfdcId)
       .then(() => cloud.post(test.api, formula, fSchema))
       .then(r => formulaId = r.body.id)

--- a/src/test/platform/formulas/executions.js
+++ b/src/test/platform/formulas/executions.js
@@ -1,8 +1,9 @@
 'use strict';
 
 const provisioner = require('core/provisioner');
+const cleaner = require('core/cleaner');
 const common = require('./assets/common');
-const util = require('util');
+const logger = require('winston');
 const suite = require('core/suite');
 const cloud = require('core/cloud');
 const fSchema = require('./assets/schemas/formula.schema');
@@ -334,12 +335,45 @@ suite.forPlatform('formulas', { name: 'formula executions', skip: false }, (test
       });
   });
 
+  /**
+   * Represents a standard execution test setup, triggering of formula and validation.
+   *
+   * NOTE: Currently working on migrating all tests in here to use this function to allow for less code and easier debugging
+   */
+  const executionTest = (formula, numberOfExecutions, numberOfStepExecutions, triggerCb, customExecutionsValidator) => {
+    customExecutionsValidator = customExecutionsValidator || ((executions) => logger.debug(`No custom execution validator found`));
+    const executionsValidator = (executions) => {
+      customExecutionsValidator(executions);
+      return executions;
+    };
+
+    const trigger = (formulaId, formulaInstanceId) => {
+      if (typeof triggerCb === 'function') {
+        return triggerCb();
+      } else if (typeof triggerCb === 'string' && triggerCb === 'manual') {
+        return cloud.post(`/formulas/${formulaId}/instances/${formulaInstanceId}/executions`, { foo: 'bar' });
+      }
+    };
+
+    let fId, fiId;
+    return cleaner.formulas.withName(formula.name)
+      .then(() => cloud.post(test.api, formula, fSchema))
+      .then(r => fId = r.body.id)
+      .then(() => cloud.post(`/formulas/${fId}/instances`, { name: 'churros-instance' }, fiSchema))
+      .then(r => fiId = r.body.id)
+      .then(() => trigger(fId, fiId))
+      .then(() => tools.wait.upTo(60000).for(common.allExecutionsCompleted(fId, fiId, numberOfExecutions, numberOfStepExecutions)))
+      .then(() => common.getFormulaInstanceExecutions(fiId))
+      .then(r => Promise.all(r.body.map(fie => common.getFormulaInstanceExecutionWithSteps(fie.id))))
+      .then(executions => executionsValidator(executions));
+  };
+
   it('should successfully execute a simple formula triggered by a single event', () => {
     const formula = require('./assets/formulas/simple-successful-formula');
     const formulaInstance = require('./assets/formulas/simple-successful-formula-instance');
 
     let formulaId, formulaInstanceId;
-    return common.deleteFormulasByName('simple-successful')
+    return cleaner.formulas.withName('simple-successful')
       .then(r => formulaInstance.configuration['trigger-instance'] = sfdcId)
       .then(() => cloud.post(test.api, formula, fSchema))
       .then(r => formulaId = r.body.id)
@@ -363,7 +397,7 @@ suite.forPlatform('formulas', { name: 'formula executions', skip: false }, (test
     const formulaInstance = require('./assets/formulas/simple-successful-formula-instance');
 
     let formulaId, formulaInstanceId;
-    return common.deleteFormulasByName('simple-successful')
+    return cleaner.formulas.withName('simple-successful')
       .then(r => formulaInstance.configuration['trigger-instance'] = sfdcId)
       .then(() => cloud.post(test.api, formula, fSchema))
       .then(r => formulaId = r.body.id)
@@ -387,7 +421,7 @@ suite.forPlatform('formulas', { name: 'formula executions', skip: false }, (test
     const formulaInstance = require('./assets/formulas/script-context-successful-formula-instance');
 
     let formulaId, formulaInstanceId;
-    return common.deleteFormulasByName('script-context-successful')
+    return cleaner.formulas.withName('script-context-successful')
       .then(r => formulaInstance.configuration['trigger-instance'] = sfdcId)
       .then(() => cloud.post(test.api, formula, fSchema))
       .then(r => formulaId = r.body.id)
@@ -411,7 +445,7 @@ suite.forPlatform('formulas', { name: 'formula executions', skip: false }, (test
     const formulaInstance = require('./assets/formulas/simple-successful-formula-instance');
 
     let formulaId, formulaInstanceId;
-    return common.deleteFormulasByName('simple-successful')
+    return cleaner.formulas.withName('simple-successful')
       .then(r => {
         formula.singleThreaded = true;
         formulaInstance.configuration['trigger-instance'] = sfdcId;
@@ -438,7 +472,7 @@ suite.forPlatform('formulas', { name: 'formula executions', skip: false }, (test
     const formulaInstance = require('./assets/formulas/simple-timeout-formula-instance');
 
     let formulaId, formulaInstanceId;
-    return common.deleteFormulasByName('simple-timeout')
+    return cleaner.formulas.withName('simple-timeout')
       .then(r => formulaInstance.configuration['trigger-instance'] = sfdcId)
       .then(() => cloud.post(test.api, formula, fSchema))
       .then(r => formulaId = r.body.id)
@@ -462,7 +496,7 @@ suite.forPlatform('formulas', { name: 'formula executions', skip: false }, (test
     const formulaInstance = require('./assets/formulas/simple-no-return-formula-instance');
 
     let formulaId, formulaInstanceId;
-    return common.deleteFormulasByName('simple-no-return')
+    return cleaner.formulas.withName('simple-no-return')
       .then(r => formulaInstance.configuration['trigger-instance'] = sfdcId)
       .then(() => cloud.post(test.api, formula, fSchema))
       .then(r => formulaId = r.body.id)
@@ -476,7 +510,7 @@ suite.forPlatform('formulas', { name: 'formula executions', skip: false }, (test
         return r;
       })
       .then(r => Promise.all(r.body.map(fie => common.getFormulaInstanceExecutionWithSteps(fie.id))))
-      .then(rs => rs.map(r => validateExecution(r)(validateSimpleV1NoReturnStepExecutions.forEvents(1))))
+      .then(rs => rs.map(r => validateExecution(r, 'failed')(validateSimpleV1NoReturnStepExecutions.forEvents(1))))
       .then(() => common.deleteFormulaInstance(formulaId, formulaInstanceId))
       .then(() => common.deleteFormula(formulaId));
   });
@@ -486,7 +520,7 @@ suite.forPlatform('formulas', { name: 'formula executions', skip: false }, (test
     const formulaInstance = require('./assets/formulas/simple-no-return-formula-instance');
 
     let formulaId, formulaInstanceId;
-    return common.deleteFormulasByName(test.api, 'simple-no-return')
+    return cleaner.formulas.withName('simple-no-return')
       .then(r => formulaInstance.configuration['trigger-instance'] = sfdcId)
       .then(() => cloud.post(test.api, formula, fSchema))
       .then(r => formulaId = r.body.id)
@@ -500,7 +534,7 @@ suite.forPlatform('formulas', { name: 'formula executions', skip: false }, (test
         return r;
       })
       .then(r => Promise.all(r.body.map(fie => common.getFormulaInstanceExecutionWithSteps(fie.id))))
-      .then(rs => rs.map(r => validateExecution(r, 'failed')(validateSimpleV2NoReturnStepExecutions.forEvents(1))))
+      .then(rs => rs.map(r => validateExecution(r)(validateSimpleV2NoReturnStepExecutions.forEvents(1))))
       .then(() => common.deleteFormulaInstance(formulaId, formulaInstanceId))
       .then(() => common.deleteFormula(formulaId));
   });
@@ -510,7 +544,7 @@ suite.forPlatform('formulas', { name: 'formula executions', skip: false }, (test
     const formulaInstance = require('./assets/formulas/simple-no-return-console-formula-instance');
 
     let formulaId, formulaInstanceId;
-    return common.deleteFormulasByName(test.api, 'simple-no-return')
+    return cleaner.formulas.withName('simple-no-return')
       .then(r => formulaInstance.configuration['trigger-instance'] = sfdcId)
       .then(() => cloud.post(test.api, formula, fSchema))
       .then(r => formulaId = r.body.id)
@@ -534,7 +568,7 @@ suite.forPlatform('formulas', { name: 'formula executions', skip: false }, (test
     const formulaInstance = require('./assets/formulas/simple-error-formula-instance');
 
     let formulaId, formulaInstanceId;
-    return common.deleteFormulasByName('simple-error')
+    return cleaner.formulas.withName('simple-error')
       .then(r => formulaInstance.configuration['trigger-instance'] = sfdcId)
       .then(() => cloud.post(test.api, formula, fSchema))
       .then(r => formulaId = r.body.id)
@@ -558,7 +592,7 @@ suite.forPlatform('formulas', { name: 'formula executions', skip: false }, (test
     const formulaInstance = require('./assets/formulas/simple-error-formula-instance');
 
     let formulaId, formulaInstanceId;
-    return common.deleteFormulasByName(test.api, 'simple-error')
+    return cleaner.formulas.withName('simple-error')
       .then(r => formulaInstance.configuration['trigger-instance'] = sfdcId)
       .then(() => cloud.post(test.api, formula, fSchema))
       .then(r => formulaId = r.body.id)
@@ -572,17 +606,17 @@ suite.forPlatform('formulas', { name: 'formula executions', skip: false }, (test
         return r;
       })
       .then(r => Promise.all(r.body.map(fie => common.getFormulaInstanceExecutionWithSteps(fie.id))))
-      .then(rs => rs.map(r => validateExecution(r)(validateSimpleErrorV2StepExecutions.forEvents(1))))
+      .then(rs => rs.map(r => validateExecution(r, 'failed')(validateSimpleErrorV2StepExecutions.forEvents(1))))
       .then(() => common.deleteFormulaInstance(formulaId, formulaInstanceId))
       .then(() => common.deleteFormula(formulaId));
   });
 
   it('should properly handle a single threaded formula with a step that contains invalid json, triggered by an event with three objects', () => {
-    const formula = require('./assets/formulas/simple-error-formula');
+    const formula = require('./assets/formulas/simple-error-formula-v1');
     const formulaInstance = require('./assets/formulas/simple-error-formula-instance');
 
     let formulaId, formulaInstanceId;
-    return common.deleteFormulasByName('simple-error')
+    return cleaner.formulas.withName('simple-error')
       .then(r => {
         formula.singleThreaded = true;
         formulaInstance.configuration['trigger-instance'] = sfdcId;
@@ -609,7 +643,7 @@ suite.forPlatform('formulas', { name: 'formula executions', skip: false }, (test
     const formulaInstance = require('./assets/formulas/simple-successful-formula-instance');
 
     let formulaId, formulaInstanceId;
-    return common.deleteFormulasByName('simple-successful')
+    return cleaner.formulas.withName('simple-successful')
       .then(r => {
 
         formula.singleThreaded = true;
@@ -640,7 +674,7 @@ suite.forPlatform('formulas', { name: 'formula executions', skip: false }, (test
     const formulaInstance = require('./assets/formulas/simple-successful-formula-instance');
 
     let formulaId, formulaInstanceId;
-    return common.deleteFormulasByName('simple-successful')
+    return cleaner.formulas.withName('simple-successful')
       .then(r => {
         formula.singleThreaded = true;
         formulaInstance.configuration['trigger-instance'] = sfdcId;
@@ -667,7 +701,7 @@ suite.forPlatform('formulas', { name: 'formula executions', skip: false }, (test
     const formulaInstance = require('./assets/formulas/simple-successful-formula-instance');
 
     let formulaId, formulaInstanceId;
-    return common.deleteFormulasByName('simple-successful')
+    return cleaner.formulas.withName('simple-successful')
       .then(r => cloud.get('/hubs/crm/ping'))
       .then(r => {
         const currentDt = r.body.dateTime;
@@ -698,7 +732,7 @@ suite.forPlatform('formulas', { name: 'formula executions', skip: false }, (test
     const formulaInstance = require('./assets/formulas/loop-successful-formula-instance');
 
     let formulaId, formulaInstanceId;
-    return common.deleteFormulasByName('loop-successful')
+    return cleaner.formulas.withName('loop-successful')
       .then(r => formulaInstance.configuration['trigger-instance'] = sfdcId)
       .then(() => cloud.post(test.api, formula, fSchema))
       .then(r => formulaId = r.body.id)
@@ -722,11 +756,11 @@ suite.forPlatform('formulas', { name: 'formula executions', skip: false }, (test
     const formulaInstance = require('./assets/formulas/element-request-successful-formula-instance');
 
     let formulaId, formulaInstanceId;
-    return common.deleteFormulasByName('element-request-successful')
+    return cleaner.formulas.withName('element-request-successful')
       .then(r => formulaInstance.configuration['trigger-instance'] = sfdcId)
       .then(() => cloud.post(test.api, formula, fSchema))
       .then(r => formulaId = r.body.id)
-      .then(() => cloud.post(util.format('/formulas/%s/instances', formulaId), formulaInstance, fiSchema))
+      .then(() => cloud.post(`/formulas/${formulaId}/instances`, formulaInstance, fiSchema))
       .then(r => formulaInstanceId = r.body.id)
       .then(() => generateSingleSfdcPollingEvent(sfdcId))
       .then(() => sleep.sleep(10))
@@ -746,7 +780,7 @@ suite.forPlatform('formulas', { name: 'formula executions', skip: false }, (test
     const formulaInstance = require('./assets/formulas/large-payload-successful-formula-instance');
 
     let formulaId, formulaInstanceId;
-    return common.deleteFormulasByName('large-payload-successful')
+    return cleaner.formulas.withName('large-payload-successful')
       .then(r => formulaInstance.configuration['trigger-instance'] = sfdcId)
       .then(() => cloud.post(test.api, formula, fSchema))
       .then(r => formulaId = r.body.id)
@@ -801,7 +835,7 @@ suite.forPlatform('formulas', { name: 'formula executions', skip: false }, (test
     };
 
     let formulaId, formulaInstanceId, formulaInstanceExecutionId;
-    return common.deleteFormulasByName('loop-formula')
+    return cleaner.formulas.withName('loop-formula')
       .then(() => cloud.post(test.api, formula, fSchema))
       .then(r => formulaId = r.body.id)
       .then(() => cloud.post(`/formulas/${formulaId}/instances`, formulaInstance, fiSchema))
@@ -825,7 +859,7 @@ suite.forPlatform('formulas', { name: 'formula executions', skip: false }, (test
     const formulaInstance = require('./assets/formulas/simple-successful-formula-instance');
 
     let formulaId, formulaInstanceId1, formulaInstanceId2, formulaInstanceId3;
-    return common.deleteFormulasByName('simple-successful')
+    return cleaner.formulas.withName('simple-successful')
       .then(r => formulaInstance.configuration['trigger-instance'] = sfdcId)
       .then(() => cloud.post(test.api, formula, fSchema))
       .then(r => formulaId = r.body.id)
@@ -875,9 +909,7 @@ suite.forPlatform('formulas', { name: 'formula executions', skip: false }, (test
     const formulaInstance3 = require('./assets/formulas/loop-successful-formula-instance');
 
     let formulaId1, formulaId2, formulaId3, formulaInstanceId1, formulaInstanceId2, formulaInstanceId3;
-    return common.deleteFormulasByName('simple-successful')
-      .then(() => common.deleteFormulasByName('element-request-successful'))
-      .then(() => common.deleteFormulasByName('loop-successful'))
+    return cleaner.formulas.withNames(['simple-successful', 'element-request-successful', 'loop-successful'])
       .then(r => {
         formulaInstance1.configuration['trigger-instance'] = sfdcId;
         formulaInstance2.configuration['trigger-instance'] = sfdcId;
@@ -931,7 +963,7 @@ suite.forPlatform('formulas', { name: 'formula executions', skip: false }, (test
     const formulaInstance = require('./assets/formulas/simple-successful-formula-instance');
 
     let formulaId, formulaInstanceId;
-    return common.deleteFormulasByName('simple-successful')
+    return cleaner.formulas.withName('simple-successful')
       .then(r => formulaInstance.configuration['trigger-instance'] = sfdcId)
       .then(() => cloud.post(test.api, formula, fSchema))
       .then(r => formulaId = r.body.id)
@@ -955,7 +987,7 @@ suite.forPlatform('formulas', { name: 'formula executions', skip: false }, (test
     const formulaInstance = require('./assets/formulas/complex-successful-formula-instance');
 
     let formulaId, formulaInstanceId;
-    return common.deleteFormulasByName('complex-successful')
+    return cleaner.formulas.withName('complex-successful')
       .then(r => formulaInstance.configuration['trigger-instance'] = sfdcId)
       .then(() => cloud.post(test.api, formula, fSchema))
       .then(r => formulaId = r.body.id)
@@ -979,7 +1011,7 @@ suite.forPlatform('formulas', { name: 'formula executions', skip: false }, (test
     const formulaInstance = require('./assets/formulas/script-with-on-failure-successful-formula-instance');
 
     let formulaId, formulaInstanceId;
-    return common.deleteFormulasByName('script-with-on-failure-successful')
+    return cleaner.formulas.withName('script-with-on-failure-successful')
       .then(r => formulaInstance.configuration['trigger-instance'] = sfdcId)
       .then(() => cloud.post(test.api, formula, fSchema))
       .then(r => formulaId = r.body.id)
@@ -1003,7 +1035,7 @@ suite.forPlatform('formulas', { name: 'formula executions', skip: false }, (test
     const formulaInstance = require('./assets/formulas/filter-returns-false-instance');
 
     let formulaId, formulaInstanceId;
-    return common.deleteFormulasByName('filter-returns-false')
+    return cleaner.formulas.withName('filter-returns-false')
       .then(r => formulaInstance.configuration['trigger-instance'] = sfdcId)
       .then(() => cloud.post(test.api, formula, fSchema))
       .then(r => formulaId = r.body.id)
@@ -1018,6 +1050,22 @@ suite.forPlatform('formulas', { name: 'formula executions', skip: false }, (test
         const execution = r.body[0];
         expect(execution.status).to.equal('success');
       });
+  });
+
+  it('should support a manual trigger type on a formula', () => {
+    const formula = require('./assets/formulas/manual-trigger');
+
+    const validator = (executions) => {
+      expect(executions).to.have.length(1);
+      const execution = executions[0];
+      expect(execution.status).to.equal('success');
+      const trigger = execution.stepExecutions.filter(se => se.stepName === 'trigger')[0];
+      expect(trigger.stepExecutionValues).to.have.length(1);
+      const stepExecutionValue = trigger.stepExecutionValues[0];
+      expect(stepExecutionValue.value).to.equal('{"foo":"bar"}');
+    };
+
+    return executionTest(formula, 1, 2, 'manual', validator);
   });
 
   /** Clean up */

--- a/src/test/platform/formulas/load.js
+++ b/src/test/platform/formulas/load.js
@@ -87,7 +87,7 @@ const createXInstances = (x, formulaId, formulaInstance) => {
  */
 suite.forPlatform('formulas', { name: 'formulas load', skip: true }, (test) => {
   let sfdcId;
-  before(() => common.deleteFormulasByName(test.api, 'complex-successful')
+  before(() => common.deleteFormulasByName('complex-successful')
     .then(r => common.provisionSfdcWithWebhook())
     .then(r => sfdcId = r.body.id));
 

--- a/src/test/platform/formulas/load.js
+++ b/src/test/platform/formulas/load.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const cleaner = require('core/cleaner');
 const suite = require('core/suite');
 const common = require('./assets/common');
 const cloud = require('core/cloud');
@@ -87,7 +88,7 @@ const createXInstances = (x, formulaId, formulaInstance) => {
  */
 suite.forPlatform('formulas', { name: 'formulas load', skip: true }, (test) => {
   let sfdcId;
-  before(() => common.deleteFormulasByName('complex-successful')
+  before(() => cleaner.formulas.withName('complex-successful')
     .then(r => common.provisionSfdcWithWebhook())
     .then(r => sfdcId = r.body.id));
 

--- a/src/test/platform/formulas/steps.js
+++ b/src/test/platform/formulas/steps.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const cleaner = require('core/cleaner');
 const cloud = require('core/cloud');
 const common = require('./assets/common');
 const expect = require('chakram').expect;
@@ -8,7 +9,7 @@ const suite = require('core/suite');
 const schema = require('./assets/schemas/formula.schema');
 
 suite.forPlatform('formulas', { name: 'formula steps', schema: schema }, (test) => {
-  before(() => common.deleteFormulasByName('formulas', invalidJson.name));
+  before(() => cleaner.formulas.withName(invalidJson.name));
 
   /* make sure step properties are being validated properly when creating a formula with steps*/
   test

--- a/src/test/platform/formulas/sub-formula-executions.js
+++ b/src/test/platform/formulas/sub-formula-executions.js
@@ -1,0 +1,77 @@
+'use strict';
+
+const cleaner = require('core/cleaner');
+const cloud = require('core/cloud');
+const suite = require('core/suite');
+const provisioner = require('core/provisioner');
+const tools = require('core/tools');
+
+/* Formula JSON */
+const formulas = require('./assets/formulas/sub-formula-executions/sub-formulas');
+const myFormulas = require('./assets/formulas/sub-formula-executions/sub-formulas-no-steps-after');
+
+suite.forPlatform('formulas', { name: 'formula executions: sub formulas' }, (test) => {
+  const cleanFormulas = () => {
+    return cleaner.formulas.withNames(formulas.map(f => f.name))
+      .then(r => cleaner.formulas.withNames(myFormulas.map(f => f.name)));
+  };
+
+  /* Create SFDC element with events enabled */
+  let sfdcId;
+  before(() => {
+    const config = { 'event.notification.enabled': true, 'event.vendor.type': 'polling', 'event.poller.refresh_interval': 999999999 };
+    return cleanFormulas()
+      .then(r => provisioner.create('sfdc', config))
+      .then(r => sfdcId = r.body.id)
+      .catch(e => tools.logAndThrow('Failed to run before()', e));
+  });
+
+  const buildConfig = (triggerId) => ({ name: 'churros-instance', configuration: { 'trigger-instance': triggerId } });
+
+  const setProperty = (allFormulas, formulaName, stepNames, value) => {
+    if (typeof stepNames === 'string') stepNames = [stepNames];
+
+    stepNames.map(stepName =>
+      allFormulas.filter(f => f.name === formulaName)[0]
+      .steps.filter(step => step.name === stepName)[0]
+      .properties.formulaId = value
+    );
+  };
+
+  it('should support a formula having a formula step type', () => {
+    let formulaId;
+    const setup = () => {
+      return cloud.post(`/formulas`, formulas[2])
+        .then(r => setProperty(formulas, 'B-sub-formula', 'B-sub-formula', r.body.id))
+        .then(r => cloud.post(`/formulas`, formulas[1]))
+        .then(r => setProperty(formulas, 'A-sub-formula', ['A-sub-formula', 'A-another-sub-formula'], r.body.id))
+        .then(r => cloud.post(`/formulas`, formulas[0]))
+        .then(r => formulaId = r.body.id);
+    };
+
+    return setup()
+      .then(r => cloud.post(`/formulas/${formulaId}/instances`, buildConfig(sfdcId)));
+  });
+
+  it('should support a formula with multiple sub-formulas and no after steps', () => {
+    let formulaId;
+    const setup = () => {
+      return cloud.post(`/formulas`, myFormulas[2])
+        .then(r => setProperty(myFormulas, 'B-sub-formula-no-steps-after', 'B-sub-formula', r.body.id))
+        .then(r => cloud.post(`/formulas`, myFormulas[1]))
+        .then(r => setProperty(myFormulas, 'A-sub-formula-no-steps-after', 'A-sub-formula', r.body.id))
+        .then(r => cloud.post(`/formulas`, myFormulas[0]))
+        .then(r => formulaId = r.body.id);
+    };
+
+    return setup()
+      .then(r => cloud.post(`/formulas/${formulaId}/instances`, buildConfig(sfdcId)));
+  });
+
+  /* Cleanup any resources */
+  after(() => {
+    return cleanFormulas()
+      .then(r => provisioner.delete(sfdcId))
+      .catch(e => tools.logAndThrow(`Failed to run after()`, e));
+  });
+});

--- a/src/test/platform/formulas/sub-formula-executions.js
+++ b/src/test/platform/formulas/sub-formula-executions.js
@@ -137,7 +137,7 @@ suite.forPlatform('formulas', { name: 'formula executions: sub formulas' }, (tes
     return executionTest(setup, 5, validator);
   });
 
-  it('should support a formula multiple sub-formulas and no after steps', () => {
+  it('should support a formula having multiple sub-formulas and no after steps', () => {
     const setup = () => {
       return createSetCreate(twoSubFormulasNoAfter, 'C-sub-formula-no-steps-after', 'B-sub-formula', 'B-sub-formula-no-steps-after')
         .then(formula => setProperty(twoSubFormulasNoAfter, 'A-sub-formula-no-steps-after', 'A-sub-formula', formula.body.id))

--- a/src/test/platform/formulas/sub-formula-executions.js
+++ b/src/test/platform/formulas/sub-formula-executions.js
@@ -26,7 +26,7 @@ suite.forPlatform('formulas', { name: 'formula executions: sub formulas' }, (tes
       .concat(manualSubFormulas.map(f => f.name))
       .concat(filterSubFormulas.map(f => f.name))
       .concat(errorSubFormulas.map(f => f.name));
-    return cleaner.formulas.withNames(names);
+    return cleaner.formulas.withName(names);
   };
 
   /* Create SFDC element with events enabled */

--- a/test/cli/churros.clean.bats
+++ b/test/cli/churros.clean.bats
@@ -1,0 +1,9 @@
+#!/usr/bin/env bats
+
+USAGE="  Usage: churros-clean [options] [command]"
+
+@test "It should support churros help clean" {
+  run churros help clean
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "${USAGE}" ]
+}

--- a/test/core/cleaner.test.js
+++ b/test/core/cleaner.test.js
@@ -1,0 +1,84 @@
+'use strict';
+
+require('core/assertions');
+const cleaner = require('core/cleaner');
+const chakram = require('chakram');
+const nock = require('nock');
+
+const BASE_URL = 'https://api.cloud-elements.com/elements/api-v2;';
+const AUTH = 'User fake, Organization fake';
+
+describe('cleaner', () => {
+  /* Setup our default chakram headers */
+  before(() => chakram.setRequestDefaults({ baseUrl: BASE_URL, headers: { Authorization: AUTH } }));
+
+  const formulas = [{ id: 123, name: 'foo' }, { id: 456, name: 'bar' }];
+
+  const genFormulaInstance = (opts) => {
+    opts = opts || {};
+    return ({ id: opts.id || null, formula: { id: opts.id || null } });
+  };
+
+  const elementInstances = [{ id: 123, name: 'foo' }, { id: 456, name: 'bar' }];
+
+  const headers = () => ({ reqheaders: { 'Authorization': (value) => value === AUTH } });
+
+  it('should support cleaning up formulas by name', () => {
+    nock(BASE_URL, headers())
+      .get('/formulas')
+      .reply(200, (uri, requestBody) => formulas)
+      .get('/formulas/123/instances')
+      .reply(200, () => [genFormulaInstance({ id: 123 })])
+      .delete('/formulas/123/instances/123')
+      .reply(200)
+      .delete('/formulas/123')
+      .reply(200);
+    return cleaner.formulas.withName('foo');
+  });
+
+  it('should support cleaning up formulas with a list of names', () => {
+    nock(BASE_URL, headers())
+      .get('/formulas')
+      .reply(200, (uri, requestBody) => formulas)
+      .get('/formulas/123/instances')
+      .reply(200, () => [genFormulaInstance({ id: 123 })])
+      .get('/formulas/456/instances')
+      .reply(200, () => [genFormulaInstance({ id: 456 })])
+      .delete('/formulas/123/instances/123')
+      .reply(200)
+      .delete('/formulas/456/instances/456')
+      .reply(200)
+      .delete('/formulas/123')
+      .reply(200)
+      .delete('/formulas/456')
+      .reply(200);
+    return cleaner.formulas.withName(['foo', 'bar']);
+  });
+
+  it('should support cleaning up formulas with a name that does not match anything', () => {
+    nock(BASE_URL, headers())
+      .get('/formulas')
+      .reply(200, (uri, requestBody) => formulas);
+    return cleaner.formulas.withName('NameThatHasNoMatches');
+  });
+
+  it('should support cleaning up elements by name', () => {
+    nock(BASE_URL, headers())
+      .get('/instances')
+      .reply(200, (uri, requestBody) => elementInstances)
+      .delete('/instances/123')
+      .reply(200);
+    return cleaner.elements.withName('foo');
+  });
+
+  it('should support cleaning up elements with a list of names', () => {
+    nock(BASE_URL, headers())
+      .get('/instances')
+      .reply(200, (uri, requestBody) => elementInstances)
+      .delete('/instances/123')
+      .reply(200)
+      .delete('/instances/456')
+      .reply(200);
+    return cleaner.elements.withName(['foo', 'bar']);
+  });
+});


### PR DESCRIPTION
## Highlights
* First cut at some sub-formula tests to demonstrate the formula step type of `formula` (i.e. formulas calling formulas)

## Examples
```  
formula executions: sub formulas
    ✓ should support a formula that contains a sub-formula (4247ms)
    ✓ should support a formula having multiple sub-formulas (22496ms)
    ✓ should support a formula multiple sub-formulas and no after steps (10457ms)
    ✓ should support a formula with a sub-formula that has a manual trigger type (7420ms)
    ✓ should have onSuccess or onFailure to represent the entire sub-formulas execution status (4346ms)
    ✓ should propagate errors from sub-formulas properly (4742ms)
```
