### PR TITLE
Add missing returns

### DIFF
--- a/src/test/elements/jira/agents.js
+++ b/src/test/elements/jira/agents.js
@@ -6,7 +6,7 @@ const cloud = require('core/cloud');
 suite.forElement('helpdesk', 'agents', (test) => {
   let agentId;
   it('should allow get for /agents', () => {
-    cloud.withOptions({qs:{where:`username='test'`}}).get('/hubs/helpdesk/agents') 
+    return cloud.withOptions({qs:{where:`username='test'`}}).get('/hubs/helpdesk/agents')
     .then(r => cloud.withOptions({qs:{where:`username='test'`, page: 1, pageSize: 1 }}).get('/hubs/helpdesk/agents'))
     .then(r => agentId = r.body[0].key)
     .then(r => cloud.get("/hubs/helpdesk/agents/" + agentId));

--- a/src/test/elements/jira/fields.js
+++ b/src/test/elements/jira/fields.js
@@ -6,7 +6,7 @@ const payload = require('./assets/field');
 
 suite.forElement('helpdesk', 'fields', {skip: true, payload:payload}, (test) => {
   it('should allow create and get of fields', () => {
-    cloud.post("/hubs/helpdesk/fields", payload)
+    return cloud.post("/hubs/helpdesk/fields", payload)
     .then(cloud.get("/hubs/helpdesk/fields"));
   });
 });

--- a/src/test/elements/jira/incidentTypes.js
+++ b/src/test/elements/jira/incidentTypes.js
@@ -12,7 +12,7 @@ updatePayload.name = payload.name;
 suite.forElement('helpdesk', 'incidentTypes', {payload:payload}, (test) => {
   it('should allow CRUDS for /incidents-types', () => {
   let incidentTypeId;
-  cloud.post(uri, payload)
+  return cloud.post(uri, payload)
   .then(r => incidentTypeId = r.body.id)
   .then(r => cloud.withOptions({qs:{ page: 1, pageSize: 1 }}).get('/hubs/helpdesk/incident-types'))
   .then(r => cloud.withOptions({qs:{ where: `id='${incidentTypeId}'` }}).get('/hubs/helpdesk/incident-types'))

--- a/src/test/elements/jira/priorities.js
+++ b/src/test/elements/jira/priorities.js
@@ -7,7 +7,7 @@ const uri = '/hubs/helpdesk/priorities';
 suite.forElement('helpdesk', 'priorities', (test) => {
 let priorityId;
   it('should allow CRUDS for /priorities', () => {
-    cloud.get(uri)
+    return cloud.get(uri)
     .then(r => priorityId = r.body[0].id)
     .then(r => cloud.get(uri + '/' + priorityId));
   });

--- a/src/test/elements/jira/statuses.js
+++ b/src/test/elements/jira/statuses.js
@@ -7,7 +7,7 @@ const uri = '/hubs/helpdesk/statuses';
 suite.forElement('helpdesk', 'statuses', (test) => {
 let statusId;
   it('should allow CRUDS for /statuses', () => {
-    cloud.get(uri)
+    return cloud.get(uri)
     .then(r => statusId = r.body[0].id)
     .then(r => cloud.get(uri + '/' + statusId));
   });


### PR DESCRIPTION
## Highlights
* I noticed (because I had the same problem in some tests I wrote), that these tests lack a return of the promise, which causes the framework to assume that the code is synchronous and that it can immediately return which results in none of the assertions being run and making it look like it's been successful when it may not have been.
