### PR TITLE
Tests for saving sample data for resource and parameter level

### DIFF
--- a/src/test/platform/elements/assets/common.js
+++ b/src/test/platform/elements/assets/common.js
@@ -54,7 +54,8 @@ exports.genResource = (opts) => new Object({
   method: (opts.method || 'GET'),
   vendorPath: (opts.path || '/getChurros'),
   vendorMethod: (opts.vendorMethod || 'GET'),
-  description: (opts.description || 'A Churros resource')
+  description: (opts.description || 'A Churros resource'),
+  response:  (opts.response || null)
 });
 
 exports.genParameter = (opts) => new Object({
@@ -63,6 +64,7 @@ exports.genParameter = (opts) => new Object({
   vendorName: (opts.vendorName || 'theParam'),
   vendorType: (opts.vendorType || 'query'),
   description: (opts.description || 'A Churros parmeter'),
+  sampleData: (opts.sampleData || null),
   dataType: 'string',
   vendorDataType: 'string'
 });
@@ -89,6 +91,17 @@ exports.crudSubResource = (url, schema, listSchema, payload, updatePayload) => {
   let subResource;
   return cloud.post(url, payload, schema)
     .then(r => subResource = r.body)
+    .then(r => cloud.get(url, listSchema))
+    .then(r => cloud.put(url + '/' + subResource.id, updatePayload, schema))
+    .then(r => cloud.delete(url + '/' + subResource.id));
+};
+
+
+exports.crudsResource = (url, schema, listSchema, payload, updatePayload) => {
+  let subResource;
+  return cloud.post(url, payload, schema)
+    .then(r => subResource = r.body)
+    .then(r => cloud.get(url + '/' + subResource.id))
     .then(r => cloud.get(url, listSchema))
     .then(r => cloud.put(url + '/' + subResource.id, updatePayload, schema))
     .then(r => cloud.delete(url + '/' + subResource.id));

--- a/src/test/platform/elements/resourceParameters.js
+++ b/src/test/platform/elements/resourceParameters.js
@@ -21,5 +21,8 @@ suite.forPlatform('elements/resources/parameters', opts, (test) => {
   it('should support CRUD by key', () => common.crudSubResource(keyUrl, schema, listSchema, common.genParameter({}), common.genParameter({ description: "An updated Churros parameter" })));
   it('should support CRUD by ID', () => common.crudSubResource(idUrl, schema, listSchema, common.genParameter({}), common.genParameter({ description: "An updated Churros parameter" })));
 
+  it('should support CRUD by key with sample data', () => common.crudSubResource(keyUrl, schema, listSchema, common.genParameter({}), common.genParameter({ description: "An updated Churros parameter", sampleData: "testKey=1" })));
+  it('should support CRUD by ID with sample data', () => common.crudSubResource(idUrl, schema, listSchema, common.genParameter({}), common.genParameter({ description: "An updated Churros parameter", sampleData: "testKey=1" })));
+
   after(() => cloud.delete('elements/' + element.key));
 });

--- a/src/test/platform/elements/resources.js
+++ b/src/test/platform/elements/resources.js
@@ -8,6 +8,7 @@ const listSchema = require('./assets/element.resources.schema.json');
 
 const opts = { payload: common.genResource({}), schema: schema };
 
+
 suite.forPlatform('elements/resources', opts, (test) => {
   let element, keyUrl, idUrl;
   before(() => common.deleteElementByKey('churros')
@@ -16,8 +17,11 @@ suite.forPlatform('elements/resources', opts, (test) => {
     .then(r => keyUrl = `elements/${element.key}/resources`)
     .then(r => idUrl = `elements/${element.id}/resources`));
 
-  it('should support CRUD by key', () => common.crudSubResource(keyUrl, schema, listSchema, common.genResource({}), common.genResource({ description: "An updated Churros resource" })));
-  it('should support CRUD by ID', () => common.crudSubResource(idUrl, schema, listSchema, common.genResource({}), common.genResource({ description: "An updated Churros resource" })));
+  it('should support CRUD by key', () => common.crudsResource(keyUrl, schema, listSchema, common.genResource({}), common.genResource({ description: "An updated Churros resource" })));
+  it('should support CRUD by ID', () => common.crudsResource(idUrl, schema, listSchema, common.genResource({}), common.genResource({ description: "An updated Churros resource" })));
+
+  it('should support CRUD by key with sample data', () => common.crudsResource(keyUrl, schema, listSchema, common.genResource({}), common.genResource({ description: "An updated Churros resource", response: { sampleData: "{\"key\": \"value\"}"} })));
+  it('should support CRUD by ID with sample data', () => common.crudsResource(idUrl, schema, listSchema, common.genResource({}), common.genResource({ description: "An updated Churros resource", response: { sampleData :"{\"key\": \"value\"}"} })));
 
   after(() => cloud.delete(`elements/${element.key}`));
 });


### PR DESCRIPTION
## Highlights
* Saving sample data for resource and parameter
* API tests for for /elements/{id}/resources/{resources}

## Examples
```
churros test platform/elements  --test 'resources'
  elements/resources/hooks
    ✓ should support CRUD by key (326ms)
    ✓ should support CRUD by ID (306ms)

  elements/resources/models
    ✓ should support CRUD by key (322ms)
    ✓ should support CRUD by ID (388ms)
    ✓ request swagger should support CRUD by key (337ms)
    ✓ request swagger should support CRUD by ID (311ms)

  elements/resources/parameters
    ✓ should support CRUD by key (348ms)
    ✓ should support CRUD by ID (323ms)
    ✓ should support CRUD by key with sample data (329ms)
    ✓ should support CRUD by ID with sample data (320ms)

  elements/resources
    ✓ should support CRUD by key (412ms)
    ✓ should support CRUD by ID (426ms)
    ✓ should support CRUD by key with sample data (437ms)
    ✓ should support CRUD by ID with sample data (466ms)
```
