### PR TITLE
add tests for the CWE 693 pen test fix

### DIFF
--- a/src/test/platform/general/headers.js
+++ b/src/test/platform/general/headers.js
@@ -1,0 +1,18 @@
+'use strict';
+
+const suite = require('core/suite');
+const props = require('core/props');
+const chakram = require('chakram');
+const expect = chakram.expect;
+
+suite.forPlatform('general', {}, (test) => {
+  describe('endpoint calls', () => {
+    it('should include x-frame-options header to a JSP endpoint', () =>
+      chakram.get('/elements/jsp/login.jsp', { baseUrl: props.get('url') })
+      .then(r => expect(r).to.have.header('x-frame-options')));
+
+    it('should not include x-frame-options header to a non-JSP endpoint', () =>
+      chakram.get('/elements/api-docs', { baseUrl: props.get('url') })
+      .then(r => expect(r).to.not.have.header('x-frame-options')));
+  });
+});


### PR DESCRIPTION
## Highlights
* New tests to check that the `X-Frame-Options` header exists for JSP endpoints, but not for others.

