### PR TITLE
Connectwise CRM Tests

### DIFF
--- a/src/test/elements/connectwisecrm/assets/contacts.json
+++ b/src/test/elements/connectwisecrm/assets/contacts.json
@@ -1,0 +1,5 @@
+{
+    "firstName": "Churros",
+    "lastName": "Test",
+    "email": "churros@connectWise.com"
+}

--- a/src/test/elements/connectwisecrm/assets/organizations.json
+++ b/src/test/elements/connectwisecrm/assets/organizations.json
@@ -1,0 +1,12 @@
+{
+  "companyName": "Churros Company",
+  "companyIdentifier": "ChurrosCompany",
+  "defaultAddress": {
+    "city": "dallas",
+    "siteName": "www.churros.com",
+    "state": "TX",
+    "zip": "75001"
+  },
+  "market": "Information Technology",
+  "phoneNumber": "900123456"
+}

--- a/src/test/elements/connectwisecrm/assets/transformations.json
+++ b/src/test/elements/connectwisecrm/assets/transformations.json
@@ -16,14 +16,5 @@
         "vendorPath": "id"
       }
     ]
-  },
-  "incidents": {
-    "vendorName": "incidents",
-    "fields": [
-      {
-        "path": "id",
-        "vendorPath": "id"
-      }
-    ]
   }
 }

--- a/src/test/elements/connectwisecrm/assets/transformations.json
+++ b/src/test/elements/connectwisecrm/assets/transformations.json
@@ -1,0 +1,29 @@
+{
+  "contacts": {
+    "vendorName": "contacts",
+    "fields": [
+      {
+        "path": "id",
+        "vendorPath": "id"
+      }
+    ]
+  },
+  "organizations": {
+    "vendorName": "organizations",
+    "fields": [
+      {
+        "path": "id",
+        "vendorPath": "id"
+      }
+    ]
+  },
+  "incidents": {
+    "vendorName": "incidents",
+    "fields": [
+      {
+        "path": "id",
+        "vendorPath": "id"
+      }
+    ]
+  }
+}

--- a/src/test/elements/connectwisecrm/contacts.js
+++ b/src/test/elements/connectwisecrm/contacts.js
@@ -1,0 +1,10 @@
+'use strict';
+
+const suite = require('core/suite');
+const payload = require('./assets/contacts');
+
+suite.forElement('crm', 'contacts', { payload: payload }, (test) => {
+  test.should.supportCruds();
+  test.withOptions({ qs: { where: 'email=\'churros@connectWise.com\'' } }).should.return200OnGet();
+  test.should.supportPagination();
+});

--- a/src/test/elements/connectwisecrm/organizations.js
+++ b/src/test/elements/connectwisecrm/organizations.js
@@ -1,0 +1,10 @@
+'use strict';
+
+const suite = require('core/suite');
+const payload = require('./assets/organizations');
+
+suite.forElement('crm', 'organizations', { payload: payload }, (test) => {
+  test.should.supportCruds();
+  test.withOptions({ qs: { where: 'companyName=\'Churros Company\'' } }).should.return200OnGet();
+  test.should.supportPagination();
+});


### PR DESCRIPTION
## Highlights
* Connectwise CRM Tests for contacts and organizations

## Examples

```
 churros test elements/connectwisecrm

  contacts
    ✓ should allow CRUDS for /hubs/crm/contacts (9637ms)
    ✓ should allow GET for /hubs/crm/contacts (1227ms)
    ✓ should allow paginating with page and pageSize /hubs/crm/contacts (1056ms)

  organizations
    ✓ should allow CRUDS for /hubs/crm/organizations (7419ms)
    ✓ should allow GET for /hubs/crm/organizations (1045ms)
    ✓ should allow paginating with page and pageSize /hubs/crm/organizations (976ms)


  6 passing (27s)
```