### PR TITLE
Updated incidents tests in Jira

### DIFF
--- a/src/test/elements/jira/incidents.js
+++ b/src/test/elements/jira/incidents.js
@@ -4,7 +4,7 @@ const suite = require('core/suite');
 const cloud = require('core/cloud');
 const payload = require('./assets/incidents');
 const commentPayload = require('./assets/incidentComments');
- const notifyPayload= require('./assets/notification');
+const notifyPayload = require('./assets/notification');
 suite.forElement('helpdesk', 'incidents', { payload: payload }, (test) => {
 
   it('should allow CRUDS for /incidents/:id/comments', () => {
@@ -15,18 +15,21 @@ suite.forElement('helpdesk', 'incidents', { payload: payload }, (test) => {
       .then(r => cloud.delete('/hubs/helpdesk/incidents/' + incidentId));
   });
 
-  it('should allow CRUDS for /incidents/:id/attachments and RD for /attachments', () => {
+  it('should allow CRDS for /incidents/:id/attachments and RD for /attachments and SR for /incidents/:id/history', () => {
     let query = { fileName: "testfile.txt" };
-    let incidentId, attachmentId;
-   
+    let incidentId, attachmentId, historyId;
+
     return cloud.post('/hubs/helpdesk/incidents', payload)
       .then(r => incidentId = r.body.id)
       .then(r => cloud.withOptions({ qs: query }).postFile('hubs/helpdesk/incidents/' + incidentId + '/attachments', __dirname + '/assets/attach.txt'))
       .then(r => cloud.get('/hubs/helpdesk/incidents/' + incidentId + '/attachments'))
       .then(r => attachmentId = r.body[0].id)
       .then(r => cloud.get('/hubs/helpdesk/attachments/' + attachmentId))
+      .then(r => cloud.get(`${test.api}/${incidentId}/history`))
+      .then(r => historyId = r.body[0].id)
+      .then(r => cloud.get(`${test.api}/${incidentId}/history/${historyId}`))
       .then(r => cloud.delete('/hubs/helpdesk/attachments/' + attachmentId))
-      .then(r => cloud.post('/hubs/helpdesk/incidents/' + incidentId + '/notifications',notifyPayload))
+      .then(r => cloud.post('/hubs/helpdesk/incidents/' + incidentId + '/notifications', notifyPayload))
       .then(r => cloud.delete(test.api + '/' + incidentId));
   });
   test.should.supportCruds();


### PR DESCRIPTION
## Highlights
* Added SR /incidents/:id/history tests

## Examples
```
info: Running tests for element: jira
  incidents
    ✓ should allow CRUDS for /incidents/:id/comments (5395ms)
    ✓ should allow CRDS for /incidents/:id/attachments and RD for /attachments and SR for /incidents/:id/history (9323ms)
    ✓ should allow CRUDS for /hubs/helpdesk/incidents (7397ms)
    ✓ should allow paginating with page and pageSize /hubs/helpdesk/incidents (438ms)
    ✓ should support searching /hubs/helpdesk/incidents by id (2219ms)