### PR TITLE
AWS Autopublish skip

### DIFF
--- a/src/test/platform/publishing/publishing.js
+++ b/src/test/platform/publishing/publishing.js
@@ -52,7 +52,7 @@ suite.forPlatform('publishing', { payload: payload }, (test) => {
   });
 
 
-  it('should allow AWS lambda autogenerate and deploy to AWS ', () => {
+  it.skip('should allow AWS lambda autogenerate and deploy to AWS ', () => {
     let publishPayload = getPublishSdkPayload();
     publishPayload.publishMetaData.amazons3InstanceId = s3InstanceId;
     publishPayload.publishMetaData.cloudformationInstanceId = awscfInstanceId;


### PR DESCRIPTION

## Highlights
* Skipping the auto publish as the maven is not installed on app servers
