### PR TITLE
Updated churros tests for Facebook Lead Ads (#4144)

### DIFF
--- a/src/test/elements/facebookleadads/pages.js
+++ b/src/test/elements/facebookleadads/pages.js
@@ -4,11 +4,19 @@ const suite = require('core/suite');
 const cloud = require('core/cloud');
 
 suite.forElement('marketing', 'pages', null, (test) => {
+  let pageId;
   test.should.supportSr();
   it('should allow R for /hubs/marketing/leads', () => {
-    let pageId;
     return cloud.get(test.api)
       .then(r => pageId = r.body[0].id)
       .then(r => cloud.get(`/hubs/marketing/leads/${pageId}`));
+  });
+
+  it(`should allow CR for ${test.api}/${pageId}/subscribed-apps`, () => {
+    let accessToken;
+    return cloud.get(test.api)
+      .then(r => accessToken = r.body[0].access_token)
+      .then(r => cloud.withOptions({ qs: { access_token: accessToken } }).get(`${test.api}/${pageId}/subscribed-apps`))
+      .then(r => cloud.withOptions({ qs: { access_token: accessToken } }).post(`${test.api}/${pageId}/subscribed-apps`));
   });
 });

--- a/src/test/elements/facebookleadads/ping.js
+++ b/src/test/elements/facebookleadads/ping.js
@@ -1,0 +1,7 @@
+'use strict';
+
+const suite = require('core/suite');
+
+suite.forElement('marketing', 'ping', (test) => {
+  test.should.return200OnGet();
+});


### PR DESCRIPTION
## Highlights
* Updated the churros tests for Facebook Lead Ads

## Examples
- POST /pages/{pageId}/subscribed-apps 
- GET /pages/{pageId}/subscribed-apps resources
- GET /ping
