### PR TITLE
Unescape symbols after sanitization

### DIFF
--- a/src/test/platform/elements/instances.js
+++ b/src/test/platform/elements/instances.js
@@ -180,12 +180,12 @@ suite.forPlatform('elements/instances', opts, (test) => {
 
   it('should sanitize element instance tags on create and update', () => {
     let id;
-    return provisioner.create('sfdc', {name: '<a href="#" onClick="javascript:alert(\'xss\');return false;">churros-xss</a>'})
+    return provisioner.create('sfdc', {name: '<a href="#" onClick="javascript:alert(\'xss\');return false;">@churros-xss</a>'})
       .then(r => id = r.body.id)
       .then(() => cloud.get(`/instances/${id}`))
-      .then(r => expect(r.body.name).to.equal('churros-xss') && expect(r.body.tags[0]).to.equal('churros-xss'))
-      .then(() => cloud.patch(`/instances/${id}`, {name: '<a href="#" onClick="javascript:alert(\'xss\');return false;">churros-xss-updated</a>'}))
-      .then(r => expect(r.body.name).to.equal('churros-xss-updated'))
+      .then(r => expect(r.body.name).to.equal('@churros-xss') && expect(r.body.tags[0]).to.equal('@churros-xss'))
+      .then(() => cloud.patch(`/instances/${id}`, {name: '<a href="#" onClick="javascript:alert(\'xss\');return false;">@churros-xss-updated</a>'}))
+      .then(r => expect(r.body.name).to.equal('@churros-xss-updated'))
       .then(() => provisioner.delete(id));
   });
 

--- a/src/test/platform/formulas/instances.js
+++ b/src/test/platform/formulas/instances.js
@@ -68,20 +68,20 @@ suite.forPlatform('formulas', opts, (test) => {
 
       let fiId;
 
-      formulaInstance.name = `<a href="#" onClick="javascript:alert(\'xss\');return false;">${name}</a>`;
+      formulaInstance.name = `<a href="#" onClick="javascript:alert(\'xss\');return false;">@${name}</a>`;
       formulaInstance.configuration['trigger-instance'] = elementInstanceId;
 
       return common.createFormulaInstance(formulaId, formulaInstance)
         .then(fi => {
           fiId = fi.id;
-          expect(fi.name).to.equal(name);
+          expect(fi.name).to.equal(`@${name}`);
           return fi;
         })
         .then(fi => {
-          fi.name = `<a href="#" onClick="javascript:alert(\'xss\');return false;">${updatedName}</a>`;
+          fi.name = `<a href="#" onClick="javascript:alert(\'xss\');return false;">@${updatedName}</a>`;
           return cloud.put(`${test.api}/${formulaId}/instances/${fiId}`, fi);
         })
-        .then(r => expect(r.body.name).to.equal(updatedName))
+        .then(r => expect(r.body.name).to.equal(`@${updatedName}`))
         .then(r => common.deleteFormulaInstance(formulaId, fiId));
     });
 


### PR DESCRIPTION
## Highlights
* New test for retaining `@` symbols after sanitizing element/formula instance names.