### PR TITLE
Fix init template source detection bug

### DIFF
--- a/src/cli/churros-init.js
+++ b/src/cli/churros-init.js
@@ -46,7 +46,7 @@ const saveSauce = (answers) => {
   };
 
   const template = (frm, to) => new Promise ((resolve, reject) => {
-    if (frm.indexOf('https') >= 0) {
+    if (frm.indexOf('https') === 0) {
       const purl = url.parse(frm);
       const token = purl.auth;
       const user = purl.pathname.split('/')[1];


### PR DESCRIPTION
## Highlights
* Upon `init` and using a template, this fixes an issue in which using local filesystem paths that include `https` would be incorrectly matched as github repos