### PR TITLE
Create the object definitions and transformation one at a time

### DIFF
--- a/src/test/elements/lifecycle.js
+++ b/src/test/elements/lifecycle.js
@@ -9,13 +9,9 @@ const fs = require('fs');
 const logger = require('winston');
 
 const createAll = (urlTemplate, list) => {
-  let promises = [];
-  Object.keys(list).forEach(key => {
-    const payload = list[key];
-    const url = util.format(urlTemplate, key);
-    promises.push(cloud.post(url, payload));
-  });
-  return Promise.all(promises);
+  return Object.keys(list).reduce((p, key) =>
+    p.then(() => cloud.post(util.format(urlTemplate, key), list[key])),
+    Promise.resolve(true)); // initial
 };
 
 const terminate = (error) => {


### PR DESCRIPTION
## Highlights
* Rather than flooding the endpoint with requests, process the object definition and transformation creations one at a time. Otherwise, running this locally tends to lock up Soba because there aren't enough threads or DB connections to handle it.
* Bonus: much more functional style 🎉 