### PR TITLE
Shopify tests for using the `orderBy` param

### DIFF
--- a/src/test/elements/shopify/customers.js
+++ b/src/test/elements/shopify/customers.js
@@ -20,4 +20,8 @@ suite.forElement('ecommerce', 'customers', { payload: customer({}) }, (test) => 
     .then(r => cloud.get(`${test.api}/${customertId}/abandoned-checkouts`))
     .then(r => cloud.delete(`${test.api}/${customertId}`));
   });
+  it('should allow GET for /customers with use of the `orderBy` parameter', () => {
+    return cloud.withOptions({qs: {orderBy: 'updated_at'}}).get(test.api)
+      .then(r => cloud.withOptions({qs: {orderBy: 'created_at'}}).get(test.api));
+  });
 });

--- a/src/test/elements/shopify/orders.js
+++ b/src/test/elements/shopify/orders.js
@@ -2,6 +2,7 @@
 
 const suite = require('core/suite');
 const tools = require('core/tools');
+const cloud = require('core/cloud');
 
 const order = (custom) => ({
   line_items: custom.line_items || [{
@@ -12,4 +13,8 @@ const order = (custom) => ({
 
 suite.forElement('ecommerce', 'orders', { payload: order({}) }, (test) => {
   test.should.supportCruds();
+  it('should allow GET for /orders with use of the `orderBy` parameter', () => {
+    return cloud.withOptions({qs: {orderBy: 'updated_at'}}).get(test.api)
+      .then(r => cloud.withOptions({qs: {orderBy: 'created_at'}}).get(test.api));
+  });
 });

--- a/src/test/elements/shopify/products.js
+++ b/src/test/elements/shopify/products.js
@@ -2,6 +2,7 @@
 
 const suite = require('core/suite');
 const tools = require('core/tools');
+const cloud = require('core/cloud');
 
 const products = (custom) => ({
   title: custom.title || tools.random(),
@@ -10,4 +11,8 @@ const products = (custom) => ({
 
 suite.forElement('ecommerce', 'products', { payload: products({}) }, (test) => {
   test.should.supportCruds();
+  it('should allow GET for /products with use of the `orderBy` parameter', () => {
+    return cloud.withOptions({qs: {orderBy: 'updated_at'}}).get(test.api)
+      .then(r => cloud.withOptions({qs: {orderBy: 'created_at'}}).get(test.api));
+  });
 });


### PR DESCRIPTION
## Highlights
* added tests for using an `orderBy` param in Shopify resources `customers`, `orders` and `products`
* Soba PR: https://github.com/cloud-elements/soba/pull/5058
