### PR TITLE
Swagger docs validation for provider aws

### DIFF
--- a/src/test/platform/docs/docs.js
+++ b/src/test/platform/docs/docs.js
@@ -3,6 +3,7 @@
 const suite = require('core/suite');
 const cloud = require('core/cloud');
 const swaggerParser = require('swagger-parser');
+const expect = require('chakram').expect;
 
 suite.forPlatform('docs', { skip: true }, () => {
   let hubs;
@@ -21,5 +22,13 @@ suite.forPlatform('docs', { skip: true }, () => {
           if(err) { throw new Error(`Docs for '${h}' hub are invalid Swagger: ${err}`); }
         }));
     }));
+  });
+
+  it('should return proper swagger json for AWS provider', () => {
+    return cloud.get(`/docs/crm?provider=aws`)
+    .then(r => {
+        expect(r.body).to.not.be.empty;
+        expect(r.body.paths['/accounts'].get.parameters[1].name).to.equal('x-api-key');
+    });
   });
 });


### PR DESCRIPTION
## Highlights
* Swagger docs validation for `x-api-key` validation when provider aws

