### PR TITLE
CE-4146: Added churros tests for GET /envelopes/{id}/custom_fields API

### DIFF
--- a/src/test/elements/docusign/envelopes.js
+++ b/src/test/elements/docusign/envelopes.js
@@ -22,7 +22,8 @@ suite.forElement('esignature', 'envelopes', (test) => {
     return cloud.withOptions(opts).postFile(test.api, path)
       .then(r => envelopeId = r.body.envelopeId)
       .then(r => cloud.get(`${test.api}/${envelopeId}`, (r) => expect(r).to.have.schemaAnd200(schema)))
-      .then(r => cloud.patch(`${test.api}/${envelopeId}`, updatePayload, (r) => expect(r).to.have.statusCode(200)));
+      .then(r => cloud.patch(`${test.api}/${envelopeId}`, updatePayload, (r) => expect(r).to.have.statusCode(200)))
+      .then(r => cloud.get(`${test.api}/${envelopeId}/custom_fields`));
   });
 
   it(`should support C on ${test.api}, SRU ${test.api}/:id/documents`, () => {


### PR DESCRIPTION
## Highlights
* Added churros tests for GET /envelopes/{id}/custom_fields API

## Examples
- GET /envelopes/{id}/custom_fields
