### PR TITLE
:baby_symbol: Added test for GET /common-resources

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "ngrok": "^2.1.6",
     "nock": "7.7.0",
     "optimist": "^0.6.1",
+    "ramda": "^0.23.0",
     "replacestream": "^4.0.0",
     "request": "^2.72.0",
     "selenium-webdriver": "^2.53.2",

--- a/src/test/platform/transformations/commonResources.js
+++ b/src/test/platform/transformations/commonResources.js
@@ -1,0 +1,37 @@
+const suite = require('core/suite');
+const cloud = require('core/cloud');
+const expect = require('chai').expect;
+const R = require('ramda');
+
+const orgCommonResource = {
+  name: 'foo',
+  fields: [{
+    path: 'id',
+    type: 'number'
+  }, {
+    path: 'name',
+    type: 'string'
+  }]
+};
+
+suite.forPlatform('common-resources', {}, () => {
+  const orgUrl = `/organizations/objects/${orgCommonResource.name}/definitions`;
+  
+  before(() => cloud.post(orgUrl, orgCommonResource));
+
+  it('should support returning all common resources that exist', () => {
+    const v = r => {
+      expect(r).to.have.statusCode(200);
+      expect(r.body).to.be.an('array');
+
+      // find newly created common resource and validate the fields
+      const newCr = R.find(R.propEq('objectName', orgCommonResource.name))(r.body);
+      expect(newCr.fields).to.be.an('array').and.have.length(2);
+      expect(newCr.fields.filter(field => field.level === 'organization')).to.have.length(2);
+    };
+
+    return cloud.get('/common-resources', v);
+  });
+
+  after(() => cloud.delete(orgUrl));
+});


### PR DESCRIPTION
## Highlights
* Added a lil' baby test for the new `/common-resources` resource that Console 2.0 is leveraging to simplify common resources in the UI.
* Added dependency on `ramda` npm module
> NOTE: Will eventually spruce up these tests as/if we expose these as consumable to customers.  Currently they're being tried out in the UI and will probably continue to change so do not want to document or add too many tests around them meow 🐱 
