### PR TITLE
Signup Partners Test

### DIFF
--- a/src/test/platform/signup/assets/userpayload.json
+++ b/src/test/platform/signup/assets/userpayload.json
@@ -1,0 +1,6 @@
+{
+  "email": "bobTestuser@c-e.com",
+  "firstName": "bob",
+  "lastName": "by",
+  "password":"test12345"
+}

--- a/src/test/platform/signup/signup-partners.js
+++ b/src/test/platform/signup/signup-partners.js
@@ -1,0 +1,8 @@
+'use strict';
+const suite = require('core/suite');
+const payload = require('./assets/userpayload.json');
+
+
+suite.forPlatform('signup-partners',{payload:payload}, (test) => {
+  test.withOptions(payload).should.return400OnPost();
+});

--- a/src/test/platform/signup/signup-partners.js
+++ b/src/test/platform/signup/signup-partners.js
@@ -1,8 +1,15 @@
 'use strict';
 const suite = require('core/suite');
 const payload = require('./assets/userpayload.json');
+const cloud = require('core/cloud');
+const chakram = require('chakram');
+const expect = chakram.expect;
+
 
 
 suite.forPlatform('signup-partners',{payload:payload}, (test) => {
-  test.withOptions(payload).should.return400OnPost();
+  it('should respond with 401', () => {
+      return cloud.post('/signup-partners',payload, (r) => expect(r).to.have.statusCode(401));
+    });
+
 });


### PR DESCRIPTION
## Highlights
* Tests for POST /signup-partners API

## Examples
Test should return 401 for unauthorized users
