### PR TITLE
Add a test for console.log() on a failed JS step

### DIFF
--- a/src/test/platform/formulas/assets/formulas/script-with-on-failure-successful-formula.json
+++ b/src/test/platform/formulas/assets/formulas/script-with-on-failure-successful-formula.json
@@ -9,7 +9,7 @@
             "name": "bad-script-step",
             "type": "script",
             "properties": {
-                "body": "This is an invalid script step;"
+                "body": "console.log('print'); throw('This is an invalid script step');"
             }
         },
         {

--- a/src/test/platform/formulas/executions.js
+++ b/src/test/platform/formulas/executions.js
@@ -454,6 +454,22 @@ suite.forPlatform('formulas', { name: 'formula executions' }, (test) => {
     return eventTriggerTest('script-with-on-failure-successful-formula', 1, 3, validator);
   });
 
+  it('should support logging on a script step that fails', () => {
+    const validator = (executions) => {
+      executions.map(e => {
+        const ses = e.stepExecutions;
+        expect(ses).to.have.length(3);
+        ses.filter(se => se.stepName === 'bad-script-step').map(validateErrorStepExecution);
+
+        const consolidated = consolidateStepExecutionValues(ses);
+        expect(consolidated['bad-script-step.error']).to.contains('This is an invalid script step');
+        expect(consolidated['bad-script-step.console']).to.contains('print');
+      });
+    };
+
+    return eventTriggerTest('script-with-on-failure-successful-formula', 1, 3, validator);
+  });
+
   it('should show a successful execution, even if the last step is a filter step that returns false', () => eventTriggerTest('filter-returns-false', 1, 2));
 
   it('should support a manual trigger type on a formula', () => {

--- a/src/test/platform/formulas/executions.js
+++ b/src/test/platform/formulas/executions.js
@@ -454,7 +454,7 @@ suite.forPlatform('formulas', { name: 'formula executions' }, (test) => {
     return eventTriggerTest('script-with-on-failure-successful-formula', 1, 3, validator);
   });
 
-  it('should support logging on a script step that fails', () => {
+  it('should return any console.log statements on a script step that fails', () => {
     const validator = (executions) => {
       executions.map(e => {
         const ses = e.stepExecutions;


### PR DESCRIPTION
## Highlights
* Add a new test to validate that console.log() statements are still returned when a script step fails.