### PR TITLE
Fixing /incidents Churros

### DIFF
--- a/src/test/elements/freshservice/assets/transformations.json
+++ b/src/test/elements/freshservice/assets/transformations.json
@@ -16,7 +16,5 @@
         "vendorPath": "user.id"
       }
     ]
-  },
-  "incidents":{
   }
 }

--- a/src/test/elements/freshservice/incidents.js
+++ b/src/test/elements/freshservice/incidents.js
@@ -6,7 +6,7 @@ const taskPayload = require('./assets/task');
 const cloud = require('core/cloud');
 const commentPayload = require('./assets/comments');
 
-suite.forElement('helpdesk', 'incidents', { skip: true, payload: payload }, (test) => {
+suite.forElement('helpdesk', 'incidents', { payload: payload }, (test) => {
   test.should.return200OnGet();
 
   it('it should support POST', () => {


### PR DESCRIPTION
## Highlights
* Removing transformations for incidents object. "id" was being mapped to 'display-id' field from vendor body. Vendor body already contains 'id' field. This transformation causes display-id to be removed from the response. We are not able to use the display-id field for further API test cases. If we try to use 'id' assuming it is transformed, churros uses the 'id' field from the vendor response. We expect display-id value here.

## Examples
If applicable, please include any images, GIFs, etc. showing up these changes

## Closes
* Closes #4439
