### PR TITLE
Connectwise Helpdesk tests

### DIFF
--- a/src/test/elements/connectwisehd/assets/comments.json
+++ b/src/test/elements/connectwisehd/assets/comments.json
@@ -1,0 +1,8 @@
+{
+  "isExternalNote": true,
+  "isPartOfDetailDescription": true,
+  "isPartOfInternalAnalysis": true,
+  "isPartOfResolution": true,
+  "isExternalNote": true,
+  "noteText": "Hey, I am Churros"
+}

--- a/src/test/elements/connectwisehd/assets/contacts.json
+++ b/src/test/elements/connectwisehd/assets/contacts.json
@@ -1,0 +1,5 @@
+{
+    "firstName": "Churros",
+    "lastName": "Test",
+    "email": "churroshd@connectWise.com"
+}

--- a/src/test/elements/connectwisehd/assets/incidents.json
+++ b/src/test/elements/connectwisehd/assets/incidents.json
@@ -1,0 +1,7 @@
+{
+  "board":"Next Business Day",
+  "summary":"Sample API Posted Issue From Churros",
+  "statusName":"New (not responded)",
+  "companyIdentifier":"apparatus",
+  "contactName":"Hosting Support"
+}

--- a/src/test/elements/connectwisehd/assets/organizations.json
+++ b/src/test/elements/connectwisehd/assets/organizations.json
@@ -1,0 +1,12 @@
+{
+  "companyName": "Churros HD Company",
+  "companyIdentifier": "ChurrosHDCompany",
+  "defaultAddress": {
+    "city": "dallas",
+    "siteName": "www.churros.com",
+    "state": "TX",
+    "zip": "75001"
+  },
+  "market": "Information Technology",
+  "phoneNumber": "900123456"
+}

--- a/src/test/elements/connectwisehd/assets/transformations.json
+++ b/src/test/elements/connectwisehd/assets/transformations.json
@@ -1,0 +1,29 @@
+{
+  "contacts": {
+    "vendorName": "contacts",
+    "fields": [
+      {
+        "path": "id",
+        "vendorPath": "id"
+      }
+    ]
+  },
+  "incidents": {
+    "vendorName": "incidents",
+    "fields": [
+      {
+        "path": "id",
+        "vendorPath": "id"
+      }
+    ]
+  },
+  "organizations": {
+    "vendorName": "organizations",
+    "fields": [
+      {
+        "path": "id",
+        "vendorPath": "id"
+      }
+    ]
+  }
+}

--- a/src/test/elements/connectwisehd/contacts.js
+++ b/src/test/elements/connectwisehd/contacts.js
@@ -1,0 +1,10 @@
+'use strict';
+
+const suite = require('core/suite');
+const payload = require('./assets/contacts');
+
+suite.forElement('helpdesk', 'contacts', { payload: payload }, (test) => {
+  test.should.supportCruds();
+  test.withOptions({ qs: { where: 'email=\'churroshd@connectWise.com\'' } }).should.return200OnGet();
+  test.should.supportPagination();
+});

--- a/src/test/elements/connectwisehd/incidents.js
+++ b/src/test/elements/connectwisehd/incidents.js
@@ -1,0 +1,26 @@
+'use strict';
+
+const suite = require('core/suite');
+const payload = require('./assets/incidents');
+const commentsPayload = require('./assets/comments');
+const cloud = require('core/cloud');
+
+
+suite.forElement('helpdesk', 'incidents', { payload: payload }, (test) => {
+  test.should.supportCruds();
+  test.withOptions({ qs: { where: 'summary=\'Sample API Posted Issue From Churros\'' } }).should.return200OnGet();
+  test.should.supportPagination();
+
+  it('should allow CRU for /hubs/helpdesk/incidents/{id}/comments', () => {
+    let incidentId = -1;
+    let commentsId = -1;
+    return cloud.post(test.api, payload)
+      .then(r => incidentId = r.body.id)
+      .then(r => cloud.put(`${test.api}/${incidentId}/comments`, commentsPayload))
+      .then(r => commentsId = r.body.id)
+      .then(r => cloud.get(`${test.api}/${incidentId}/comments/${commentsId}`))
+      .then(r => cloud.patch(`${test.api}/${incidentId}/comments/${commentsId}`, {noteText: 'Hey, I am Churros, have fun', isPartOfResolution: true}))
+      .then(r => cloud.delete(`${test.api}/${incidentId}`));
+  });
+
+});

--- a/src/test/elements/connectwisehd/organizations.js
+++ b/src/test/elements/connectwisehd/organizations.js
@@ -1,0 +1,10 @@
+'use strict';
+
+const suite = require('core/suite');
+const payload = require('./assets/organizations');
+
+suite.forElement('helpdesk', 'organizations', { payload: payload }, (test) => {
+  test.should.supportCruds();
+  test.withOptions({ qs: { where: 'companyName=\'Churros HD Company\'' } }).should.return200OnGet();
+  test.should.supportPagination();
+});


### PR DESCRIPTION
## Highlights
* Connectwise Helpdesk tests for `contacts`, `incidents`, `incident/comments`, `organizations`

## Examples
```
  contacts
    ✓ should allow CRUDS for /hubs/helpdesk/contacts (8548ms)
    ✓ should allow GET for /hubs/helpdesk/contacts (1059ms)
    ✓ should allow paginating with page and pageSize /hubs/helpdesk/contacts (1601ms)

  incidents
    ✓ should allow CRUDS for /hubs/helpdesk/incidents (9010ms)
    ✓ should allow GET for /hubs/helpdesk/incidents (927ms)
    ✓ should allow paginating with page and pageSize /hubs/helpdesk/incidents (781ms)
    ✓ should allow CRU for /hubs/helpdesk/incidents/{id}/comments (5970ms)

  organizations
    ✓ should allow CRUDS for /hubs/helpdesk/organizations (6648ms)
    ✓ should allow GET for /hubs/helpdesk/organizations (725ms)
    ✓ should allow paginating with page and pageSize /hubs/helpdesk/organizations (819ms)


  10 passing (42s)
```