### PR TITLE
Added metadata tests for SFDC and Autotask CRM

### DIFF
--- a/src/test/elements/autotaskcrm/metadata.js
+++ b/src/test/elements/autotaskcrm/metadata.js
@@ -1,0 +1,18 @@
+'use strict';
+
+const suite = require('core/suite');
+const cloud = require('core/cloud');
+const expect = require('chakram').expect;
+
+suite.forElement('crm', 'objects', (test) => {
+    const validateAccountType = (fields) => {
+        let isPicklist = false;
+        fields.forEach(field => isPicklist = (field.vendorPath === 'accountType' && field.vendorNativeType === 'picklist' && expect(field).to.contain.key('picklistValues')));
+        return isPicklist;
+    };
+
+    it('should include picklist for account metadata', () => {
+        return cloud.get(test.api + '/Account/metadata')
+            .then(r => validateAccountType(r.body.fields));
+    });
+});

--- a/src/test/elements/sfdc/metadata.js
+++ b/src/test/elements/sfdc/metadata.js
@@ -16,4 +16,15 @@ suite.forElement('crm', 'metadata', (test) => {
                 expect(metadata.updateable).to.exist;
             });
     });
+
+    it('should include picklist for contact metadata', () => {
+      const validateSalutation = (fields) => {
+        let isPicklist = false;
+        fields.forEach(field => isPicklist = (field.vendorPath === 'Salutation' && field.vendorNativeType === 'picklist' && expect(field).to.contain.key('picklistValues')));
+        return isPicklist;
+      };
+
+      return cloud.get(uri)
+        .then(r => validateSalutation(r.body.fields));
+    });
 });


### PR DESCRIPTION
## Highlights
* Added a test to ensure a `picklist` is returned for the `Salutation` field for the Salesforce.com `Contact` object metadata
* Added a test to ensure a `picklist` is returned for the `accountType` field for the Autotask CRM `Account` object metadata

## Closes
* Closes #690 
