### PR TITLE
Tests for adding operationId to resources

### DIFF
--- a/src/test/platform/elements/assets/common.js
+++ b/src/test/platform/elements/assets/common.js
@@ -49,14 +49,16 @@ exports.genJdbcBaseUrlConfig = (opts) => new Object({
   type: 'TEXTFIELD_1000'
 });
 
-exports.genResource = (opts) => new Object({
-  path: (opts.path || '/churros'),
-  method: (opts.method || 'GET'),
-  vendorPath: (opts.path || '/getChurros'),
-  vendorMethod: (opts.vendorMethod || 'GET'),
-  description: (opts.description || 'A Churros resource'),
-  response:  (opts.response || null)
-});
+exports.genResource = (opts) => {
+  opts = opts || {};
+  opts.path = (opts.path || '/churros');
+  opts.method = (opts.method || 'GET');
+  opts.vendorPath = (opts.path || '/getChurros');
+  opts.vendorMethod = (opts.vendorMethod || 'GET');
+  opts.description = (opts.description || 'A Churros resource');
+  opts.response = (opts.response || null);
+  return opts;
+};
 
 exports.genParameter = (opts) => new Object({
   name: (opts.name || 'param'),

--- a/src/test/platform/elements/resources.js
+++ b/src/test/platform/elements/resources.js
@@ -20,8 +20,8 @@ suite.forPlatform('elements/resources', opts, (test) => {
   it('should support CRUD by key', () => common.crudsResource(keyUrl, schema, listSchema, common.genResource({}), common.genResource({ description: "An updated Churros resource" })));
   it('should support CRUD by ID', () => common.crudsResource(idUrl, schema, listSchema, common.genResource({}), common.genResource({ description: "An updated Churros resource" })));
 
-  it('should support CRUD by key with sample data', () => common.crudsResource(keyUrl, schema, listSchema, common.genResource({}), common.genResource({ description: "An updated Churros resource", response: { sampleData: "{\"key\": \"value\"}"} })));
-  it('should support CRUD by ID with sample data', () => common.crudsResource(idUrl, schema, listSchema, common.genResource({}), common.genResource({ description: "An updated Churros resource", response: { sampleData :"{\"key\": \"value\"}"} })));
+  it('should support CRUD by key with sample data and other optional fields', () => common.crudsResource(keyUrl, schema, listSchema, common.genResource({}), common.genResource({ description: "An updated Churros resource", response: { sampleData: "{\"key\": \"value\"}"}, operationId: "getChurrosById" })));
+  it('should support CRUD by ID with sample data and other optional fields', () => common.crudsResource(idUrl, schema, listSchema, common.genResource({}), common.genResource({ description: "An updated Churros resource", response: { sampleData :"{\"key\": \"value\"}"}, operationId: "getChurrosByKey" })));
 
   after(() => cloud.delete(`elements/${element.key}`));
 });


### PR DESCRIPTION
## Highlights
* Tests for adding operationId to resources

## Examples

```
  elements/resources/hooks
    ✓ should support CRUD by key (311ms)
    ✓ should support CRUD by ID (328ms)

  elements/resources/models
    ✓ should support CRUD by key (317ms)
    ✓ should support CRUD by ID (319ms)
    ✓ request swagger should support CRUD by key (315ms)
    ✓ request swagger should support CRUD by ID (320ms)

  elements/resources/parameters
    ✓ should support CRUD by key (327ms)
    ✓ should support CRUD by ID (312ms)
    ✓ should support CRUD by key with sample data (319ms)
    ✓ should support CRUD by ID with sample data (309ms)

  elements/resources
    ✓ should support CRUD by key (398ms)
    ✓ should support CRUD by ID (412ms)
    ✓ should support CRUD by key with sample data and other optional fields (405ms)
    ✓ should support CRUD by ID with sample data and other optional fields (399ms)


  14 passing (7s)

```
