### PR TITLE
Pipedrive Delete Filters

### DIFF
--- a/src/test/elements/pipedrive/filters.js
+++ b/src/test/elements/pipedrive/filters.js
@@ -7,7 +7,6 @@ const tools = require('core/tools');
 const cloud = require('core/cloud');
 const build = (overrides) => Object.assign({}, payload, overrides);
 const expect = chakram.expect;
-const opportunitiesPayload = build({ title: tools.random(), value: tools.randomInt() });
 
 
 

--- a/src/test/elements/pipedrive/filters.js
+++ b/src/test/elements/pipedrive/filters.js
@@ -1,0 +1,29 @@
+'use strict';
+
+const suite = require('core/suite');
+const chakram = require('chakram');
+const payload = require('./assets/opportunities');
+const tools = require('core/tools');
+const cloud = require('core/cloud');
+const build = (overrides) => Object.assign({}, payload, overrides);
+const expect = chakram.expect;
+const opportunitiesPayload = build({ title: tools.random(), value: tools.randomInt() });
+
+
+
+suite.forElement('crm', 'filters', (test) => {
+  let elements_total_count;
+
+
+    it('compare of pipedrive filters before and after get call', () => {
+      return cloud.get('/hubs/crm/filters')
+        .then(r => elements_total_count = r.response.headers['elements-returned-count'])
+        .then(r => cloud.withOptions({ qs: { where: 'title = \'Demo Deal NEW\'' } }).get('/hubs/crm/opportunities'))
+        .then(r => cloud.get('/hubs/crm/filters'))
+        .then(r => expect(r.response.headers['elements-returned-count']).to.equal(elements_total_count));
+
+
+  });
+
+
+});

--- a/src/test/elements/pipedrive/filters.js
+++ b/src/test/elements/pipedrive/filters.js
@@ -2,10 +2,7 @@
 
 const suite = require('core/suite');
 const chakram = require('chakram');
-const payload = require('./assets/opportunities');
-const tools = require('core/tools');
 const cloud = require('core/cloud');
-const build = (overrides) => Object.assign({}, payload, overrides);
 const expect = chakram.expect;
 
 

--- a/src/test/elements/pipedrive/opportunities.js
+++ b/src/test/elements/pipedrive/opportunities.js
@@ -15,7 +15,7 @@ suite.forElement('crm', 'opportunities', { payload: opportunitiesPayload }, (tes
   let elements_total_count;
 
 
-    it('should allow GET of Pipedrive filters', () => {
+    it('should allow get of pipedrive filters', () => {
         return cloud.get('/hubs/crm/filters')
         .then(r => elements_total_count = r.response.headers['elements-returned-count']);
 
@@ -35,7 +35,7 @@ suite.forElement('crm', 'opportunities', { payload: opportunitiesPayload }, (tes
   test.should.supportPagination();
   test.withOptions({ qs: { where: 'title = \'Demo Deal NEW\'' } }).should.return200OnGet();
 
-  it('Count of Pipedrive filters should remain the same', () => {
+  it('count of pipedrive filters should remain the same', () => {
       return cloud.get('/hubs/crm/filters')
       .then(r => expect(r.response.headers['elements-returned-count']).to.equal(elements_total_count));
 

--- a/src/test/elements/pipedrive/opportunities.js
+++ b/src/test/elements/pipedrive/opportunities.js
@@ -4,25 +4,10 @@ const suite = require('core/suite');
 const chakram = require('chakram');
 const payload = require('./assets/opportunities');
 const tools = require('core/tools');
-const cloud = require('core/cloud');
 const build = (overrides) => Object.assign({}, payload, overrides);
-const expect = chakram.expect;
 const opportunitiesPayload = build({ title: tools.random(), value: tools.randomInt() });
 
-
-
 suite.forElement('crm', 'opportunities', { payload: opportunitiesPayload }, (test) => {
-  let elements_total_count;
-
-
-    it('should allow get of pipedrive filters', () => {
-        return cloud.get('/hubs/crm/filters')
-        .then(r => elements_total_count = r.response.headers['elements-returned-count']);
-
-    });
-
-
-
   const options = {
     churros: {
       updatePayload: {
@@ -34,13 +19,4 @@ suite.forElement('crm', 'opportunities', { payload: opportunitiesPayload }, (tes
   test.withOptions(options).should.supportCruds(chakram.put);
   test.should.supportPagination();
   test.withOptions({ qs: { where: 'title = \'Demo Deal NEW\'' } }).should.return200OnGet();
-
-  it('count of pipedrive filters should remain the same', () => {
-      return cloud.get('/hubs/crm/filters')
-      .then(r => expect(r.response.headers['elements-returned-count']).to.equal(elements_total_count));
-
-
-  });
-
-
 });

--- a/src/test/elements/pipedrive/opportunities.js
+++ b/src/test/elements/pipedrive/opportunities.js
@@ -4,10 +4,25 @@ const suite = require('core/suite');
 const chakram = require('chakram');
 const payload = require('./assets/opportunities');
 const tools = require('core/tools');
+const cloud = require('core/cloud');
 const build = (overrides) => Object.assign({}, payload, overrides);
+const expect = chakram.expect;
 const opportunitiesPayload = build({ title: tools.random(), value: tools.randomInt() });
 
+
+
 suite.forElement('crm', 'opportunities', { payload: opportunitiesPayload }, (test) => {
+  let elements_total_count;
+
+
+    it('should allow GET of Pipedrive filters', () => {
+        return cloud.get('/hubs/crm/filters')
+        .then(r => elements_total_count = r.response.headers['elements-returned-count']);
+
+    });
+
+
+
   const options = {
     churros: {
       updatePayload: {
@@ -19,4 +34,13 @@ suite.forElement('crm', 'opportunities', { payload: opportunitiesPayload }, (tes
   test.withOptions(options).should.supportCruds(chakram.put);
   test.should.supportPagination();
   test.withOptions({ qs: { where: 'title = \'Demo Deal NEW\'' } }).should.return200OnGet();
+
+  it('Count of Pipedrive filters should remain the same', () => {
+      return cloud.get('/hubs/crm/filters')
+      .then(r => expect(r.response.headers['elements-returned-count']).to.equal(elements_total_count));
+
+
+  });
+
+
 });


### PR DESCRIPTION
## Highlights
* Added test to check that deleting filters works for Pipedrive
https://github.com/cloud-elements/soba/pull/4392
## Examples
* When a GET is performed with a `where` parameter, a filter is created.  This deletes that filter.
## Closes
* Closes #541
