### PR TITLE
Added bulk malformed query test cases

### DIFF
--- a/src/test/elements/freshdeskv2/contacts.js
+++ b/src/test/elements/freshdeskv2/contacts.js
@@ -1,9 +1,17 @@
 'use strict';
 
+const expect = require('chakram').expect;
 const suite = require('core/suite');
 const payload = require('./assets/contacts');
+const cloud = require('core/cloud');
 
 suite.forElement('helpdesk', 'contacts', { payload: payload }, (test) => {
   test.should.supportCruds();
   test.should.supportPagination();
+
+  it('should not allow malformed bulk query and throw a 400', () => {
+    return cloud.withOptions({ qs: { q: 'select * contacts'} })
+      .post('/hubs/helpdesk/bulk/query', null,
+            r => { (expect(r).to.have.statusCode(400) && expect(r.body.message).to.include('Error parsing query')); });
+  });
 });


### PR DESCRIPTION
## Highlights
* Added a test case to ensure to that `400` is returned when a malformed bulk query request is made
* The malformed queries used are `POST /crm/bulk/query?select * contacts` (`from` is missing) and `POST /helpdesk/bulk/query?select * contacts` for the `sfdc` and `freshdeskv2` elements respectively

## Closes
* Closes #651 
