### PR TITLE
Don't create unnecessary object definitions for element tests

### DIFF
--- a/src/test/elements/lifecycle.js
+++ b/src/test/elements/lifecycle.js
@@ -8,28 +8,30 @@ const argv = require('optimist').argv;
 const fs = require('fs');
 const logger = require('winston');
 const props = require('core/props');
+const tools = require('core/tools');
 
 const createAll = (urlTemplate, list) => {
-  return Object.keys(list).reduce((p, key) =>
-    p.then(() => cloud.post(util.format(urlTemplate, key), list[key])),
-    Promise.resolve(true)); // initial
+  return Object.keys(list)
+    .reduce((p, key) => p.then(() => cloud.post(util.format(urlTemplate, key), list[key])), Promise.resolve(true)); // initial
 };
 
-const terminate = (error) => {
+const terminate = error => {
   logger.error('Failed to initialize element: %s', error);
   process.exit(1);
 };
 
+const element = argv.element;
 let instanceId;
+
 before(() => {
-  const element = argv.element;
   logger.info('Running tests for element: %s', element);
-  if(props.getOptionalForKey(argv.element, 'skip') === true) {
+  if (props.getOptionalForKey(argv.element, 'skip') === true) {
     logger.info('Skip provisioning and all tests for %s', element);
     return {};
   }
 
-  return provisioner.create(element)
+  return provisioner
+    .create(element)
     .then(r => {
       expect(r).to.have.statusCode(200);
       instanceId = r.body.id;
@@ -38,7 +40,26 @@ before(() => {
       if (fs.existsSync(objectDefinitionsFile + '.json')) {
         logger.debug('Setting up object definitions');
         const url = `/instances/${instanceId}/objects/%s/definitions`;
-        return createAll(url, require(objectDefinitionsFile));
+
+        // only create object definitions for the resources that are being transformed for this element.  If there
+        // aren't any transformations, no need to create any object definitions.
+        const transformationsFile = `${__dirname}/${element}/assets/transformations`;
+        if (!fs.existsSync(transformationsFile + '.json')) {
+          logger.debug(`No transformations found for ${element} so not going to create object definitions`);
+          return null;
+        }
+
+        const transformations = require(transformationsFile);
+        const allObjectDefinitions = require(objectDefinitionsFile);
+        const objectDefinitions = Object.keys(allObjectDefinitions)
+          .reduce((accum, objectDefinitionName) => {
+            if (transformations[objectDefinitionName]) {
+              accum[objectDefinitionName] = allObjectDefinitions[objectDefinitionName];
+            }
+            return accum;
+          }, {});
+
+        return createAll(url, objectDefinitions);
       }
     })
     .then(r => {
@@ -51,18 +72,39 @@ before(() => {
       }
     })
     .catch(r => {
-      return instanceId ?
-        provisioner.delete(instanceId)
-        .then(() => terminate(r))
-        .catch(() => terminate(r)) :
-        terminate(r);
+      return instanceId ? provisioner.delete(instanceId).then(() => terminate(r)).catch(() => terminate(r)) : terminate(r);
     });
 });
 
+it('should not allow provisioning with bad credentials', () => {
+  const config = props.all(element);
+  const badConfig = Object.keys(config).reduce((accum, configKey) => {
+    accum[configKey] = 'IAmBad';
+    return accum;
+  }, {});
+
+  const passThrough = (r) => r ;
+
+  const elementInstance = {
+    name: tools.random(),
+    element: { key: element },
+    configuration: badConfig
+  };
+
+  let badInstanceId;
+  return cloud.post(`/instances`, elementInstance, passThrough)
+    .then(r => {
+      expect(r).to.have.statusCode(401);
+      badInstanceId = r.body.id;
+    })
+    .then(r => badInstanceId ? cloud.delete(`/instances/${badInstanceId}`) : null)
+    .catch(r => badInstanceId ? cloud.delete(`/instances/${badInstanceId}`) : null);
+});
+
 after(done => {
-  instanceId ?
-    provisioner.delete(instanceId)
-    .then(() => done())
-    .catch(r => logger.error('Failed to delete element instance: %s', r)) :
-    done();
+  instanceId ? provisioner
+        .delete(instanceId)
+        .then(() => done())
+        .catch(r => logger.error('Failed to delete element instance: %s', r))
+    : done();
 });

--- a/src/test/elements/lifecycle.js
+++ b/src/test/elements/lifecycle.js
@@ -8,7 +8,6 @@ const argv = require('optimist').argv;
 const fs = require('fs');
 const logger = require('winston');
 const props = require('core/props');
-const tools = require('core/tools');
 
 const createAll = (urlTemplate, list) => {
   return Object.keys(list)
@@ -74,31 +73,6 @@ before(() => {
     .catch(r => {
       return instanceId ? provisioner.delete(instanceId).then(() => terminate(r)).catch(() => terminate(r)) : terminate(r);
     });
-});
-
-it('should not allow provisioning with bad credentials', () => {
-  const config = props.all(element);
-  const badConfig = Object.keys(config).reduce((accum, configKey) => {
-    accum[configKey] = 'IAmBad';
-    return accum;
-  }, {});
-
-  const passThrough = (r) => r ;
-
-  const elementInstance = {
-    name: tools.random(),
-    element: { key: element },
-    configuration: badConfig
-  };
-
-  let badInstanceId;
-  return cloud.post(`/instances`, elementInstance, passThrough)
-    .then(r => {
-      expect(r).to.have.statusCode(401);
-      badInstanceId = r.body.id;
-    })
-    .then(r => badInstanceId ? cloud.delete(`/instances/${badInstanceId}`) : null)
-    .catch(r => badInstanceId ? cloud.delete(`/instances/${badInstanceId}`) : null);
 });
 
 after(done => {


### PR DESCRIPTION
## Highlights
* When running elements tests, only the necessary object definitions are created, as opposed to *every* object definition in the `object.definitions.json` file.

## Closes
* Closes #507 
