### PR TITLE
Shopify /customers `orderBy` update

### DIFF
--- a/src/test/elements/shopify/customers.js
+++ b/src/test/elements/shopify/customers.js
@@ -22,6 +22,6 @@ suite.forElement('ecommerce', 'customers', { payload: customer({}) }, (test) => 
   });
   it('should allow GET for /customers with use of the `orderBy` parameter', () => {
     return cloud.withOptions({qs: {orderBy: 'updated_at'}}).get(test.api)
-      .then(r => cloud.withOptions({qs: {orderBy: 'created_at'}}).get(test.api));
+      .then(r => cloud.withOptions({qs: {orderBy: 'last_order_date'}}).get(test.api));
   });
 });


### PR DESCRIPTION
## Highlights
* super minor change to supported params for `/customers`

