### PR TITLE
Added test to ensure that a 401 is thrown for api calls against a deleted instance

### DIFF
--- a/src/test/platform/elements/instances.js
+++ b/src/test/platform/elements/instances.js
@@ -178,4 +178,12 @@ suite.forPlatform('elements/instances', opts, (test) => {
       .then(r => expect(r.body.name).to.equal('churros-xss-updated'))
       .then(() => provisioner.delete(id));
   });
+
+  it('should fail with 401 for deleted instance api call', () => {
+    let instanceId;
+    return provisioner.create('sfdc')
+      .then(r => instanceId = r.body.id)
+      .then(() => provisioner.delete(instanceId))
+      .then(() => cloud.get('hubs/crm/account?pageSize=1', (r) => expect(r).to.have.statusCode(401)));
+  });
 });


### PR DESCRIPTION
## Highlights
* A  401 should be thrown when API calls are made against a deleted element instance.

## Closes
* Closes #617 
