### PR TITLE
Adding postive/negative tests for Desk.com querying

### DIFF
--- a/src/test/elements/desk/contacts.js
+++ b/src/test/elements/desk/contacts.js
@@ -2,6 +2,8 @@
 
 const suite = require('core/suite');
 const payload = require('./assets/contacts');
+const chakram = require('chakram');
+const expect = chakram.expect;
 
 const contactUpdate = () => ({
   "first_name": "test",
@@ -16,5 +18,14 @@ const options = {
 suite.forElement('helpdesk', 'contacts', { payload: payload }, (test) => {
   test.withOptions(options).should.supportCrus();
   test.should.supportPagination();
-  test.withOptions({ qs: { where: 'email=\'support@desk.com\'' } }).should.return200OnGet();
+  test
+    .withName(`should support searching ${test.api} by email`)
+    .withOptions({ qs: { where: 'email=\'support@desk.com\'' } })
+    .withValidation((r) => expect(r.body).to.not.be.empty)
+    .should.return200OnGet();
+  test
+    .withName(`should not support searching ${test.api} by updated_at using equals`)
+    .withOptions({ qs: { where: 'updated_at=\'2015-10-22T16:40:10Z\'' } })
+    .withValidation((r) => expect(r).to.have.statusCode(400))
+    .should.return200OnGet();
 });

--- a/src/test/elements/desk/incidents.js
+++ b/src/test/elements/desk/incidents.js
@@ -2,6 +2,8 @@
 
 const suite = require('core/suite');
 const payload = require('./assets/incidents');
+const chakram = require('chakram');
+const expect = chakram.expect;
 
 const incidentsUpdate = () => ({
   "subject": "Updated",
@@ -16,5 +18,14 @@ const options = { churros: { updatePayload: incidentsUpdate() } };
 suite.forElement('helpdesk', 'incidents', { payload: payload }, (test) => {
   test.withOptions(options).should.supportCruds();
   test.should.supportPagination();
-  test.withOptions({ qs: { where: 'email=\'support@desk.com\'' } }).should.return200OnGet();
+  test
+    .withName(`should support searching ${test.api} by email`)
+    .withOptions({ qs: { where: 'email=\'support@desk.com\'' } })
+    .withValidation((r) => expect(r.body).to.not.be.empty)
+    .should.return200OnGet();
+  test
+    .withName(`should not support searching ${test.api} by updated_at using equals`)
+    .withOptions({ qs: { where: 'updated_at=\'2015-10-22T16:40:10Z\'' } })
+    .withValidation((r) => expect(r).to.have.statusCode(400))
+    .should.return200OnGet();
 });

--- a/src/test/elements/sfdcservicecloud/contacts.js
+++ b/src/test/elements/sfdcservicecloud/contacts.js
@@ -14,13 +14,13 @@ suite.forElement('helpdesk', 'contacts', { payload: contactsPayload }, (test) =>
     return cloud.get(`/hubs/helpdesk/ping`);
   });
 
+  test.should.supportPagination();
   it('should allow CRUDS /hubs/helpdesk/contacts ', () => {
     let contactId;
     return cloud.post(test.api, payload)
       .then(r => contactId = r.body.Id)
       .then(r => cloud.get(`${test.api}/${contactId}`))
       .then(r => cloud.get(test.api))
-      .then(r => cloud.withOptions({ qs: { page: 1, pageSize: 1 } }).get(test.api))
       .then(r => cloud.withOptions({ qs: { where: `id='${contactId}'` } }).get(test.api))
       .then(r => cloud.patch(`${test.api}/${contactId}`, contactsPayload))
       .then(r => cloud.delete(`${test.api}/${contactId}`));


### PR DESCRIPTION
## Highlights
* Adds querying tests to `contacts` and `incidents`
* Moving `sfdcservicecloud` paging test to the suite
