### PR TITLE
Element metadata changes for Mendeleev

### DIFF
--- a/src/test/platform/elements/assets/element.metadata.expanedschema.json
+++ b/src/test/platform/elements/assets/element.metadata.expanedschema.json
@@ -1,0 +1,271 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "integer"
+    },
+    "name": {
+      "type": "string"
+    },
+    "key": {
+      "type": "string"
+    },
+    "image": {
+      "type": "string"
+    },
+    "displayOrder": {
+      "type": "integer"
+    },
+    "active": {
+      "type": "boolean"
+    },
+    "beta": {
+      "type": "boolean"
+    },
+    "description": {
+      "type": "string"
+    },
+    "transformations": {
+      "type": "boolean"
+    },
+    "elementType": {
+      "type": "string"
+    },
+    "churros": {
+      "type": "boolean"
+    },
+    "normalizedPaging": {
+      "type": "boolean"
+    },
+    "swaggerValidated": {
+      "type": "boolean"
+    },
+    "cloneable": {
+      "type": "boolean"
+    },
+    "authenticationType": {
+      "type": "string"
+    },
+    "events": {
+      "type": "object",
+      "properties": {
+        "supported": {
+          "type": "boolean"
+        },
+        "methods": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "required": [
+        "supported",
+        "methods"
+      ]
+    },
+    "discovery": {
+      "type": "object",
+      "properties": {
+        "customFields": {
+          "type": "boolean"
+        },
+        "customObjects": {
+          "type": "boolean"
+        },
+        "endpointCustomFields": {
+          "type": "boolean"
+        },
+        "endpointCustomObjects": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "customFields",
+        "customObjects",
+        "endpointCustomFields",
+        "endpointCustomObjects"
+      ]
+    },
+    "bulk": {
+      "type": "object",
+      "properties": {
+        "upload": {
+          "type": "boolean"
+        },
+        "download": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "upload",
+        "download"
+      ]
+    },
+    "usage": {
+      "type": "object",
+      "properties": {
+        "instanceCount": {
+          "type": "integer"
+        },
+        "customerCount": {
+          "type": "integer"
+        },
+        "traffic": {
+          "type": "integer"
+        }
+      },
+      "required": [
+        "instanceCount",
+        "customerCount",
+        "traffic"
+      ]
+    },
+    "api": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string"
+        },
+        "contentType": {
+          "type": "string"
+        }
+      }
+    },
+    "resources": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "canonicalName": {
+            "type": "string"
+          },
+          "operations": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "events": {
+            "type": "object",
+            "properties": {
+              "supported": {
+                "type": "boolean"
+              },
+              "methods": {
+                "type": "array",
+                "items": {}
+              },
+              "eventTypes": {
+                "type": "array",
+                "items": {}
+              }
+            },
+            "required": [
+              "supported",
+              "methods",
+              "eventTypes"
+            ]
+          },
+          "bulk": {
+            "type": "object",
+            "properties": {
+              "upload": {
+                "type": "object",
+                "properties": {
+                  "supported": {
+                    "type": "boolean"
+                  },
+                  "native": {
+                    "type": "boolean"
+                  }
+                },
+                "required": [
+                  "supported",
+                  "native"
+                ]
+              },
+              "download": {
+                "type": "object",
+                "properties": {
+                  "supported": {
+                    "type": "boolean"
+                  },
+                  "native": {
+                    "type": "boolean"
+                  }
+                },
+                "required": [
+                  "supported",
+                  "native"
+                ]
+              }
+            },
+            "required": [
+              "upload",
+              "download"
+            ]
+          },
+          "customField": {
+            "type": "object",
+            "properties": {
+              "get": {
+                "type": "boolean"
+              },
+              "create": {
+                "type": "boolean"
+              },
+              "update": {
+                "type": "boolean"
+              },
+              "delete": {
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "get",
+              "create",
+              "update",
+              "delete"
+            ]
+          }
+        },
+        "required": [
+          "canonicalName",
+          "operations",
+          "events",
+          "bulk",
+          "customField"
+        ]
+      }
+    },
+    "hub": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "id",
+    "name",
+    "key",
+    "image",
+    "displayOrder",
+    "active",
+    "beta",
+    "description",
+    "transformations",
+    "elementType",
+    "churros",
+    "normalizedPaging",
+    "swaggerValidated",
+    "cloneable",
+    "authenticationType",
+    "events",
+    "discovery",
+    "bulk",
+    "usage",
+    "api",
+    "resources",
+    "hub"
+  ]
+}

--- a/src/test/platform/elements/metadata.js
+++ b/src/test/platform/elements/metadata.js
@@ -4,14 +4,27 @@ const expect = require('chakram').expect;
 const suite = require('core/suite');
 const cloud = require('core/cloud');
 const metadataSchema = require('./assets/element.metadata.schema.json');
+const metadataExpandedSchema = require('./assets/element.metadata.expanedschema.json');
 
 const opts = { schema: metadataSchema };
 
 suite.forPlatform('elements/metadata', opts, (test) => {
 
+  it('should get all elements metadata', () => {
+    return cloud.get('elements/metadata', (r) => {
+      expect(r).to.have.statusCode(200);
+      expect(r.body).to.not.be.empty;
+    });
+  });
+
   it('should return element metadata', () => {
     return cloud.get('elements/sfdc')
       .then(r => cloud.get(`elements/${r.body.id}/metadata`, metadataSchema));
+  });
+
+  it('should return element metadata for exapnd', () => {
+    return cloud.get('elements/sfdc')
+      .then(r => cloud.get(`elements/${r.body.id}/metadata?expand=true`, metadataExpandedSchema));
   });
 
   it('should return 404 for invalid element ID', () => {


### PR DESCRIPTION
## Highlights
* New schema validation for additional fields
* Added missing get all elements metadata

## Examples
```
  elements/metadata
    ✓ should get all elements metadata (172ms)
    ✓ should return element metadata (227ms)
    ✓ should return element metadata for exapnd (248ms)
    ✓ should return 404 for invalid element ID (65ms)
    ✓ should return polling event metadata for polling element (175ms)
    ✓ should return webhook event metadata for webhook element (271ms)
```
