### PR TITLE
churros init should support environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,8 @@ that you want to initialize from. It can accept both local filesystem paths and 
   * `churros init --template /absolute/path/to/existing/sauce.json`
   * `churros init --template https://token@github.com/cloud-elements/churros-sauce/sauce.json`
 
-> __PROTIP:__ `node` version `5.4.0` is prone to showing messages like the one below.  Just ignore them...
+> __PROTIP:__ `node` version `5.4.0` is prone to showing messages like the one below. Just ignore them...
+
 ```bash
 npm WARN ENOENT ENOENT: no such file or directory, open '/blah/blah/blah/churros/src/core/package.json'
 ```

--- a/README.md
+++ b/README.md
@@ -41,7 +41,14 @@ that you want to initialize from. It can accept both local filesystem paths and 
   * `churros init --template /absolute/path/to/existing/sauce.json`
   * `churros init --template https://token@github.com/cloud-elements/churros-sauce/sauce.json`
 
-> __PROTIP:__ `node` version `5.4.0` is prone to showing messages like the one below. Just ignore them...
+> __PROTIP:__ You can set environment variables so that `churros init` does not prompt:
+  * `CHURROS_USER`
+  * `CHURROS_PASSWORD`
+  * `CHURROS_URL`
+  * `CHURROS_TEMPLATE`
+
+> __PROTIP:__ `node` version `5.4.0` is prone to showing messages like the one below. Just ignore
+them...
 
 ```bash
 npm WARN ENOENT ENOENT: no such file or directory, open '/blah/blah/blah/churros/src/core/package.json'

--- a/src/cli/churros-init.js
+++ b/src/cli/churros-init.js
@@ -4,7 +4,11 @@ const commander = require('commander');
 const fs = require('fs');
 const github = new require('github')({});
 const inquirer = require('inquirer');
-const optimist = require('optimist');
+const optimist = require('optimist')
+  .default('user', process.env.CHURROS_USER)
+  .default('password', process.env.CHURROS_PASSWORD)
+  .default('url', process.env.CHURROS_URL)
+  .default('template', process.env.CHURROS_TEMPLATE);
 const url = require('url');
 
 commander


### PR DESCRIPTION
## Highlights
* `churros init` order of precedence is now CLI options, environment variables, and finally prompting.

## Examples
* `export CHURROS_USER="rocky@cloud-elements.com"`
* `export CHURROS_PASSWORD="password"`
* `export CHURROS_URL="api.cloud-elements.com"`
* `export CHURROS_TEMPLATE="https://token@github.com/cloud-elements/churros-sauce/sauce.json"`