### PR TITLE
Patch instances with reauthentication

### DIFF
--- a/src/core/provisioner.js
+++ b/src/core/provisioner.js
@@ -148,9 +148,8 @@ const oauth1 = (element, args) => {
  * @param  {string} baseApi  The base API
  * @return {Promise}         JS promise that resolves to the instance created
  */
-const orchestrateCreate = (element, args, baseApi) => {
+const orchestrateCreate = (element, args, baseApi, cb) => {
   const type = props.getOptionalForKey(element, 'provisioning');
-  const external = props.getOptionalForKey(element, 'external');
   const config = genConfig(props.all(element), args);
 
   logger.debug('Attempting to provision %s using the %s provisioning flow', element, type ? type : 'standard');
@@ -165,14 +164,7 @@ const orchestrateCreate = (element, args, baseApi) => {
       return parseProps(element)
         .then(r => (type === 'oauth1') ? oauth1(element, r) : r)
         .then(r => oauth(element, r, config))
-        .then(r => {
-          if (external && type === 'oauth2') {
-            return createExternalInstance(element, config, r);
-          } else if (external && type === 'oauth1') {
-            throw Error('External Authentication via churros is not yet implemented for OAuth1');
-          }
-          return createInstance(element, config, r, baseApi);
-        });
+        .then(r => cb(type, config, r));
     case 'custom':
       const cp = `${__dirname}/../test/elements/${element}/provisioner`;
       return require(cp).create(config);
@@ -181,12 +173,30 @@ const orchestrateCreate = (element, args, baseApi) => {
   }
 };
 
+exports.partialOauth = (element, args, baseApi) => {
+  const cb = (type, config, r) => {
+    return r.code;
+  };
+
+  return orchestrateCreate(element, args, baseApi, cb);
+};
+
 exports.create = (element, args, baseApi) => {
-  return orchestrateCreate(element, args, baseApi)
-    .then(r => {
-      defaults.token(r.body.token); // update defaults with token to add to requests
-      return r;
-    });
+  const cb = (type, config, r) => {
+    const external = props.getOptionalForKey(element, 'external');
+    if (external && type === 'oauth2') {
+      return createExternalInstance(element, config, r);
+    } else if (external && type === 'oauth1') {
+      throw Error('External Authentication via churros is not yet implemented for OAuth1');
+    }
+    return createInstance(element, config, r, baseApi)
+      .then(r => {
+        defaults.token(r.body.token);
+        return r;
+      });
+  };
+
+  return orchestrateCreate(element, args, baseApi, cb);
 };
 
 exports.delete = (id, baseApi) => {

--- a/src/test/platform/elements/instances.js
+++ b/src/test/platform/elements/instances.js
@@ -41,9 +41,32 @@ const updateInstanceWithReprovision = (baseUrl, schema) => {
     .then(r => {
       return provisioner.partialOauth('shopify');
     })
-    .then(code => cloud.put(`${baseUrl}/${id}`, genInstance('shopify', { name: 'updated-instance', providerData: { code: code } })))
+    .then(code =>
+      cloud.put(`${baseUrl}/${id}`, genInstance('shopify', { name: 'updated-instance', providerData: { code: code } }), r => {
+        expect(r).to.have.statusCode(200);
+        expect(r.body.configuration).to.not.be.empty;
+        expect(r.body.configuration.password).to.equal("********");
+        expect(r.body.configuration.username).to.equal(props.getForKey('shopify', 'username'));
+        expect(r.body).to.not.have.key('providerData');
+      }))
+    .then(r => cloud.get(`/hubs/ecommerce/orders`))
+    .then(r => {
+      expect(r).to.have.statusCode(200);
+      expect(r.body).to.be.instanceof(Array);
+    })
     .then(r => provisioner.partialOauth('shopify'))
-    .then(code => cloud.patch(`${baseUrl}/${id}`, { name: 'updated-instance', providerData: { code: code } }))
+    .then(code => cloud.patch(`${baseUrl}/${id}`, { name: 'updated-instance', providerData: { code: code } }, r => {
+        expect(r).to.have.statusCode(200);
+        expect(r.body.configuration).to.not.be.empty;
+        expect(r.body.configuration.password).to.equal("********");
+        expect(r.body.configuration.username).to.equal(props.getForKey('shopify', 'username'));
+        expect(r.body).to.not.have.key('providerData');
+    }))
+    .then(r => cloud.get(`/hubs/ecommerce/orders`))
+    .then(r => {
+      expect(r).to.have.statusCode(200);
+      expect(r.body).to.be.instanceof(Array);
+    })
     .then(r => provisioner.delete(id, baseUrl));
 };
 

--- a/src/test/platform/elements/instances.js
+++ b/src/test/platform/elements/instances.js
@@ -9,6 +9,7 @@ const instanceSchema = require('./assets/element.instance.schema.json');
 
 const genInstance = (element, o) => ({
   name: (o.name || 'churros-instance'),
+  providerData: (o.providerData || undefined),
   element: { key: element },
   configuration: props.all(element)
 });
@@ -27,6 +28,25 @@ const crudInstance = (baseUrl, schema) => {
     .then(r => provisioner.delete(id, baseUrl));
 };
 
+const updateInstanceWithReprovision = (baseUrl, schema) => {
+  let id;
+  return provisioner.create('shopify')
+    .then(r => id = r.body.id)
+    .then(r => cloud.get(`${baseUrl}/${id}`, (r) => {
+      expect(r).to.have.schemaAnd200(schema);
+      expect(r.body.configuration).to.not.be.empty;
+      expect(r.body.configuration.password).to.equal("********");
+      expect(r.body.configuration.username).to.equal(props.getForKey('shopify', 'username'));
+    }))
+    .then(r => {
+      return provisioner.partialOauth('shopify');
+    })
+    .then(code => cloud.put(`${baseUrl}/${id}`, genInstance('shopify', { name: 'updated-instance', providerData: { code: code } })))
+    .then(r => provisioner.partialOauth('shopify'))
+    .then(code => cloud.patch(`${baseUrl}/${id}`, { name: 'updated-instance', providerData: { code: code } }))
+    .then(r => provisioner.delete(id, baseUrl));
+};
+
 const opts = { schema: instanceSchema };
 
 suite.forPlatform('elements/instances', opts, (test) => {
@@ -35,4 +55,5 @@ suite.forPlatform('elements/instances', opts, (test) => {
     return cloud.get('elements/jira')
       .then(r => crudInstance(`elements/${r.body.id}/instances`, instanceSchema));
   });
+  it('should support update with reprovision by key', () => updateInstanceWithReprovision('/instances', instanceSchema));
 });

--- a/test/core/provisioner.test.js
+++ b/test/core/provisioner.test.js
@@ -226,6 +226,16 @@ describe('provisioner', () => {
       .then(r => mockery.disable());
   });
 
+  it('should allow partially provisioning an oauth2 element instance', () => {
+    setupProps();
+    return provisioner.partialOauth('myoauth2element')
+      .then(r => {
+        expect(r).to.exist;
+        expect(r).to.equal('speakercity');
+      })
+      .then(r => mockery.disable());
+  });
+
   it('should throw an error for provisioning an oauth1 element with external', () => {
     setupProps();
     return provisioner.create('myoauth1external')


### PR DESCRIPTION
## Highlights
* Test out `PUT` and `PATCH` of `/instances/{id}` with `providerData` in order to re-authenticate.

```
churros test platform/elements --file instances --test 'update with reprovision'          ✓  4232  11:15:58


  elements/instances
    ✓ should support update with reprovision by key (61301ms)


  1 passing (1m)
```