### PR TITLE
Updated cron formula test to use a 30 second interval

### DIFF
--- a/src/test/platform/formulas/formulas.js
+++ b/src/test/platform/formulas/formulas.js
@@ -35,7 +35,7 @@ suite.forPlatform('formulas', opts, (test) => {
   it('should not allow an invalid cron for a "scheduled" trigger', () => {
     let formulaId;
     const f = common.genFormula({});
-    const t = common.genTrigger({ properties: { cron: '0 0/14 * 1/1 * ? *' } });
+    const t = common.genTrigger({ properties: { cron: '0/30 * * 1/1 * ? *' } });
     return cloud.post(test.api, f, schema)
       .then(r => formulaId = r.body.id)
       .then(r => cloud.post(`${test.api}/${formulaId}/triggers`, t, (r) => expect(r).to.have.statusCode(400)))


### PR DESCRIPTION
## Highlights
* Updated the cron string for the scheduled formula test, since the minimum allowable is now 1 minute.