### PR TITLE
Element extend tests

### DIFF
--- a/src/test/platform/elementbuilder/assets/elementextend/account.json
+++ b/src/test/platform/elementbuilder/assets/elementextend/account.json
@@ -1,0 +1,4 @@
+{
+  "externalId": "churros-newaccount@cloud-elements.com",
+  "name": "churros-newaccount"
+}

--- a/src/test/platform/elementbuilder/assets/elementextend/elementswagger.schema.json
+++ b/src/test/platform/elementbuilder/assets/elementextend/elementswagger.schema.json
@@ -1,0 +1,1613 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "definitions": {},
+  "id": "http://example.com/example.json",
+  "properties": {
+    "basePath": {
+      "id": "/properties/basePath",
+      "type": "string"
+    },
+    "definitions": {
+      "id": "/properties/definitions",
+      "properties": {
+        "address": {
+          "id": "/properties/definitions/properties/address",
+          "properties": {
+            "properties": {
+              "id": "/properties/definitions/properties/address/properties/properties",
+              "properties": {
+                "city": {
+                  "id": "/properties/definitions/properties/address/properties/properties/properties/city",
+                  "properties": {
+                    "type": {
+                      "id": "/properties/definitions/properties/address/properties/properties/properties/city/properties/type",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "country": {
+                  "id": "/properties/definitions/properties/address/properties/properties/properties/country",
+                  "properties": {
+                    "type": {
+                      "id": "/properties/definitions/properties/address/properties/properties/properties/country/properties/type",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "line1": {
+                  "id": "/properties/definitions/properties/address/properties/properties/properties/line1",
+                  "properties": {
+                    "type": {
+                      "id": "/properties/definitions/properties/address/properties/properties/properties/line1/properties/type",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "state": {
+                  "id": "/properties/definitions/properties/address/properties/properties/properties/state",
+                  "properties": {
+                    "type": {
+                      "id": "/properties/definitions/properties/address/properties/properties/properties/state/properties/type",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              },
+              "type": "object"
+            },
+            "type": {
+              "id": "/properties/definitions/properties/address/properties/type",
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "contacts": {
+          "id": "/properties/definitions/properties/contacts",
+          "properties": {
+            "properties": {
+              "id": "/properties/definitions/properties/contacts/properties/properties",
+              "properties": {
+                "homeEmail": {
+                  "id": "/properties/definitions/properties/contacts/properties/properties/properties/homeEmail",
+                  "properties": {
+                    "type": {
+                      "id": "/properties/definitions/properties/contacts/properties/properties/properties/homeEmail/properties/type",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "homePhone": {
+                  "id": "/properties/definitions/properties/contacts/properties/properties/properties/homePhone",
+                  "properties": {
+                    "type": {
+                      "id": "/properties/definitions/properties/contacts/properties/properties/properties/homePhone/properties/type",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "homeUrl": {
+                  "id": "/properties/definitions/properties/contacts/properties/properties/properties/homeUrl",
+                  "properties": {
+                    "type": {
+                      "id": "/properties/definitions/properties/contacts/properties/properties/properties/homeUrl/properties/type",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "lead_id": {
+                  "id": "/properties/definitions/properties/contacts/properties/properties/properties/lead_id",
+                  "properties": {
+                    "type": {
+                      "id": "/properties/definitions/properties/contacts/properties/properties/properties/lead_id/properties/type",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "mobilePhone": {
+                  "id": "/properties/definitions/properties/contacts/properties/properties/properties/mobilePhone",
+                  "properties": {
+                    "type": {
+                      "id": "/properties/definitions/properties/contacts/properties/properties/properties/mobilePhone/properties/type",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "name": {
+                  "id": "/properties/definitions/properties/contacts/properties/properties/properties/name",
+                  "properties": {
+                    "type": {
+                      "id": "/properties/definitions/properties/contacts/properties/properties/properties/name/properties/type",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "officeEmail": {
+                  "id": "/properties/definitions/properties/contacts/properties/properties/properties/officeEmail",
+                  "properties": {
+                    "type": {
+                      "id": "/properties/definitions/properties/contacts/properties/properties/properties/officeEmail/properties/type",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "officePhone": {
+                  "id": "/properties/definitions/properties/contacts/properties/properties/properties/officePhone",
+                  "properties": {
+                    "type": {
+                      "id": "/properties/definitions/properties/contacts/properties/properties/properties/officePhone/properties/type",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "officeUrl": {
+                  "id": "/properties/definitions/properties/contacts/properties/properties/properties/officeUrl",
+                  "properties": {
+                    "type": {
+                      "id": "/properties/definitions/properties/contacts/properties/properties/properties/officeUrl/properties/type",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "organization_id": {
+                  "id": "/properties/definitions/properties/contacts/properties/properties/properties/organization_id",
+                  "properties": {
+                    "type": {
+                      "id": "/properties/definitions/properties/contacts/properties/properties/properties/organization_id/properties/type",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "title": {
+                  "id": "/properties/definitions/properties/contacts/properties/properties/properties/title",
+                  "properties": {
+                    "type": {
+                      "id": "/properties/definitions/properties/contacts/properties/properties/properties/title/properties/type",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              },
+              "type": "object"
+            },
+            "required": {
+              "additionalItems": false,
+              "id": "/properties/definitions/properties/contacts/properties/required",
+              "items": {
+                "id": "/properties/definitions/properties/contacts/properties/required/items",
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "type": {
+              "id": "/properties/definitions/properties/contacts/properties/type",
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "mynewcontacts": {
+          "id": "/properties/definitions/properties/mynewcontacts",
+          "properties": {
+            "properties": {
+              "id": "/properties/definitions/properties/mynewcontacts/properties/properties",
+              "properties": {
+                "address": {
+                  "id": "/properties/definitions/properties/mynewcontacts/properties/properties/properties/address",
+                  "properties": {
+                    "$ref": {
+                      "id": "/properties/definitions/properties/mynewcontacts/properties/properties/properties/address/properties/$ref",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "contact_id": {
+                  "id": "/properties/definitions/properties/mynewcontacts/properties/properties/properties/contact_id",
+                  "properties": {
+                    "format": {
+                      "id": "/properties/definitions/properties/mynewcontacts/properties/properties/properties/contact_id/properties/format",
+                      "type": "string"
+                    },
+                    "type": {
+                      "id": "/properties/definitions/properties/mynewcontacts/properties/properties/properties/contact_id/properties/type",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "created_at": {
+                  "id": "/properties/definitions/properties/mynewcontacts/properties/properties/properties/created_at",
+                  "properties": {
+                    "type": {
+                      "id": "/properties/definitions/properties/mynewcontacts/properties/properties/properties/created_at/properties/type",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "creator_id": {
+                  "id": "/properties/definitions/properties/mynewcontacts/properties/properties/properties/creator_id",
+                  "properties": {
+                    "format": {
+                      "id": "/properties/definitions/properties/mynewcontacts/properties/properties/properties/creator_id/properties/format",
+                      "type": "string"
+                    },
+                    "type": {
+                      "id": "/properties/definitions/properties/mynewcontacts/properties/properties/properties/creator_id/properties/type",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "customer_status": {
+                  "id": "/properties/definitions/properties/mynewcontacts/properties/properties/properties/customer_status",
+                  "properties": {
+                    "type": {
+                      "id": "/properties/definitions/properties/mynewcontacts/properties/properties/properties/customer_status/properties/type",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "description": {
+                  "id": "/properties/definitions/properties/mynewcontacts/properties/properties/properties/description",
+                  "properties": {
+                    "type": {
+                      "id": "/properties/definitions/properties/mynewcontacts/properties/properties/properties/description/properties/type",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "email": {
+                  "id": "/properties/definitions/properties/mynewcontacts/properties/properties/properties/email",
+                  "properties": {
+                    "type": {
+                      "id": "/properties/definitions/properties/mynewcontacts/properties/properties/properties/email/properties/type",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "facebook": {
+                  "id": "/properties/definitions/properties/mynewcontacts/properties/properties/properties/facebook",
+                  "properties": {
+                    "type": {
+                      "id": "/properties/definitions/properties/mynewcontacts/properties/properties/properties/facebook/properties/type",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "fax": {
+                  "id": "/properties/definitions/properties/mynewcontacts/properties/properties/properties/fax",
+                  "properties": {
+                    "type": {
+                      "id": "/properties/definitions/properties/mynewcontacts/properties/properties/properties/fax/properties/type",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "first_name": {
+                  "id": "/properties/definitions/properties/mynewcontacts/properties/properties/properties/first_name",
+                  "properties": {
+                    "type": {
+                      "id": "/properties/definitions/properties/mynewcontacts/properties/properties/properties/first_name/properties/type",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "id": {
+                  "id": "/properties/definitions/properties/mynewcontacts/properties/properties/properties/id",
+                  "properties": {
+                    "format": {
+                      "id": "/properties/definitions/properties/mynewcontacts/properties/properties/properties/id/properties/format",
+                      "type": "string"
+                    },
+                    "type": {
+                      "id": "/properties/definitions/properties/mynewcontacts/properties/properties/properties/id/properties/type",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "industry": {
+                  "id": "/properties/definitions/properties/mynewcontacts/properties/properties/properties/industry",
+                  "properties": {
+                    "type": {
+                      "id": "/properties/definitions/properties/mynewcontacts/properties/properties/properties/industry/properties/type",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "is_organization": {
+                  "id": "/properties/definitions/properties/mynewcontacts/properties/properties/properties/is_organization",
+                  "properties": {
+                    "type": {
+                      "id": "/properties/definitions/properties/mynewcontacts/properties/properties/properties/is_organization/properties/type",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "last_name": {
+                  "id": "/properties/definitions/properties/mynewcontacts/properties/properties/properties/last_name",
+                  "properties": {
+                    "type": {
+                      "id": "/properties/definitions/properties/mynewcontacts/properties/properties/properties/last_name/properties/type",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "linkedin": {
+                  "id": "/properties/definitions/properties/mynewcontacts/properties/properties/properties/linkedin",
+                  "properties": {
+                    "type": {
+                      "id": "/properties/definitions/properties/mynewcontacts/properties/properties/properties/linkedin/properties/type",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "mobile": {
+                  "id": "/properties/definitions/properties/mynewcontacts/properties/properties/properties/mobile",
+                  "properties": {
+                    "type": {
+                      "id": "/properties/definitions/properties/mynewcontacts/properties/properties/properties/mobile/properties/type",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "name": {
+                  "id": "/properties/definitions/properties/mynewcontacts/properties/properties/properties/name",
+                  "properties": {
+                    "type": {
+                      "id": "/properties/definitions/properties/mynewcontacts/properties/properties/properties/name/properties/type",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "owner_id": {
+                  "id": "/properties/definitions/properties/mynewcontacts/properties/properties/properties/owner_id",
+                  "properties": {
+                    "format": {
+                      "id": "/properties/definitions/properties/mynewcontacts/properties/properties/properties/owner_id/properties/format",
+                      "type": "string"
+                    },
+                    "type": {
+                      "id": "/properties/definitions/properties/mynewcontacts/properties/properties/properties/owner_id/properties/type",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "phone": {
+                  "id": "/properties/definitions/properties/mynewcontacts/properties/properties/properties/phone",
+                  "properties": {
+                    "type": {
+                      "id": "/properties/definitions/properties/mynewcontacts/properties/properties/properties/phone/properties/type",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "prospect_status": {
+                  "id": "/properties/definitions/properties/mynewcontacts/properties/properties/properties/prospect_status",
+                  "properties": {
+                    "type": {
+                      "id": "/properties/definitions/properties/mynewcontacts/properties/properties/properties/prospect_status/properties/type",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "skype": {
+                  "id": "/properties/definitions/properties/mynewcontacts/properties/properties/properties/skype",
+                  "properties": {
+                    "type": {
+                      "id": "/properties/definitions/properties/mynewcontacts/properties/properties/properties/skype/properties/type",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "title": {
+                  "id": "/properties/definitions/properties/mynewcontacts/properties/properties/properties/title",
+                  "properties": {
+                    "type": {
+                      "id": "/properties/definitions/properties/mynewcontacts/properties/properties/properties/title/properties/type",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "twitter": {
+                  "id": "/properties/definitions/properties/mynewcontacts/properties/properties/properties/twitter",
+                  "properties": {
+                    "type": {
+                      "id": "/properties/definitions/properties/mynewcontacts/properties/properties/properties/twitter/properties/type",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "updated_at": {
+                  "id": "/properties/definitions/properties/mynewcontacts/properties/properties/properties/updated_at",
+                  "properties": {
+                    "type": {
+                      "id": "/properties/definitions/properties/mynewcontacts/properties/properties/properties/updated_at/properties/type",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "website": {
+                  "id": "/properties/definitions/properties/mynewcontacts/properties/properties/properties/website",
+                  "properties": {
+                    "type": {
+                      "id": "/properties/definitions/properties/mynewcontacts/properties/properties/properties/website/properties/type",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              },
+              "type": "object"
+            },
+            "required": {
+              "additionalItems": false,
+              "id": "/properties/definitions/properties/mynewcontacts/properties/required",
+              "items": {
+                "id": "/properties/definitions/properties/mynewcontacts/properties/required/items",
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "type": {
+              "id": "/properties/definitions/properties/mynewcontacts/properties/type",
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "objectsMetadata": {
+          "id": "/properties/definitions/properties/objectsMetadata",
+          "properties": {
+            "properties": {
+              "id": "/properties/definitions/properties/objectsMetadata/properties/properties",
+              "properties": {
+                "fields": {
+                  "id": "/properties/definitions/properties/objectsMetadata/properties/properties/properties/fields",
+                  "properties": {
+                    "items": {
+                      "id": "/properties/definitions/properties/objectsMetadata/properties/properties/properties/fields/properties/items",
+                      "properties": {
+                        "$ref": {
+                          "id": "/properties/definitions/properties/objectsMetadata/properties/properties/properties/fields/properties/items/properties/$ref",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "type": {
+                      "id": "/properties/definitions/properties/objectsMetadata/properties/properties/properties/fields/properties/type",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "type": "object"
+        }
+      },
+      "type": "object"
+    },
+    "info": {
+      "id": "/properties/info",
+      "properties": {
+        "contact": {
+          "id": "/properties/info/properties/contact",
+          "properties": {
+            "email": {
+              "id": "/properties/info/properties/contact/properties/email",
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "title": {
+          "id": "/properties/info/properties/title",
+          "type": "string"
+        },
+        "version": {
+          "id": "/properties/info/properties/version",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "paths": {
+      "id": "/properties/paths",
+      "properties": {
+        "/contacts": {
+          "id": "/properties/paths/properties//contacts",
+          "properties": {
+            "get": {
+              "id": "/properties/paths/properties//contacts/properties/get",
+              "properties": {
+                "operationId": {
+                  "id": "/properties/paths/properties//contacts/properties/get/properties/operationId",
+                  "type": "string"
+                },
+                "parameters": {
+                  "additionalItems": false,
+                  "id": "/properties/paths/properties//contacts/properties/get/properties/parameters",
+                  "items": {
+                    "id": "/properties/paths/properties//contacts/properties/get/properties/parameters/items",
+                    "properties": {
+                      "description": {
+                        "id": "/properties/paths/properties//contacts/properties/get/properties/parameters/items/properties/description",
+                        "type": "string"
+                      },
+                      "in": {
+                        "id": "/properties/paths/properties//contacts/properties/get/properties/parameters/items/properties/in",
+                        "type": "string"
+                      },
+                      "name": {
+                        "id": "/properties/paths/properties//contacts/properties/get/properties/parameters/items/properties/name",
+                        "type": "string"
+                      },
+                      "required": {
+                        "id": "/properties/paths/properties//contacts/properties/get/properties/parameters/items/properties/required",
+                        "type": "boolean"
+                      },
+                      "type": {
+                        "id": "/properties/paths/properties//contacts/properties/get/properties/parameters/items/properties/type",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "type": "array"
+                },
+                "responses": {
+                  "id": "/properties/paths/properties//contacts/properties/get/properties/responses",
+                  "properties": {
+                    "200": {
+                      "id": "/properties/paths/properties//contacts/properties/get/properties/responses/properties/200",
+                      "properties": {
+                        "description": {
+                          "id": "/properties/paths/properties//contacts/properties/get/properties/responses/properties/200/properties/description",
+                          "type": "string"
+                        },
+                        "schema": {
+                          "id": "/properties/paths/properties//contacts/properties/get/properties/responses/properties/200/properties/schema",
+                          "properties": {
+                            "$ref": {
+                              "id": "/properties/paths/properties//contacts/properties/get/properties/responses/properties/200/properties/schema/properties/$ref",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "400": {
+                      "id": "/properties/paths/properties//contacts/properties/get/properties/responses/properties/400",
+                      "properties": {
+                        "description": {
+                          "id": "/properties/paths/properties//contacts/properties/get/properties/responses/properties/400/properties/description",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "401": {
+                      "id": "/properties/paths/properties//contacts/properties/get/properties/responses/properties/401",
+                      "properties": {
+                        "description": {
+                          "id": "/properties/paths/properties//contacts/properties/get/properties/responses/properties/401/properties/description",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "403": {
+                      "id": "/properties/paths/properties//contacts/properties/get/properties/responses/properties/403",
+                      "properties": {
+                        "description": {
+                          "id": "/properties/paths/properties//contacts/properties/get/properties/responses/properties/403/properties/description",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "404": {
+                      "id": "/properties/paths/properties//contacts/properties/get/properties/responses/properties/404",
+                      "properties": {
+                        "description": {
+                          "id": "/properties/paths/properties//contacts/properties/get/properties/responses/properties/404/properties/description",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "405": {
+                      "id": "/properties/paths/properties//contacts/properties/get/properties/responses/properties/405",
+                      "properties": {
+                        "description": {
+                          "id": "/properties/paths/properties//contacts/properties/get/properties/responses/properties/405/properties/description",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "406": {
+                      "id": "/properties/paths/properties//contacts/properties/get/properties/responses/properties/406",
+                      "properties": {
+                        "description": {
+                          "id": "/properties/paths/properties//contacts/properties/get/properties/responses/properties/406/properties/description",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "409": {
+                      "id": "/properties/paths/properties//contacts/properties/get/properties/responses/properties/409",
+                      "properties": {
+                        "description": {
+                          "id": "/properties/paths/properties//contacts/properties/get/properties/responses/properties/409/properties/description",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "415": {
+                      "id": "/properties/paths/properties//contacts/properties/get/properties/responses/properties/415",
+                      "properties": {
+                        "description": {
+                          "id": "/properties/paths/properties//contacts/properties/get/properties/responses/properties/415/properties/description",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "500": {
+                      "id": "/properties/paths/properties//contacts/properties/get/properties/responses/properties/500",
+                      "properties": {
+                        "description": {
+                          "id": "/properties/paths/properties//contacts/properties/get/properties/responses/properties/500/properties/description",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    }
+                  },
+                  "type": "object"
+                },
+                "summary": {
+                  "id": "/properties/paths/properties//contacts/properties/get/properties/summary",
+                  "type": "string"
+                },
+                "tags": {
+                  "additionalItems": false,
+                  "id": "/properties/paths/properties//contacts/properties/get/properties/tags",
+                  "items": {
+                    "id": "/properties/paths/properties//contacts/properties/get/properties/tags/items",
+                    "type": "string"
+                  },
+                  "type": "array"
+                }
+              },
+              "type": "object"
+            },
+            "post": {
+              "id": "/properties/paths/properties//contacts/properties/post",
+              "properties": {
+                "operationId": {
+                  "id": "/properties/paths/properties//contacts/properties/post/properties/operationId",
+                  "type": "string"
+                },
+                "parameters": {
+                  "additionalItems": false,
+                  "id": "/properties/paths/properties//contacts/properties/post/properties/parameters",
+                  "items": {
+                    "id": "/properties/paths/properties//contacts/properties/post/properties/parameters/items",
+                    "properties": {
+                      "description": {
+                        "id": "/properties/paths/properties//contacts/properties/post/properties/parameters/items/properties/description",
+                        "type": "string"
+                      },
+                      "in": {
+                        "id": "/properties/paths/properties//contacts/properties/post/properties/parameters/items/properties/in",
+                        "type": "string"
+                      },
+                      "name": {
+                        "id": "/properties/paths/properties//contacts/properties/post/properties/parameters/items/properties/name",
+                        "type": "string"
+                      },
+                      "required": {
+                        "id": "/properties/paths/properties//contacts/properties/post/properties/parameters/items/properties/required",
+                        "type": "boolean"
+                      },
+                      "type": {
+                        "id": "/properties/paths/properties//contacts/properties/post/properties/parameters/items/properties/type",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "type": "array"
+                },
+                "responses": {
+                  "id": "/properties/paths/properties//contacts/properties/post/properties/responses",
+                  "properties": {
+                    "200": {
+                      "id": "/properties/paths/properties//contacts/properties/post/properties/responses/properties/200",
+                      "properties": {
+                        "description": {
+                          "id": "/properties/paths/properties//contacts/properties/post/properties/responses/properties/200/properties/description",
+                          "type": "string"
+                        },
+                        "schema": {
+                          "id": "/properties/paths/properties//contacts/properties/post/properties/responses/properties/200/properties/schema",
+                          "properties": {
+                            "$ref": {
+                              "id": "/properties/paths/properties//contacts/properties/post/properties/responses/properties/200/properties/schema/properties/$ref",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "400": {
+                      "id": "/properties/paths/properties//contacts/properties/post/properties/responses/properties/400",
+                      "properties": {
+                        "description": {
+                          "id": "/properties/paths/properties//contacts/properties/post/properties/responses/properties/400/properties/description",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "401": {
+                      "id": "/properties/paths/properties//contacts/properties/post/properties/responses/properties/401",
+                      "properties": {
+                        "description": {
+                          "id": "/properties/paths/properties//contacts/properties/post/properties/responses/properties/401/properties/description",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "403": {
+                      "id": "/properties/paths/properties//contacts/properties/post/properties/responses/properties/403",
+                      "properties": {
+                        "description": {
+                          "id": "/properties/paths/properties//contacts/properties/post/properties/responses/properties/403/properties/description",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "404": {
+                      "id": "/properties/paths/properties//contacts/properties/post/properties/responses/properties/404",
+                      "properties": {
+                        "description": {
+                          "id": "/properties/paths/properties//contacts/properties/post/properties/responses/properties/404/properties/description",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "405": {
+                      "id": "/properties/paths/properties//contacts/properties/post/properties/responses/properties/405",
+                      "properties": {
+                        "description": {
+                          "id": "/properties/paths/properties//contacts/properties/post/properties/responses/properties/405/properties/description",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "406": {
+                      "id": "/properties/paths/properties//contacts/properties/post/properties/responses/properties/406",
+                      "properties": {
+                        "description": {
+                          "id": "/properties/paths/properties//contacts/properties/post/properties/responses/properties/406/properties/description",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "409": {
+                      "id": "/properties/paths/properties//contacts/properties/post/properties/responses/properties/409",
+                      "properties": {
+                        "description": {
+                          "id": "/properties/paths/properties//contacts/properties/post/properties/responses/properties/409/properties/description",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "415": {
+                      "id": "/properties/paths/properties//contacts/properties/post/properties/responses/properties/415",
+                      "properties": {
+                        "description": {
+                          "id": "/properties/paths/properties//contacts/properties/post/properties/responses/properties/415/properties/description",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "500": {
+                      "id": "/properties/paths/properties//contacts/properties/post/properties/responses/properties/500",
+                      "properties": {
+                        "description": {
+                          "id": "/properties/paths/properties//contacts/properties/post/properties/responses/properties/500/properties/description",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    }
+                  },
+                  "type": "object"
+                },
+                "summary": {
+                  "id": "/properties/paths/properties//contacts/properties/post/properties/summary",
+                  "type": "string"
+                },
+                "tags": {
+                  "additionalItems": false,
+                  "id": "/properties/paths/properties//contacts/properties/post/properties/tags",
+                  "items": {
+                    "id": "/properties/paths/properties//contacts/properties/post/properties/tags/items",
+                    "type": "string"
+                  },
+                  "type": "array"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "type": "object"
+        },
+        "/contacts/{id}": {
+          "id": "/properties/paths/properties//contacts/{id}",
+          "properties": {
+            "delete": {
+              "id": "/properties/paths/properties//contacts/{id}/properties/delete",
+              "properties": {
+                "operationId": {
+                  "id": "/properties/paths/properties//contacts/{id}/properties/delete/properties/operationId",
+                  "type": "string"
+                },
+                "parameters": {
+                  "additionalItems": false,
+                  "id": "/properties/paths/properties//contacts/{id}/properties/delete/properties/parameters",
+                  "items": {
+                    "id": "/properties/paths/properties//contacts/{id}/properties/delete/properties/parameters/items",
+                    "properties": {
+                      "description": {
+                        "id": "/properties/paths/properties//contacts/{id}/properties/delete/properties/parameters/items/properties/description",
+                        "type": "string"
+                      },
+                      "in": {
+                        "id": "/properties/paths/properties//contacts/{id}/properties/delete/properties/parameters/items/properties/in",
+                        "type": "string"
+                      },
+                      "name": {
+                        "id": "/properties/paths/properties//contacts/{id}/properties/delete/properties/parameters/items/properties/name",
+                        "type": "string"
+                      },
+                      "required": {
+                        "id": "/properties/paths/properties//contacts/{id}/properties/delete/properties/parameters/items/properties/required",
+                        "type": "boolean"
+                      },
+                      "type": {
+                        "id": "/properties/paths/properties//contacts/{id}/properties/delete/properties/parameters/items/properties/type",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "type": "array"
+                },
+                "responses": {
+                  "id": "/properties/paths/properties//contacts/{id}/properties/delete/properties/responses",
+                  "properties": {
+                    "200": {
+                      "id": "/properties/paths/properties//contacts/{id}/properties/delete/properties/responses/properties/200",
+                      "properties": {
+                        "description": {
+                          "id": "/properties/paths/properties//contacts/{id}/properties/delete/properties/responses/properties/200/properties/description",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "400": {
+                      "id": "/properties/paths/properties//contacts/{id}/properties/delete/properties/responses/properties/400",
+                      "properties": {
+                        "description": {
+                          "id": "/properties/paths/properties//contacts/{id}/properties/delete/properties/responses/properties/400/properties/description",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "401": {
+                      "id": "/properties/paths/properties//contacts/{id}/properties/delete/properties/responses/properties/401",
+                      "properties": {
+                        "description": {
+                          "id": "/properties/paths/properties//contacts/{id}/properties/delete/properties/responses/properties/401/properties/description",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "403": {
+                      "id": "/properties/paths/properties//contacts/{id}/properties/delete/properties/responses/properties/403",
+                      "properties": {
+                        "description": {
+                          "id": "/properties/paths/properties//contacts/{id}/properties/delete/properties/responses/properties/403/properties/description",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "404": {
+                      "id": "/properties/paths/properties//contacts/{id}/properties/delete/properties/responses/properties/404",
+                      "properties": {
+                        "description": {
+                          "id": "/properties/paths/properties//contacts/{id}/properties/delete/properties/responses/properties/404/properties/description",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "405": {
+                      "id": "/properties/paths/properties//contacts/{id}/properties/delete/properties/responses/properties/405",
+                      "properties": {
+                        "description": {
+                          "id": "/properties/paths/properties//contacts/{id}/properties/delete/properties/responses/properties/405/properties/description",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "406": {
+                      "id": "/properties/paths/properties//contacts/{id}/properties/delete/properties/responses/properties/406",
+                      "properties": {
+                        "description": {
+                          "id": "/properties/paths/properties//contacts/{id}/properties/delete/properties/responses/properties/406/properties/description",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "409": {
+                      "id": "/properties/paths/properties//contacts/{id}/properties/delete/properties/responses/properties/409",
+                      "properties": {
+                        "description": {
+                          "id": "/properties/paths/properties//contacts/{id}/properties/delete/properties/responses/properties/409/properties/description",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "415": {
+                      "id": "/properties/paths/properties//contacts/{id}/properties/delete/properties/responses/properties/415",
+                      "properties": {
+                        "description": {
+                          "id": "/properties/paths/properties//contacts/{id}/properties/delete/properties/responses/properties/415/properties/description",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "500": {
+                      "id": "/properties/paths/properties//contacts/{id}/properties/delete/properties/responses/properties/500",
+                      "properties": {
+                        "description": {
+                          "id": "/properties/paths/properties//contacts/{id}/properties/delete/properties/responses/properties/500/properties/description",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    }
+                  },
+                  "type": "object"
+                },
+                "summary": {
+                  "id": "/properties/paths/properties//contacts/{id}/properties/delete/properties/summary",
+                  "type": "string"
+                },
+                "tags": {
+                  "additionalItems": false,
+                  "id": "/properties/paths/properties//contacts/{id}/properties/delete/properties/tags",
+                  "items": {
+                    "id": "/properties/paths/properties//contacts/{id}/properties/delete/properties/tags/items",
+                    "type": "string"
+                  },
+                  "type": "array"
+                }
+              },
+              "type": "object"
+            },
+            "get": {
+              "id": "/properties/paths/properties//contacts/{id}/properties/get",
+              "properties": {
+                "operationId": {
+                  "id": "/properties/paths/properties//contacts/{id}/properties/get/properties/operationId",
+                  "type": "string"
+                },
+                "parameters": {
+                  "additionalItems": false,
+                  "id": "/properties/paths/properties//contacts/{id}/properties/get/properties/parameters",
+                  "items": {
+                    "id": "/properties/paths/properties//contacts/{id}/properties/get/properties/parameters/items",
+                    "properties": {
+                      "description": {
+                        "id": "/properties/paths/properties//contacts/{id}/properties/get/properties/parameters/items/properties/description",
+                        "type": "string"
+                      },
+                      "in": {
+                        "id": "/properties/paths/properties//contacts/{id}/properties/get/properties/parameters/items/properties/in",
+                        "type": "string"
+                      },
+                      "name": {
+                        "id": "/properties/paths/properties//contacts/{id}/properties/get/properties/parameters/items/properties/name",
+                        "type": "string"
+                      },
+                      "required": {
+                        "id": "/properties/paths/properties//contacts/{id}/properties/get/properties/parameters/items/properties/required",
+                        "type": "boolean"
+                      },
+                      "type": {
+                        "id": "/properties/paths/properties//contacts/{id}/properties/get/properties/parameters/items/properties/type",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "type": "array"
+                },
+                "responses": {
+                  "id": "/properties/paths/properties//contacts/{id}/properties/get/properties/responses",
+                  "properties": {
+                    "200": {
+                      "id": "/properties/paths/properties//contacts/{id}/properties/get/properties/responses/properties/200",
+                      "properties": {
+                        "description": {
+                          "id": "/properties/paths/properties//contacts/{id}/properties/get/properties/responses/properties/200/properties/description",
+                          "type": "string"
+                        },
+                        "schema": {
+                          "id": "/properties/paths/properties//contacts/{id}/properties/get/properties/responses/properties/200/properties/schema",
+                          "properties": {
+                            "$ref": {
+                              "id": "/properties/paths/properties//contacts/{id}/properties/get/properties/responses/properties/200/properties/schema/properties/$ref",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "400": {
+                      "id": "/properties/paths/properties//contacts/{id}/properties/get/properties/responses/properties/400",
+                      "properties": {
+                        "description": {
+                          "id": "/properties/paths/properties//contacts/{id}/properties/get/properties/responses/properties/400/properties/description",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "401": {
+                      "id": "/properties/paths/properties//contacts/{id}/properties/get/properties/responses/properties/401",
+                      "properties": {
+                        "description": {
+                          "id": "/properties/paths/properties//contacts/{id}/properties/get/properties/responses/properties/401/properties/description",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "403": {
+                      "id": "/properties/paths/properties//contacts/{id}/properties/get/properties/responses/properties/403",
+                      "properties": {
+                        "description": {
+                          "id": "/properties/paths/properties//contacts/{id}/properties/get/properties/responses/properties/403/properties/description",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "404": {
+                      "id": "/properties/paths/properties//contacts/{id}/properties/get/properties/responses/properties/404",
+                      "properties": {
+                        "description": {
+                          "id": "/properties/paths/properties//contacts/{id}/properties/get/properties/responses/properties/404/properties/description",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "405": {
+                      "id": "/properties/paths/properties//contacts/{id}/properties/get/properties/responses/properties/405",
+                      "properties": {
+                        "description": {
+                          "id": "/properties/paths/properties//contacts/{id}/properties/get/properties/responses/properties/405/properties/description",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "406": {
+                      "id": "/properties/paths/properties//contacts/{id}/properties/get/properties/responses/properties/406",
+                      "properties": {
+                        "description": {
+                          "id": "/properties/paths/properties//contacts/{id}/properties/get/properties/responses/properties/406/properties/description",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "409": {
+                      "id": "/properties/paths/properties//contacts/{id}/properties/get/properties/responses/properties/409",
+                      "properties": {
+                        "description": {
+                          "id": "/properties/paths/properties//contacts/{id}/properties/get/properties/responses/properties/409/properties/description",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "415": {
+                      "id": "/properties/paths/properties//contacts/{id}/properties/get/properties/responses/properties/415",
+                      "properties": {
+                        "description": {
+                          "id": "/properties/paths/properties//contacts/{id}/properties/get/properties/responses/properties/415/properties/description",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "500": {
+                      "id": "/properties/paths/properties//contacts/{id}/properties/get/properties/responses/properties/500",
+                      "properties": {
+                        "description": {
+                          "id": "/properties/paths/properties//contacts/{id}/properties/get/properties/responses/properties/500/properties/description",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    }
+                  },
+                  "type": "object"
+                },
+                "summary": {
+                  "id": "/properties/paths/properties//contacts/{id}/properties/get/properties/summary",
+                  "type": "string"
+                },
+                "tags": {
+                  "additionalItems": false,
+                  "id": "/properties/paths/properties//contacts/{id}/properties/get/properties/tags",
+                  "items": {
+                    "id": "/properties/paths/properties//contacts/{id}/properties/get/properties/tags/items",
+                    "type": "string"
+                  },
+                  "type": "array"
+                }
+              },
+              "type": "object"
+            },
+            "patch": {
+              "id": "/properties/paths/properties//contacts/{id}/properties/patch",
+              "properties": {
+                "operationId": {
+                  "id": "/properties/paths/properties//contacts/{id}/properties/patch/properties/operationId",
+                  "type": "string"
+                },
+                "parameters": {
+                  "additionalItems": false,
+                  "id": "/properties/paths/properties//contacts/{id}/properties/patch/properties/parameters",
+                  "items": {
+                    "id": "/properties/paths/properties//contacts/{id}/properties/patch/properties/parameters/items",
+                    "properties": {
+                      "description": {
+                        "id": "/properties/paths/properties//contacts/{id}/properties/patch/properties/parameters/items/properties/description",
+                        "type": "string"
+                      },
+                      "in": {
+                        "id": "/properties/paths/properties//contacts/{id}/properties/patch/properties/parameters/items/properties/in",
+                        "type": "string"
+                      },
+                      "name": {
+                        "id": "/properties/paths/properties//contacts/{id}/properties/patch/properties/parameters/items/properties/name",
+                        "type": "string"
+                      },
+                      "required": {
+                        "id": "/properties/paths/properties//contacts/{id}/properties/patch/properties/parameters/items/properties/required",
+                        "type": "boolean"
+                      },
+                      "type": {
+                        "id": "/properties/paths/properties//contacts/{id}/properties/patch/properties/parameters/items/properties/type",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "type": "array"
+                },
+                "responses": {
+                  "id": "/properties/paths/properties//contacts/{id}/properties/patch/properties/responses",
+                  "properties": {
+                    "200": {
+                      "id": "/properties/paths/properties//contacts/{id}/properties/patch/properties/responses/properties/200",
+                      "properties": {
+                        "description": {
+                          "id": "/properties/paths/properties//contacts/{id}/properties/patch/properties/responses/properties/200/properties/description",
+                          "type": "string"
+                        },
+                        "schema": {
+                          "id": "/properties/paths/properties//contacts/{id}/properties/patch/properties/responses/properties/200/properties/schema",
+                          "properties": {
+                            "$ref": {
+                              "id": "/properties/paths/properties//contacts/{id}/properties/patch/properties/responses/properties/200/properties/schema/properties/$ref",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "400": {
+                      "id": "/properties/paths/properties//contacts/{id}/properties/patch/properties/responses/properties/400",
+                      "properties": {
+                        "description": {
+                          "id": "/properties/paths/properties//contacts/{id}/properties/patch/properties/responses/properties/400/properties/description",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "401": {
+                      "id": "/properties/paths/properties//contacts/{id}/properties/patch/properties/responses/properties/401",
+                      "properties": {
+                        "description": {
+                          "id": "/properties/paths/properties//contacts/{id}/properties/patch/properties/responses/properties/401/properties/description",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "403": {
+                      "id": "/properties/paths/properties//contacts/{id}/properties/patch/properties/responses/properties/403",
+                      "properties": {
+                        "description": {
+                          "id": "/properties/paths/properties//contacts/{id}/properties/patch/properties/responses/properties/403/properties/description",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "404": {
+                      "id": "/properties/paths/properties//contacts/{id}/properties/patch/properties/responses/properties/404",
+                      "properties": {
+                        "description": {
+                          "id": "/properties/paths/properties//contacts/{id}/properties/patch/properties/responses/properties/404/properties/description",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "405": {
+                      "id": "/properties/paths/properties//contacts/{id}/properties/patch/properties/responses/properties/405",
+                      "properties": {
+                        "description": {
+                          "id": "/properties/paths/properties//contacts/{id}/properties/patch/properties/responses/properties/405/properties/description",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "406": {
+                      "id": "/properties/paths/properties//contacts/{id}/properties/patch/properties/responses/properties/406",
+                      "properties": {
+                        "description": {
+                          "id": "/properties/paths/properties//contacts/{id}/properties/patch/properties/responses/properties/406/properties/description",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "409": {
+                      "id": "/properties/paths/properties//contacts/{id}/properties/patch/properties/responses/properties/409",
+                      "properties": {
+                        "description": {
+                          "id": "/properties/paths/properties//contacts/{id}/properties/patch/properties/responses/properties/409/properties/description",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "415": {
+                      "id": "/properties/paths/properties//contacts/{id}/properties/patch/properties/responses/properties/415",
+                      "properties": {
+                        "description": {
+                          "id": "/properties/paths/properties//contacts/{id}/properties/patch/properties/responses/properties/415/properties/description",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "500": {
+                      "id": "/properties/paths/properties//contacts/{id}/properties/patch/properties/responses/properties/500",
+                      "properties": {
+                        "description": {
+                          "id": "/properties/paths/properties//contacts/{id}/properties/patch/properties/responses/properties/500/properties/description",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    }
+                  },
+                  "type": "object"
+                },
+                "summary": {
+                  "id": "/properties/paths/properties//contacts/{id}/properties/patch/properties/summary",
+                  "type": "string"
+                },
+                "tags": {
+                  "additionalItems": false,
+                  "id": "/properties/paths/properties//contacts/{id}/properties/patch/properties/tags",
+                  "items": {
+                    "id": "/properties/paths/properties//contacts/{id}/properties/patch/properties/tags/items",
+                    "type": "string"
+                  },
+                  "type": "array"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "type": "object"
+        },
+        "/mynewcontacts": {
+          "id": "/properties/paths/properties//mynewcontacts",
+          "properties": {
+            "get": {
+              "id": "/properties/paths/properties//mynewcontacts/properties/get",
+              "properties": {
+                "operationId": {
+                  "id": "/properties/paths/properties//mynewcontacts/properties/get/properties/operationId",
+                  "type": "string"
+                },
+                "parameters": {
+                  "additionalItems": false,
+                  "id": "/properties/paths/properties//mynewcontacts/properties/get/properties/parameters",
+                  "items": {
+                    "id": "/properties/paths/properties//mynewcontacts/properties/get/properties/parameters/items",
+                    "properties": {
+                      "description": {
+                        "id": "/properties/paths/properties//mynewcontacts/properties/get/properties/parameters/items/properties/description",
+                        "type": "string"
+                      },
+                      "in": {
+                        "id": "/properties/paths/properties//mynewcontacts/properties/get/properties/parameters/items/properties/in",
+                        "type": "string"
+                      },
+                      "name": {
+                        "id": "/properties/paths/properties//mynewcontacts/properties/get/properties/parameters/items/properties/name",
+                        "type": "string"
+                      },
+                      "required": {
+                        "id": "/properties/paths/properties//mynewcontacts/properties/get/properties/parameters/items/properties/required",
+                        "type": "boolean"
+                      },
+                      "type": {
+                        "id": "/properties/paths/properties//mynewcontacts/properties/get/properties/parameters/items/properties/type",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "type": "array"
+                },
+                "responses": {
+                  "id": "/properties/paths/properties//mynewcontacts/properties/get/properties/responses",
+                  "properties": {
+                    "200": {
+                      "id": "/properties/paths/properties//mynewcontacts/properties/get/properties/responses/properties/200",
+                      "properties": {
+                        "description": {
+                          "id": "/properties/paths/properties//mynewcontacts/properties/get/properties/responses/properties/200/properties/description",
+                          "type": "string"
+                        },
+                        "schema": {
+                          "id": "/properties/paths/properties//mynewcontacts/properties/get/properties/responses/properties/200/properties/schema",
+                          "properties": {
+                            "$ref": {
+                              "id": "/properties/paths/properties//mynewcontacts/properties/get/properties/responses/properties/200/properties/schema/properties/$ref",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "400": {
+                      "id": "/properties/paths/properties//mynewcontacts/properties/get/properties/responses/properties/400",
+                      "properties": {
+                        "description": {
+                          "id": "/properties/paths/properties//mynewcontacts/properties/get/properties/responses/properties/400/properties/description",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "401": {
+                      "id": "/properties/paths/properties//mynewcontacts/properties/get/properties/responses/properties/401",
+                      "properties": {
+                        "description": {
+                          "id": "/properties/paths/properties//mynewcontacts/properties/get/properties/responses/properties/401/properties/description",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "403": {
+                      "id": "/properties/paths/properties//mynewcontacts/properties/get/properties/responses/properties/403",
+                      "properties": {
+                        "description": {
+                          "id": "/properties/paths/properties//mynewcontacts/properties/get/properties/responses/properties/403/properties/description",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "404": {
+                      "id": "/properties/paths/properties//mynewcontacts/properties/get/properties/responses/properties/404",
+                      "properties": {
+                        "description": {
+                          "id": "/properties/paths/properties//mynewcontacts/properties/get/properties/responses/properties/404/properties/description",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "405": {
+                      "id": "/properties/paths/properties//mynewcontacts/properties/get/properties/responses/properties/405",
+                      "properties": {
+                        "description": {
+                          "id": "/properties/paths/properties//mynewcontacts/properties/get/properties/responses/properties/405/properties/description",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "406": {
+                      "id": "/properties/paths/properties//mynewcontacts/properties/get/properties/responses/properties/406",
+                      "properties": {
+                        "description": {
+                          "id": "/properties/paths/properties//mynewcontacts/properties/get/properties/responses/properties/406/properties/description",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "409": {
+                      "id": "/properties/paths/properties//mynewcontacts/properties/get/properties/responses/properties/409",
+                      "properties": {
+                        "description": {
+                          "id": "/properties/paths/properties//mynewcontacts/properties/get/properties/responses/properties/409/properties/description",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "415": {
+                      "id": "/properties/paths/properties//mynewcontacts/properties/get/properties/responses/properties/415",
+                      "properties": {
+                        "description": {
+                          "id": "/properties/paths/properties//mynewcontacts/properties/get/properties/responses/properties/415/properties/description",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "500": {
+                      "id": "/properties/paths/properties//mynewcontacts/properties/get/properties/responses/properties/500",
+                      "properties": {
+                        "description": {
+                          "id": "/properties/paths/properties//mynewcontacts/properties/get/properties/responses/properties/500/properties/description",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    }
+                  },
+                  "type": "object"
+                },
+                "summary": {
+                  "id": "/properties/paths/properties//mynewcontacts/properties/get/properties/summary",
+                  "type": "string"
+                },
+                "tags": {
+                  "additionalItems": false,
+                  "id": "/properties/paths/properties//mynewcontacts/properties/get/properties/tags",
+                  "items": {
+                    "id": "/properties/paths/properties//mynewcontacts/properties/get/properties/tags/items",
+                    "type": "string"
+                  },
+                  "type": "array"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "type": "object"
+        }
+      },
+      "type": "object"
+    },
+    "swagger": {
+      "id": "/properties/swagger",
+      "type": "string"
+    },
+    "tags": {
+      "additionalItems": false,
+      "id": "/properties/tags",
+      "items": {
+        "id": "/properties/tags/items",
+        "properties": {
+          "description": {
+            "id": "/properties/tags/items/properties/description",
+            "type": "string"
+          },
+          "name": {
+            "id": "/properties/tags/items/properties/name",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "type": "array"
+    }
+  },
+  "type": "object"
+}

--- a/src/test/platform/elementbuilder/assets/elementextend/model.json
+++ b/src/test/platform/elementbuilder/assets/elementextend/model.json
@@ -1,0 +1,223 @@
+{
+  "name": "mynewcontacts",
+  "transform": false,
+  "rawSwagger": {
+    "address": {
+      "id": "address",
+      "properties": {
+        "city": {
+          "type": "string"
+        },
+        "country": {
+          "type": "string"
+        },
+        "line1": {
+          "type": "string"
+        },
+        "postal_code": {
+          "type": "unknown"
+        },
+        "state": {
+          "type": "string"
+        }
+      }
+    },
+    "custom_fields": {
+      "id": "custom_fields",
+      "properties": {}
+    },
+    "mynewcontacts": {
+      "id": "mynewcontacts",
+      "properties": {
+        "address": {
+          "type": "address"
+        },
+        "contact_id": {
+          "format": "int32",
+          "type": "integer"
+        },
+        "created_at": {
+          "type": "string"
+        },
+        "creator_id": {
+          "format": "int32",
+          "type": "integer"
+        },
+        "custom_fields": {
+          "type": "custom_fields"
+        },
+        "customer_status": {
+          "type": "string"
+        },
+        "description": {
+          "type": "unknown"
+        },
+        "email": {
+          "type": "unknown"
+        },
+        "facebook": {
+          "type": "unknown"
+        },
+        "fax": {
+          "type": "unknown"
+        },
+        "first_name": {
+          "type": "string"
+        },
+        "id": {
+          "format": "int32",
+          "type": "integer"
+        },
+        "industry": {
+          "type": "unknown"
+        },
+        "is_organization": {
+          "type": "boolean"
+        },
+        "last_name": {
+          "type": "string"
+        },
+        "linkedin": {
+          "type": "unknown"
+        },
+        "mobile": {
+          "type": "unknown"
+        },
+        "name": {
+          "type": "string"
+        },
+        "owner_id": {
+          "format": "int32",
+          "type": "integer"
+        },
+        "phone": {
+          "type": "string"
+        },
+        "prospect_status": {
+          "type": "string"
+        },
+        "skype": {
+          "type": "unknown"
+        },
+        "title": {
+          "type": "unknown"
+        },
+        "twitter": {
+          "type": "unknown"
+        },
+        "updated_at": {
+          "type": "string"
+        },
+        "website": {
+          "type": "unknown"
+        }
+      }
+    }
+  },
+  "swagger": {
+    "address": {
+      "id": "address",
+      "properties": {
+        "city": {
+          "type": "string"
+        },
+        "country": {
+          "type": "string"
+        },
+        "line1": {
+          "type": "string"
+        },
+        "state": {
+          "type": "string"
+        }
+      }
+    },
+    "mynewcontacts": {
+      "id": "mynewcontacts",
+      "properties": {
+        "address": {
+          "type": "address"
+        },
+        "contact_id": {
+          "format": "int32",
+          "type": "integer"
+        },
+        "created_at": {
+          "type": "string"
+        },
+        "creator_id": {
+          "format": "int32",
+          "type": "integer"
+        },
+        "customer_status": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "email": {
+          "type": "string"
+        },
+        "facebook": {
+          "type": "string"
+        },
+        "fax": {
+          "type": "string"
+        },
+        "first_name": {
+          "required": true,
+          "type": "string"
+        },
+        "id": {
+          "format": "int32",
+          "type": "integer"
+        },
+        "industry": {
+          "type": "string"
+        },
+        "is_organization": {
+          "type": "boolean"
+        },
+        "last_name": {
+          "required": true,
+          "type": "string"
+        },
+        "linkedin": {
+          "type": "string"
+        },
+        "mobile": {
+          "type": "string"
+        },
+        "name": {
+          "required": true,
+          "type": "string"
+        },
+        "owner_id": {
+          "format": "int32",
+          "type": "integer"
+        },
+        "phone": {
+          "type": "string"
+        },
+        "prospect_status": {
+          "type": "string"
+        },
+        "skype": {
+          "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "twitter": {
+          "type": "string"
+        },
+        "updated_at": {
+          "type": "string"
+        },
+        "website": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/src/test/platform/elementbuilder/assets/elementextend/modeldefinition.json
+++ b/src/test/platform/elementbuilder/assets/elementextend/modeldefinition.json
@@ -1,0 +1,20 @@
+{
+  "fields": [
+    {
+      "path": "mynewId",
+      "type": "string"
+    },
+    {
+      "path": "mynewdescription",
+      "type": "string"
+    },
+    {
+      "path": "mynewemail",
+      "type": "string"
+    },
+    {
+      "path": "myfirstname",
+      "type": "string"
+    }
+  ]
+}

--- a/src/test/platform/elementbuilder/assets/elementextend/modeltransformation.json
+++ b/src/test/platform/elementbuilder/assets/elementextend/modeltransformation.json
@@ -1,0 +1,33 @@
+{
+  "vendorName": "mynewcontacts",
+  "configuration": [
+    {
+      "type": "passThrough",
+      "properties": {
+        "fromVendor": false,
+        "toVendor": false
+      }
+    },
+    {
+      "type": "addToDocumentation"
+    }
+  ],
+  "fields": [
+    {
+      "path": "myfirstname",
+      "vendorPath": "first_name"
+    },
+    {
+      "path": "mynewemail",
+      "vendorPath": "email"
+    },
+    {
+      "path": "mynewId",
+      "vendorPath": "id"
+    },
+    {
+      "path": "mynewdescription",
+      "vendorPath": "description"
+    }
+  ]
+}

--- a/src/test/platform/elementbuilder/assets/elementextend/newresource.json
+++ b/src/test/platform/elementbuilder/assets/elementextend/newresource.json
@@ -1,0 +1,38 @@
+{
+  "description": "Search for My New contacts",
+  "path": "/hubs/crm/mynewcontacts",
+  "vendorPath": "/contact/",
+  "method": "GET",
+  "vendorMethod": "GET",
+  "parameters": [
+    {
+      "name": "page",
+      "vendorName": "_skip",
+      "description": "The page number. When this parameter is omitted, 1 is implied.",
+      "type": "query",
+      "vendorType": "query",
+      "dataType": "string",
+      "vendorDataType": "string",
+      "source": "request",
+      "required": false
+    },
+    {
+      "name": "pageSize",
+      "vendorName": "_limit",
+      "description": "The number of results to fetch in a given page with a maximum of 2000. When this parameter is omitted, 200 results are returned.",
+      "type": "query",
+      "vendorType": "query",
+      "dataType": "string",
+      "vendorDataType": "string",
+      "source": "request",
+      "required": false
+    }
+  ],
+  "type": "api",
+  "rootKey": "data",
+  "nextPageKey": "",
+  "hooks": [],
+  "response": {
+    "contentType": "application/json"
+  }
+}

--- a/src/test/platform/elementbuilder/assets/elementextend/overrideresource.json
+++ b/src/test/platform/elementbuilder/assets/elementextend/overrideresource.json
@@ -1,0 +1,38 @@
+{
+  "description": "This resource is overriding the contacts",
+  "path": "/hubs/crm/contacts",
+  "vendorPath": "/contact/",
+  "method": "GET",
+  "vendorMethod": "GET",
+  "parameters": [
+    {
+      "name": "page",
+      "vendorName": "_skip",
+      "description": "The page number. When this parameter is omitted, 1 is implied.",
+      "type": "query",
+      "vendorType": "query",
+      "dataType": "string",
+      "vendorDataType": "string",
+      "source": "request",
+      "required": false
+    },
+    {
+      "name": "pageSize",
+      "vendorName": "_limit",
+      "description": "The number of results to fetch in a given page with a maximum of 2000. When this parameter is omitted, 200 results are returned.",
+      "type": "query",
+      "vendorType": "query",
+      "dataType": "string",
+      "vendorDataType": "string",
+      "source": "request",
+      "required": false
+    }
+  ],
+  "type": "api",
+  "rootKey": "data",
+  "nextPageKey": "",
+  "hooks": [],
+  "response": {
+    "contentType": "application/json"
+  }
+}

--- a/src/test/platform/elementbuilder/assets/elementextend/parameter.json
+++ b/src/test/platform/elementbuilder/assets/elementextend/parameter.json
@@ -1,0 +1,11 @@
+{
+  "name": "myquery",
+  "vendorName": "vendorquery",
+  "description": "Sample myquery",
+  "type": "query",
+  "vendorType": "query",
+  "dataType": "string",
+  "vendorDataType": "string",
+  "source": "request",
+  "required": false
+}

--- a/src/test/platform/elementbuilder/assets/elementextend/swagger.schema.json
+++ b/src/test/platform/elementbuilder/assets/elementextend/swagger.schema.json
@@ -1,0 +1,1845 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "definitions": {},
+  "id": "http://example.com/example.json",
+  "properties": {
+    "basePath": {
+      "id": "/properties/basePath",
+      "type": "string"
+    },
+    "definitions": {
+      "id": "/properties/definitions",
+      "properties": {
+        "address": {
+          "id": "/properties/definitions/properties/address",
+          "properties": {
+            "properties": {
+              "id": "/properties/definitions/properties/address/properties/properties",
+              "properties": {
+                "city": {
+                  "id": "/properties/definitions/properties/address/properties/properties/properties/city",
+                  "properties": {
+                    "type": {
+                      "id": "/properties/definitions/properties/address/properties/properties/properties/city/properties/type",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "country": {
+                  "id": "/properties/definitions/properties/address/properties/properties/properties/country",
+                  "properties": {
+                    "type": {
+                      "id": "/properties/definitions/properties/address/properties/properties/properties/country/properties/type",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "line1": {
+                  "id": "/properties/definitions/properties/address/properties/properties/properties/line1",
+                  "properties": {
+                    "type": {
+                      "id": "/properties/definitions/properties/address/properties/properties/properties/line1/properties/type",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "state": {
+                  "id": "/properties/definitions/properties/address/properties/properties/properties/state",
+                  "properties": {
+                    "type": {
+                      "id": "/properties/definitions/properties/address/properties/properties/properties/state/properties/type",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              },
+              "type": "object"
+            },
+            "type": {
+              "id": "/properties/definitions/properties/address/properties/type",
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "contacts": {
+          "id": "/properties/definitions/properties/contacts",
+          "properties": {
+            "properties": {
+              "id": "/properties/definitions/properties/contacts/properties/properties",
+              "properties": {
+                "homeEmail": {
+                  "id": "/properties/definitions/properties/contacts/properties/properties/properties/homeEmail",
+                  "properties": {
+                    "type": {
+                      "id": "/properties/definitions/properties/contacts/properties/properties/properties/homeEmail/properties/type",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "homePhone": {
+                  "id": "/properties/definitions/properties/contacts/properties/properties/properties/homePhone",
+                  "properties": {
+                    "type": {
+                      "id": "/properties/definitions/properties/contacts/properties/properties/properties/homePhone/properties/type",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "homeUrl": {
+                  "id": "/properties/definitions/properties/contacts/properties/properties/properties/homeUrl",
+                  "properties": {
+                    "type": {
+                      "id": "/properties/definitions/properties/contacts/properties/properties/properties/homeUrl/properties/type",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "lead_id": {
+                  "id": "/properties/definitions/properties/contacts/properties/properties/properties/lead_id",
+                  "properties": {
+                    "type": {
+                      "id": "/properties/definitions/properties/contacts/properties/properties/properties/lead_id/properties/type",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "mobilePhone": {
+                  "id": "/properties/definitions/properties/contacts/properties/properties/properties/mobilePhone",
+                  "properties": {
+                    "type": {
+                      "id": "/properties/definitions/properties/contacts/properties/properties/properties/mobilePhone/properties/type",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "name": {
+                  "id": "/properties/definitions/properties/contacts/properties/properties/properties/name",
+                  "properties": {
+                    "type": {
+                      "id": "/properties/definitions/properties/contacts/properties/properties/properties/name/properties/type",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "officeEmail": {
+                  "id": "/properties/definitions/properties/contacts/properties/properties/properties/officeEmail",
+                  "properties": {
+                    "type": {
+                      "id": "/properties/definitions/properties/contacts/properties/properties/properties/officeEmail/properties/type",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "officePhone": {
+                  "id": "/properties/definitions/properties/contacts/properties/properties/properties/officePhone",
+                  "properties": {
+                    "type": {
+                      "id": "/properties/definitions/properties/contacts/properties/properties/properties/officePhone/properties/type",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "officeUrl": {
+                  "id": "/properties/definitions/properties/contacts/properties/properties/properties/officeUrl",
+                  "properties": {
+                    "type": {
+                      "id": "/properties/definitions/properties/contacts/properties/properties/properties/officeUrl/properties/type",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "organization_id": {
+                  "id": "/properties/definitions/properties/contacts/properties/properties/properties/organization_id",
+                  "properties": {
+                    "type": {
+                      "id": "/properties/definitions/properties/contacts/properties/properties/properties/organization_id/properties/type",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "title": {
+                  "id": "/properties/definitions/properties/contacts/properties/properties/properties/title",
+                  "properties": {
+                    "type": {
+                      "id": "/properties/definitions/properties/contacts/properties/properties/properties/title/properties/type",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              },
+              "type": "object"
+            },
+            "required": {
+              "additionalItems": false,
+              "id": "/properties/definitions/properties/contacts/properties/required",
+              "items": {
+                "id": "/properties/definitions/properties/contacts/properties/required/items",
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "type": {
+              "id": "/properties/definitions/properties/contacts/properties/type",
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "mynewcontacts": {
+          "id": "/properties/definitions/properties/mynewcontacts",
+          "properties": {
+            "properties": {
+              "id": "/properties/definitions/properties/mynewcontacts/properties/properties",
+              "properties": {
+                "address": {
+                  "id": "/properties/definitions/properties/mynewcontacts/properties/properties/properties/address",
+                  "properties": {
+                    "$ref": {
+                      "id": "/properties/definitions/properties/mynewcontacts/properties/properties/properties/address/properties/$ref",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "contact_id": {
+                  "id": "/properties/definitions/properties/mynewcontacts/properties/properties/properties/contact_id",
+                  "properties": {
+                    "format": {
+                      "id": "/properties/definitions/properties/mynewcontacts/properties/properties/properties/contact_id/properties/format",
+                      "type": "string"
+                    },
+                    "type": {
+                      "id": "/properties/definitions/properties/mynewcontacts/properties/properties/properties/contact_id/properties/type",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "created_at": {
+                  "id": "/properties/definitions/properties/mynewcontacts/properties/properties/properties/created_at",
+                  "properties": {
+                    "type": {
+                      "id": "/properties/definitions/properties/mynewcontacts/properties/properties/properties/created_at/properties/type",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "creator_id": {
+                  "id": "/properties/definitions/properties/mynewcontacts/properties/properties/properties/creator_id",
+                  "properties": {
+                    "format": {
+                      "id": "/properties/definitions/properties/mynewcontacts/properties/properties/properties/creator_id/properties/format",
+                      "type": "string"
+                    },
+                    "type": {
+                      "id": "/properties/definitions/properties/mynewcontacts/properties/properties/properties/creator_id/properties/type",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "customer_status": {
+                  "id": "/properties/definitions/properties/mynewcontacts/properties/properties/properties/customer_status",
+                  "properties": {
+                    "type": {
+                      "id": "/properties/definitions/properties/mynewcontacts/properties/properties/properties/customer_status/properties/type",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "description": {
+                  "id": "/properties/definitions/properties/mynewcontacts/properties/properties/properties/description",
+                  "properties": {
+                    "type": {
+                      "id": "/properties/definitions/properties/mynewcontacts/properties/properties/properties/description/properties/type",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "email": {
+                  "id": "/properties/definitions/properties/mynewcontacts/properties/properties/properties/email",
+                  "properties": {
+                    "type": {
+                      "id": "/properties/definitions/properties/mynewcontacts/properties/properties/properties/email/properties/type",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "facebook": {
+                  "id": "/properties/definitions/properties/mynewcontacts/properties/properties/properties/facebook",
+                  "properties": {
+                    "type": {
+                      "id": "/properties/definitions/properties/mynewcontacts/properties/properties/properties/facebook/properties/type",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "fax": {
+                  "id": "/properties/definitions/properties/mynewcontacts/properties/properties/properties/fax",
+                  "properties": {
+                    "type": {
+                      "id": "/properties/definitions/properties/mynewcontacts/properties/properties/properties/fax/properties/type",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "first_name": {
+                  "id": "/properties/definitions/properties/mynewcontacts/properties/properties/properties/first_name",
+                  "properties": {
+                    "type": {
+                      "id": "/properties/definitions/properties/mynewcontacts/properties/properties/properties/first_name/properties/type",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "id": {
+                  "id": "/properties/definitions/properties/mynewcontacts/properties/properties/properties/id",
+                  "properties": {
+                    "format": {
+                      "id": "/properties/definitions/properties/mynewcontacts/properties/properties/properties/id/properties/format",
+                      "type": "string"
+                    },
+                    "type": {
+                      "id": "/properties/definitions/properties/mynewcontacts/properties/properties/properties/id/properties/type",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "industry": {
+                  "id": "/properties/definitions/properties/mynewcontacts/properties/properties/properties/industry",
+                  "properties": {
+                    "type": {
+                      "id": "/properties/definitions/properties/mynewcontacts/properties/properties/properties/industry/properties/type",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "is_organization": {
+                  "id": "/properties/definitions/properties/mynewcontacts/properties/properties/properties/is_organization",
+                  "properties": {
+                    "type": {
+                      "id": "/properties/definitions/properties/mynewcontacts/properties/properties/properties/is_organization/properties/type",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "last_name": {
+                  "id": "/properties/definitions/properties/mynewcontacts/properties/properties/properties/last_name",
+                  "properties": {
+                    "type": {
+                      "id": "/properties/definitions/properties/mynewcontacts/properties/properties/properties/last_name/properties/type",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "linkedin": {
+                  "id": "/properties/definitions/properties/mynewcontacts/properties/properties/properties/linkedin",
+                  "properties": {
+                    "type": {
+                      "id": "/properties/definitions/properties/mynewcontacts/properties/properties/properties/linkedin/properties/type",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "mobile": {
+                  "id": "/properties/definitions/properties/mynewcontacts/properties/properties/properties/mobile",
+                  "properties": {
+                    "type": {
+                      "id": "/properties/definitions/properties/mynewcontacts/properties/properties/properties/mobile/properties/type",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "name": {
+                  "id": "/properties/definitions/properties/mynewcontacts/properties/properties/properties/name",
+                  "properties": {
+                    "type": {
+                      "id": "/properties/definitions/properties/mynewcontacts/properties/properties/properties/name/properties/type",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "owner_id": {
+                  "id": "/properties/definitions/properties/mynewcontacts/properties/properties/properties/owner_id",
+                  "properties": {
+                    "format": {
+                      "id": "/properties/definitions/properties/mynewcontacts/properties/properties/properties/owner_id/properties/format",
+                      "type": "string"
+                    },
+                    "type": {
+                      "id": "/properties/definitions/properties/mynewcontacts/properties/properties/properties/owner_id/properties/type",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "phone": {
+                  "id": "/properties/definitions/properties/mynewcontacts/properties/properties/properties/phone",
+                  "properties": {
+                    "type": {
+                      "id": "/properties/definitions/properties/mynewcontacts/properties/properties/properties/phone/properties/type",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "prospect_status": {
+                  "id": "/properties/definitions/properties/mynewcontacts/properties/properties/properties/prospect_status",
+                  "properties": {
+                    "type": {
+                      "id": "/properties/definitions/properties/mynewcontacts/properties/properties/properties/prospect_status/properties/type",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "skype": {
+                  "id": "/properties/definitions/properties/mynewcontacts/properties/properties/properties/skype",
+                  "properties": {
+                    "type": {
+                      "id": "/properties/definitions/properties/mynewcontacts/properties/properties/properties/skype/properties/type",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "title": {
+                  "id": "/properties/definitions/properties/mynewcontacts/properties/properties/properties/title",
+                  "properties": {
+                    "type": {
+                      "id": "/properties/definitions/properties/mynewcontacts/properties/properties/properties/title/properties/type",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "twitter": {
+                  "id": "/properties/definitions/properties/mynewcontacts/properties/properties/properties/twitter",
+                  "properties": {
+                    "type": {
+                      "id": "/properties/definitions/properties/mynewcontacts/properties/properties/properties/twitter/properties/type",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "updated_at": {
+                  "id": "/properties/definitions/properties/mynewcontacts/properties/properties/properties/updated_at",
+                  "properties": {
+                    "type": {
+                      "id": "/properties/definitions/properties/mynewcontacts/properties/properties/properties/updated_at/properties/type",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "website": {
+                  "id": "/properties/definitions/properties/mynewcontacts/properties/properties/properties/website",
+                  "properties": {
+                    "type": {
+                      "id": "/properties/definitions/properties/mynewcontacts/properties/properties/properties/website/properties/type",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              },
+              "type": "object"
+            },
+            "required": {
+              "additionalItems": false,
+              "id": "/properties/definitions/properties/mynewcontacts/properties/required",
+              "items": {
+                "id": "/properties/definitions/properties/mynewcontacts/properties/required/items",
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "type": {
+              "id": "/properties/definitions/properties/mynewcontacts/properties/type",
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "newtransformedcontacts": {
+          "id": "/properties/definitions/properties/newtransformedcontacts",
+          "properties": {
+            "properties": {
+              "id": "/properties/definitions/properties/newtransformedcontacts/properties/properties",
+              "properties": {
+                "myfirstname": {
+                  "id": "/properties/definitions/properties/newtransformedcontacts/properties/properties/properties/myfirstname",
+                  "properties": {
+                    "type": {
+                      "id": "/properties/definitions/properties/newtransformedcontacts/properties/properties/properties/myfirstname/properties/type",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "mynewId": {
+                  "id": "/properties/definitions/properties/newtransformedcontacts/properties/properties/properties/mynewId",
+                  "properties": {
+                    "type": {
+                      "id": "/properties/definitions/properties/newtransformedcontacts/properties/properties/properties/mynewId/properties/type",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "mynewdescription": {
+                  "id": "/properties/definitions/properties/newtransformedcontacts/properties/properties/properties/mynewdescription",
+                  "properties": {
+                    "type": {
+                      "id": "/properties/definitions/properties/newtransformedcontacts/properties/properties/properties/mynewdescription/properties/type",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "mynewemail": {
+                  "id": "/properties/definitions/properties/newtransformedcontacts/properties/properties/properties/mynewemail",
+                  "properties": {
+                    "type": {
+                      "id": "/properties/definitions/properties/newtransformedcontacts/properties/properties/properties/mynewemail/properties/type",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              },
+              "type": "object"
+            },
+            "type": {
+              "id": "/properties/definitions/properties/newtransformedcontacts/properties/type",
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "objectsMetadata": {
+          "id": "/properties/definitions/properties/objectsMetadata",
+          "properties": {
+            "properties": {
+              "id": "/properties/definitions/properties/objectsMetadata/properties/properties",
+              "properties": {
+                "fields": {
+                  "id": "/properties/definitions/properties/objectsMetadata/properties/properties/properties/fields",
+                  "properties": {
+                    "items": {
+                      "id": "/properties/definitions/properties/objectsMetadata/properties/properties/properties/fields/properties/items",
+                      "properties": {
+                        "$ref": {
+                          "id": "/properties/definitions/properties/objectsMetadata/properties/properties/properties/fields/properties/items/properties/$ref",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "type": {
+                      "id": "/properties/definitions/properties/objectsMetadata/properties/properties/properties/fields/properties/type",
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "type": "object"
+        }
+      },
+      "type": "object"
+    },
+    "info": {
+      "id": "/properties/info",
+      "properties": {
+        "contact": {
+          "id": "/properties/info/properties/contact",
+          "properties": {
+            "email": {
+              "id": "/properties/info/properties/contact/properties/email",
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "title": {
+          "id": "/properties/info/properties/title",
+          "type": "string"
+        },
+        "version": {
+          "id": "/properties/info/properties/version",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "paths": {
+      "id": "/properties/paths",
+      "properties": {
+        "/contacts": {
+          "id": "/properties/paths/properties//contacts",
+          "properties": {
+            "get": {
+              "id": "/properties/paths/properties//contacts/properties/get",
+              "properties": {
+                "operationId": {
+                  "id": "/properties/paths/properties//contacts/properties/get/properties/operationId",
+                  "type": "string"
+                },
+                "parameters": {
+                  "additionalItems": false,
+                  "id": "/properties/paths/properties//contacts/properties/get/properties/parameters",
+                  "items": {
+                    "id": "/properties/paths/properties//contacts/properties/get/properties/parameters/items",
+                    "properties": {
+                      "description": {
+                        "id": "/properties/paths/properties//contacts/properties/get/properties/parameters/items/properties/description",
+                        "type": "string"
+                      },
+                      "in": {
+                        "id": "/properties/paths/properties//contacts/properties/get/properties/parameters/items/properties/in",
+                        "type": "string"
+                      },
+                      "name": {
+                        "id": "/properties/paths/properties//contacts/properties/get/properties/parameters/items/properties/name",
+                        "type": "string"
+                      },
+                      "required": {
+                        "id": "/properties/paths/properties//contacts/properties/get/properties/parameters/items/properties/required",
+                        "type": "boolean"
+                      },
+                      "type": {
+                        "id": "/properties/paths/properties//contacts/properties/get/properties/parameters/items/properties/type",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "type": "array"
+                },
+                "responses": {
+                  "id": "/properties/paths/properties//contacts/properties/get/properties/responses",
+                  "properties": {
+                    "200": {
+                      "id": "/properties/paths/properties//contacts/properties/get/properties/responses/properties/200",
+                      "properties": {
+                        "description": {
+                          "id": "/properties/paths/properties//contacts/properties/get/properties/responses/properties/200/properties/description",
+                          "type": "string"
+                        },
+                        "schema": {
+                          "id": "/properties/paths/properties//contacts/properties/get/properties/responses/properties/200/properties/schema",
+                          "properties": {
+                            "$ref": {
+                              "id": "/properties/paths/properties//contacts/properties/get/properties/responses/properties/200/properties/schema/properties/$ref",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "400": {
+                      "id": "/properties/paths/properties//contacts/properties/get/properties/responses/properties/400",
+                      "properties": {
+                        "description": {
+                          "id": "/properties/paths/properties//contacts/properties/get/properties/responses/properties/400/properties/description",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "401": {
+                      "id": "/properties/paths/properties//contacts/properties/get/properties/responses/properties/401",
+                      "properties": {
+                        "description": {
+                          "id": "/properties/paths/properties//contacts/properties/get/properties/responses/properties/401/properties/description",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "403": {
+                      "id": "/properties/paths/properties//contacts/properties/get/properties/responses/properties/403",
+                      "properties": {
+                        "description": {
+                          "id": "/properties/paths/properties//contacts/properties/get/properties/responses/properties/403/properties/description",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "404": {
+                      "id": "/properties/paths/properties//contacts/properties/get/properties/responses/properties/404",
+                      "properties": {
+                        "description": {
+                          "id": "/properties/paths/properties//contacts/properties/get/properties/responses/properties/404/properties/description",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "405": {
+                      "id": "/properties/paths/properties//contacts/properties/get/properties/responses/properties/405",
+                      "properties": {
+                        "description": {
+                          "id": "/properties/paths/properties//contacts/properties/get/properties/responses/properties/405/properties/description",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "406": {
+                      "id": "/properties/paths/properties//contacts/properties/get/properties/responses/properties/406",
+                      "properties": {
+                        "description": {
+                          "id": "/properties/paths/properties//contacts/properties/get/properties/responses/properties/406/properties/description",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "409": {
+                      "id": "/properties/paths/properties//contacts/properties/get/properties/responses/properties/409",
+                      "properties": {
+                        "description": {
+                          "id": "/properties/paths/properties//contacts/properties/get/properties/responses/properties/409/properties/description",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "415": {
+                      "id": "/properties/paths/properties//contacts/properties/get/properties/responses/properties/415",
+                      "properties": {
+                        "description": {
+                          "id": "/properties/paths/properties//contacts/properties/get/properties/responses/properties/415/properties/description",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "500": {
+                      "id": "/properties/paths/properties//contacts/properties/get/properties/responses/properties/500",
+                      "properties": {
+                        "description": {
+                          "id": "/properties/paths/properties//contacts/properties/get/properties/responses/properties/500/properties/description",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    }
+                  },
+                  "type": "object"
+                },
+                "summary": {
+                  "id": "/properties/paths/properties//contacts/properties/get/properties/summary",
+                  "type": "string"
+                },
+                "tags": {
+                  "additionalItems": false,
+                  "id": "/properties/paths/properties//contacts/properties/get/properties/tags",
+                  "items": {
+                    "id": "/properties/paths/properties//contacts/properties/get/properties/tags/items",
+                    "type": "string"
+                  },
+                  "type": "array"
+                }
+              },
+              "type": "object"
+            },
+            "post": {
+              "id": "/properties/paths/properties//contacts/properties/post",
+              "properties": {
+                "operationId": {
+                  "id": "/properties/paths/properties//contacts/properties/post/properties/operationId",
+                  "type": "string"
+                },
+                "parameters": {
+                  "additionalItems": false,
+                  "id": "/properties/paths/properties//contacts/properties/post/properties/parameters",
+                  "items": {
+                    "id": "/properties/paths/properties//contacts/properties/post/properties/parameters/items",
+                    "properties": {
+                      "description": {
+                        "id": "/properties/paths/properties//contacts/properties/post/properties/parameters/items/properties/description",
+                        "type": "string"
+                      },
+                      "in": {
+                        "id": "/properties/paths/properties//contacts/properties/post/properties/parameters/items/properties/in",
+                        "type": "string"
+                      },
+                      "name": {
+                        "id": "/properties/paths/properties//contacts/properties/post/properties/parameters/items/properties/name",
+                        "type": "string"
+                      },
+                      "required": {
+                        "id": "/properties/paths/properties//contacts/properties/post/properties/parameters/items/properties/required",
+                        "type": "boolean"
+                      },
+                      "type": {
+                        "id": "/properties/paths/properties//contacts/properties/post/properties/parameters/items/properties/type",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "type": "array"
+                },
+                "responses": {
+                  "id": "/properties/paths/properties//contacts/properties/post/properties/responses",
+                  "properties": {
+                    "200": {
+                      "id": "/properties/paths/properties//contacts/properties/post/properties/responses/properties/200",
+                      "properties": {
+                        "description": {
+                          "id": "/properties/paths/properties//contacts/properties/post/properties/responses/properties/200/properties/description",
+                          "type": "string"
+                        },
+                        "schema": {
+                          "id": "/properties/paths/properties//contacts/properties/post/properties/responses/properties/200/properties/schema",
+                          "properties": {
+                            "$ref": {
+                              "id": "/properties/paths/properties//contacts/properties/post/properties/responses/properties/200/properties/schema/properties/$ref",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "400": {
+                      "id": "/properties/paths/properties//contacts/properties/post/properties/responses/properties/400",
+                      "properties": {
+                        "description": {
+                          "id": "/properties/paths/properties//contacts/properties/post/properties/responses/properties/400/properties/description",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "401": {
+                      "id": "/properties/paths/properties//contacts/properties/post/properties/responses/properties/401",
+                      "properties": {
+                        "description": {
+                          "id": "/properties/paths/properties//contacts/properties/post/properties/responses/properties/401/properties/description",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "403": {
+                      "id": "/properties/paths/properties//contacts/properties/post/properties/responses/properties/403",
+                      "properties": {
+                        "description": {
+                          "id": "/properties/paths/properties//contacts/properties/post/properties/responses/properties/403/properties/description",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "404": {
+                      "id": "/properties/paths/properties//contacts/properties/post/properties/responses/properties/404",
+                      "properties": {
+                        "description": {
+                          "id": "/properties/paths/properties//contacts/properties/post/properties/responses/properties/404/properties/description",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "405": {
+                      "id": "/properties/paths/properties//contacts/properties/post/properties/responses/properties/405",
+                      "properties": {
+                        "description": {
+                          "id": "/properties/paths/properties//contacts/properties/post/properties/responses/properties/405/properties/description",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "406": {
+                      "id": "/properties/paths/properties//contacts/properties/post/properties/responses/properties/406",
+                      "properties": {
+                        "description": {
+                          "id": "/properties/paths/properties//contacts/properties/post/properties/responses/properties/406/properties/description",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "409": {
+                      "id": "/properties/paths/properties//contacts/properties/post/properties/responses/properties/409",
+                      "properties": {
+                        "description": {
+                          "id": "/properties/paths/properties//contacts/properties/post/properties/responses/properties/409/properties/description",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "415": {
+                      "id": "/properties/paths/properties//contacts/properties/post/properties/responses/properties/415",
+                      "properties": {
+                        "description": {
+                          "id": "/properties/paths/properties//contacts/properties/post/properties/responses/properties/415/properties/description",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "500": {
+                      "id": "/properties/paths/properties//contacts/properties/post/properties/responses/properties/500",
+                      "properties": {
+                        "description": {
+                          "id": "/properties/paths/properties//contacts/properties/post/properties/responses/properties/500/properties/description",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    }
+                  },
+                  "type": "object"
+                },
+                "summary": {
+                  "id": "/properties/paths/properties//contacts/properties/post/properties/summary",
+                  "type": "string"
+                },
+                "tags": {
+                  "additionalItems": false,
+                  "id": "/properties/paths/properties//contacts/properties/post/properties/tags",
+                  "items": {
+                    "id": "/properties/paths/properties//contacts/properties/post/properties/tags/items",
+                    "type": "string"
+                  },
+                  "type": "array"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "type": "object"
+        },
+        "/contacts/{id}": {
+          "id": "/properties/paths/properties//contacts/{id}",
+          "properties": {
+            "delete": {
+              "id": "/properties/paths/properties//contacts/{id}/properties/delete",
+              "properties": {
+                "operationId": {
+                  "id": "/properties/paths/properties//contacts/{id}/properties/delete/properties/operationId",
+                  "type": "string"
+                },
+                "parameters": {
+                  "additionalItems": false,
+                  "id": "/properties/paths/properties//contacts/{id}/properties/delete/properties/parameters",
+                  "items": {
+                    "id": "/properties/paths/properties//contacts/{id}/properties/delete/properties/parameters/items",
+                    "properties": {
+                      "description": {
+                        "id": "/properties/paths/properties//contacts/{id}/properties/delete/properties/parameters/items/properties/description",
+                        "type": "string"
+                      },
+                      "in": {
+                        "id": "/properties/paths/properties//contacts/{id}/properties/delete/properties/parameters/items/properties/in",
+                        "type": "string"
+                      },
+                      "name": {
+                        "id": "/properties/paths/properties//contacts/{id}/properties/delete/properties/parameters/items/properties/name",
+                        "type": "string"
+                      },
+                      "required": {
+                        "id": "/properties/paths/properties//contacts/{id}/properties/delete/properties/parameters/items/properties/required",
+                        "type": "boolean"
+                      },
+                      "type": {
+                        "id": "/properties/paths/properties//contacts/{id}/properties/delete/properties/parameters/items/properties/type",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "type": "array"
+                },
+                "responses": {
+                  "id": "/properties/paths/properties//contacts/{id}/properties/delete/properties/responses",
+                  "properties": {
+                    "200": {
+                      "id": "/properties/paths/properties//contacts/{id}/properties/delete/properties/responses/properties/200",
+                      "properties": {
+                        "description": {
+                          "id": "/properties/paths/properties//contacts/{id}/properties/delete/properties/responses/properties/200/properties/description",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "400": {
+                      "id": "/properties/paths/properties//contacts/{id}/properties/delete/properties/responses/properties/400",
+                      "properties": {
+                        "description": {
+                          "id": "/properties/paths/properties//contacts/{id}/properties/delete/properties/responses/properties/400/properties/description",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "401": {
+                      "id": "/properties/paths/properties//contacts/{id}/properties/delete/properties/responses/properties/401",
+                      "properties": {
+                        "description": {
+                          "id": "/properties/paths/properties//contacts/{id}/properties/delete/properties/responses/properties/401/properties/description",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "403": {
+                      "id": "/properties/paths/properties//contacts/{id}/properties/delete/properties/responses/properties/403",
+                      "properties": {
+                        "description": {
+                          "id": "/properties/paths/properties//contacts/{id}/properties/delete/properties/responses/properties/403/properties/description",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "404": {
+                      "id": "/properties/paths/properties//contacts/{id}/properties/delete/properties/responses/properties/404",
+                      "properties": {
+                        "description": {
+                          "id": "/properties/paths/properties//contacts/{id}/properties/delete/properties/responses/properties/404/properties/description",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "405": {
+                      "id": "/properties/paths/properties//contacts/{id}/properties/delete/properties/responses/properties/405",
+                      "properties": {
+                        "description": {
+                          "id": "/properties/paths/properties//contacts/{id}/properties/delete/properties/responses/properties/405/properties/description",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "406": {
+                      "id": "/properties/paths/properties//contacts/{id}/properties/delete/properties/responses/properties/406",
+                      "properties": {
+                        "description": {
+                          "id": "/properties/paths/properties//contacts/{id}/properties/delete/properties/responses/properties/406/properties/description",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "409": {
+                      "id": "/properties/paths/properties//contacts/{id}/properties/delete/properties/responses/properties/409",
+                      "properties": {
+                        "description": {
+                          "id": "/properties/paths/properties//contacts/{id}/properties/delete/properties/responses/properties/409/properties/description",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "415": {
+                      "id": "/properties/paths/properties//contacts/{id}/properties/delete/properties/responses/properties/415",
+                      "properties": {
+                        "description": {
+                          "id": "/properties/paths/properties//contacts/{id}/properties/delete/properties/responses/properties/415/properties/description",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "500": {
+                      "id": "/properties/paths/properties//contacts/{id}/properties/delete/properties/responses/properties/500",
+                      "properties": {
+                        "description": {
+                          "id": "/properties/paths/properties//contacts/{id}/properties/delete/properties/responses/properties/500/properties/description",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    }
+                  },
+                  "type": "object"
+                },
+                "summary": {
+                  "id": "/properties/paths/properties//contacts/{id}/properties/delete/properties/summary",
+                  "type": "string"
+                },
+                "tags": {
+                  "additionalItems": false,
+                  "id": "/properties/paths/properties//contacts/{id}/properties/delete/properties/tags",
+                  "items": {
+                    "id": "/properties/paths/properties//contacts/{id}/properties/delete/properties/tags/items",
+                    "type": "string"
+                  },
+                  "type": "array"
+                }
+              },
+              "type": "object"
+            },
+            "get": {
+              "id": "/properties/paths/properties//contacts/{id}/properties/get",
+              "properties": {
+                "operationId": {
+                  "id": "/properties/paths/properties//contacts/{id}/properties/get/properties/operationId",
+                  "type": "string"
+                },
+                "parameters": {
+                  "additionalItems": false,
+                  "id": "/properties/paths/properties//contacts/{id}/properties/get/properties/parameters",
+                  "items": {
+                    "id": "/properties/paths/properties//contacts/{id}/properties/get/properties/parameters/items",
+                    "properties": {
+                      "description": {
+                        "id": "/properties/paths/properties//contacts/{id}/properties/get/properties/parameters/items/properties/description",
+                        "type": "string"
+                      },
+                      "in": {
+                        "id": "/properties/paths/properties//contacts/{id}/properties/get/properties/parameters/items/properties/in",
+                        "type": "string"
+                      },
+                      "name": {
+                        "id": "/properties/paths/properties//contacts/{id}/properties/get/properties/parameters/items/properties/name",
+                        "type": "string"
+                      },
+                      "required": {
+                        "id": "/properties/paths/properties//contacts/{id}/properties/get/properties/parameters/items/properties/required",
+                        "type": "boolean"
+                      },
+                      "type": {
+                        "id": "/properties/paths/properties//contacts/{id}/properties/get/properties/parameters/items/properties/type",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "type": "array"
+                },
+                "responses": {
+                  "id": "/properties/paths/properties//contacts/{id}/properties/get/properties/responses",
+                  "properties": {
+                    "200": {
+                      "id": "/properties/paths/properties//contacts/{id}/properties/get/properties/responses/properties/200",
+                      "properties": {
+                        "description": {
+                          "id": "/properties/paths/properties//contacts/{id}/properties/get/properties/responses/properties/200/properties/description",
+                          "type": "string"
+                        },
+                        "schema": {
+                          "id": "/properties/paths/properties//contacts/{id}/properties/get/properties/responses/properties/200/properties/schema",
+                          "properties": {
+                            "$ref": {
+                              "id": "/properties/paths/properties//contacts/{id}/properties/get/properties/responses/properties/200/properties/schema/properties/$ref",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "400": {
+                      "id": "/properties/paths/properties//contacts/{id}/properties/get/properties/responses/properties/400",
+                      "properties": {
+                        "description": {
+                          "id": "/properties/paths/properties//contacts/{id}/properties/get/properties/responses/properties/400/properties/description",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "401": {
+                      "id": "/properties/paths/properties//contacts/{id}/properties/get/properties/responses/properties/401",
+                      "properties": {
+                        "description": {
+                          "id": "/properties/paths/properties//contacts/{id}/properties/get/properties/responses/properties/401/properties/description",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "403": {
+                      "id": "/properties/paths/properties//contacts/{id}/properties/get/properties/responses/properties/403",
+                      "properties": {
+                        "description": {
+                          "id": "/properties/paths/properties//contacts/{id}/properties/get/properties/responses/properties/403/properties/description",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "404": {
+                      "id": "/properties/paths/properties//contacts/{id}/properties/get/properties/responses/properties/404",
+                      "properties": {
+                        "description": {
+                          "id": "/properties/paths/properties//contacts/{id}/properties/get/properties/responses/properties/404/properties/description",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "405": {
+                      "id": "/properties/paths/properties//contacts/{id}/properties/get/properties/responses/properties/405",
+                      "properties": {
+                        "description": {
+                          "id": "/properties/paths/properties//contacts/{id}/properties/get/properties/responses/properties/405/properties/description",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "406": {
+                      "id": "/properties/paths/properties//contacts/{id}/properties/get/properties/responses/properties/406",
+                      "properties": {
+                        "description": {
+                          "id": "/properties/paths/properties//contacts/{id}/properties/get/properties/responses/properties/406/properties/description",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "409": {
+                      "id": "/properties/paths/properties//contacts/{id}/properties/get/properties/responses/properties/409",
+                      "properties": {
+                        "description": {
+                          "id": "/properties/paths/properties//contacts/{id}/properties/get/properties/responses/properties/409/properties/description",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "415": {
+                      "id": "/properties/paths/properties//contacts/{id}/properties/get/properties/responses/properties/415",
+                      "properties": {
+                        "description": {
+                          "id": "/properties/paths/properties//contacts/{id}/properties/get/properties/responses/properties/415/properties/description",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "500": {
+                      "id": "/properties/paths/properties//contacts/{id}/properties/get/properties/responses/properties/500",
+                      "properties": {
+                        "description": {
+                          "id": "/properties/paths/properties//contacts/{id}/properties/get/properties/responses/properties/500/properties/description",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    }
+                  },
+                  "type": "object"
+                },
+                "summary": {
+                  "id": "/properties/paths/properties//contacts/{id}/properties/get/properties/summary",
+                  "type": "string"
+                },
+                "tags": {
+                  "additionalItems": false,
+                  "id": "/properties/paths/properties//contacts/{id}/properties/get/properties/tags",
+                  "items": {
+                    "id": "/properties/paths/properties//contacts/{id}/properties/get/properties/tags/items",
+                    "type": "string"
+                  },
+                  "type": "array"
+                }
+              },
+              "type": "object"
+            },
+            "patch": {
+              "id": "/properties/paths/properties//contacts/{id}/properties/patch",
+              "properties": {
+                "operationId": {
+                  "id": "/properties/paths/properties//contacts/{id}/properties/patch/properties/operationId",
+                  "type": "string"
+                },
+                "parameters": {
+                  "additionalItems": false,
+                  "id": "/properties/paths/properties//contacts/{id}/properties/patch/properties/parameters",
+                  "items": {
+                    "id": "/properties/paths/properties//contacts/{id}/properties/patch/properties/parameters/items",
+                    "properties": {
+                      "description": {
+                        "id": "/properties/paths/properties//contacts/{id}/properties/patch/properties/parameters/items/properties/description",
+                        "type": "string"
+                      },
+                      "in": {
+                        "id": "/properties/paths/properties//contacts/{id}/properties/patch/properties/parameters/items/properties/in",
+                        "type": "string"
+                      },
+                      "name": {
+                        "id": "/properties/paths/properties//contacts/{id}/properties/patch/properties/parameters/items/properties/name",
+                        "type": "string"
+                      },
+                      "required": {
+                        "id": "/properties/paths/properties//contacts/{id}/properties/patch/properties/parameters/items/properties/required",
+                        "type": "boolean"
+                      },
+                      "type": {
+                        "id": "/properties/paths/properties//contacts/{id}/properties/patch/properties/parameters/items/properties/type",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "type": "array"
+                },
+                "responses": {
+                  "id": "/properties/paths/properties//contacts/{id}/properties/patch/properties/responses",
+                  "properties": {
+                    "200": {
+                      "id": "/properties/paths/properties//contacts/{id}/properties/patch/properties/responses/properties/200",
+                      "properties": {
+                        "description": {
+                          "id": "/properties/paths/properties//contacts/{id}/properties/patch/properties/responses/properties/200/properties/description",
+                          "type": "string"
+                        },
+                        "schema": {
+                          "id": "/properties/paths/properties//contacts/{id}/properties/patch/properties/responses/properties/200/properties/schema",
+                          "properties": {
+                            "$ref": {
+                              "id": "/properties/paths/properties//contacts/{id}/properties/patch/properties/responses/properties/200/properties/schema/properties/$ref",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "400": {
+                      "id": "/properties/paths/properties//contacts/{id}/properties/patch/properties/responses/properties/400",
+                      "properties": {
+                        "description": {
+                          "id": "/properties/paths/properties//contacts/{id}/properties/patch/properties/responses/properties/400/properties/description",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "401": {
+                      "id": "/properties/paths/properties//contacts/{id}/properties/patch/properties/responses/properties/401",
+                      "properties": {
+                        "description": {
+                          "id": "/properties/paths/properties//contacts/{id}/properties/patch/properties/responses/properties/401/properties/description",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "403": {
+                      "id": "/properties/paths/properties//contacts/{id}/properties/patch/properties/responses/properties/403",
+                      "properties": {
+                        "description": {
+                          "id": "/properties/paths/properties//contacts/{id}/properties/patch/properties/responses/properties/403/properties/description",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "404": {
+                      "id": "/properties/paths/properties//contacts/{id}/properties/patch/properties/responses/properties/404",
+                      "properties": {
+                        "description": {
+                          "id": "/properties/paths/properties//contacts/{id}/properties/patch/properties/responses/properties/404/properties/description",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "405": {
+                      "id": "/properties/paths/properties//contacts/{id}/properties/patch/properties/responses/properties/405",
+                      "properties": {
+                        "description": {
+                          "id": "/properties/paths/properties//contacts/{id}/properties/patch/properties/responses/properties/405/properties/description",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "406": {
+                      "id": "/properties/paths/properties//contacts/{id}/properties/patch/properties/responses/properties/406",
+                      "properties": {
+                        "description": {
+                          "id": "/properties/paths/properties//contacts/{id}/properties/patch/properties/responses/properties/406/properties/description",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "409": {
+                      "id": "/properties/paths/properties//contacts/{id}/properties/patch/properties/responses/properties/409",
+                      "properties": {
+                        "description": {
+                          "id": "/properties/paths/properties//contacts/{id}/properties/patch/properties/responses/properties/409/properties/description",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "415": {
+                      "id": "/properties/paths/properties//contacts/{id}/properties/patch/properties/responses/properties/415",
+                      "properties": {
+                        "description": {
+                          "id": "/properties/paths/properties//contacts/{id}/properties/patch/properties/responses/properties/415/properties/description",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "500": {
+                      "id": "/properties/paths/properties//contacts/{id}/properties/patch/properties/responses/properties/500",
+                      "properties": {
+                        "description": {
+                          "id": "/properties/paths/properties//contacts/{id}/properties/patch/properties/responses/properties/500/properties/description",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    }
+                  },
+                  "type": "object"
+                },
+                "summary": {
+                  "id": "/properties/paths/properties//contacts/{id}/properties/patch/properties/summary",
+                  "type": "string"
+                },
+                "tags": {
+                  "additionalItems": false,
+                  "id": "/properties/paths/properties//contacts/{id}/properties/patch/properties/tags",
+                  "items": {
+                    "id": "/properties/paths/properties//contacts/{id}/properties/patch/properties/tags/items",
+                    "type": "string"
+                  },
+                  "type": "array"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "type": "object"
+        },
+        "/mynewcontacts": {
+          "id": "/properties/paths/properties//mynewcontacts",
+          "properties": {
+            "get": {
+              "id": "/properties/paths/properties//mynewcontacts/properties/get",
+              "properties": {
+                "operationId": {
+                  "id": "/properties/paths/properties//mynewcontacts/properties/get/properties/operationId",
+                  "type": "string"
+                },
+                "parameters": {
+                  "additionalItems": false,
+                  "id": "/properties/paths/properties//mynewcontacts/properties/get/properties/parameters",
+                  "items": {
+                    "id": "/properties/paths/properties//mynewcontacts/properties/get/properties/parameters/items",
+                    "properties": {
+                      "description": {
+                        "id": "/properties/paths/properties//mynewcontacts/properties/get/properties/parameters/items/properties/description",
+                        "type": "string"
+                      },
+                      "in": {
+                        "id": "/properties/paths/properties//mynewcontacts/properties/get/properties/parameters/items/properties/in",
+                        "type": "string"
+                      },
+                      "name": {
+                        "id": "/properties/paths/properties//mynewcontacts/properties/get/properties/parameters/items/properties/name",
+                        "type": "string"
+                      },
+                      "required": {
+                        "id": "/properties/paths/properties//mynewcontacts/properties/get/properties/parameters/items/properties/required",
+                        "type": "boolean"
+                      },
+                      "type": {
+                        "id": "/properties/paths/properties//mynewcontacts/properties/get/properties/parameters/items/properties/type",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "type": "array"
+                },
+                "responses": {
+                  "id": "/properties/paths/properties//mynewcontacts/properties/get/properties/responses",
+                  "properties": {
+                    "200": {
+                      "id": "/properties/paths/properties//mynewcontacts/properties/get/properties/responses/properties/200",
+                      "properties": {
+                        "description": {
+                          "id": "/properties/paths/properties//mynewcontacts/properties/get/properties/responses/properties/200/properties/description",
+                          "type": "string"
+                        },
+                        "schema": {
+                          "id": "/properties/paths/properties//mynewcontacts/properties/get/properties/responses/properties/200/properties/schema",
+                          "properties": {
+                            "$ref": {
+                              "id": "/properties/paths/properties//mynewcontacts/properties/get/properties/responses/properties/200/properties/schema/properties/$ref",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "400": {
+                      "id": "/properties/paths/properties//mynewcontacts/properties/get/properties/responses/properties/400",
+                      "properties": {
+                        "description": {
+                          "id": "/properties/paths/properties//mynewcontacts/properties/get/properties/responses/properties/400/properties/description",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "401": {
+                      "id": "/properties/paths/properties//mynewcontacts/properties/get/properties/responses/properties/401",
+                      "properties": {
+                        "description": {
+                          "id": "/properties/paths/properties//mynewcontacts/properties/get/properties/responses/properties/401/properties/description",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "403": {
+                      "id": "/properties/paths/properties//mynewcontacts/properties/get/properties/responses/properties/403",
+                      "properties": {
+                        "description": {
+                          "id": "/properties/paths/properties//mynewcontacts/properties/get/properties/responses/properties/403/properties/description",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "404": {
+                      "id": "/properties/paths/properties//mynewcontacts/properties/get/properties/responses/properties/404",
+                      "properties": {
+                        "description": {
+                          "id": "/properties/paths/properties//mynewcontacts/properties/get/properties/responses/properties/404/properties/description",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "405": {
+                      "id": "/properties/paths/properties//mynewcontacts/properties/get/properties/responses/properties/405",
+                      "properties": {
+                        "description": {
+                          "id": "/properties/paths/properties//mynewcontacts/properties/get/properties/responses/properties/405/properties/description",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "406": {
+                      "id": "/properties/paths/properties//mynewcontacts/properties/get/properties/responses/properties/406",
+                      "properties": {
+                        "description": {
+                          "id": "/properties/paths/properties//mynewcontacts/properties/get/properties/responses/properties/406/properties/description",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "409": {
+                      "id": "/properties/paths/properties//mynewcontacts/properties/get/properties/responses/properties/409",
+                      "properties": {
+                        "description": {
+                          "id": "/properties/paths/properties//mynewcontacts/properties/get/properties/responses/properties/409/properties/description",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "415": {
+                      "id": "/properties/paths/properties//mynewcontacts/properties/get/properties/responses/properties/415",
+                      "properties": {
+                        "description": {
+                          "id": "/properties/paths/properties//mynewcontacts/properties/get/properties/responses/properties/415/properties/description",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "500": {
+                      "id": "/properties/paths/properties//mynewcontacts/properties/get/properties/responses/properties/500",
+                      "properties": {
+                        "description": {
+                          "id": "/properties/paths/properties//mynewcontacts/properties/get/properties/responses/properties/500/properties/description",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    }
+                  },
+                  "type": "object"
+                },
+                "summary": {
+                  "id": "/properties/paths/properties//mynewcontacts/properties/get/properties/summary",
+                  "type": "string"
+                },
+                "tags": {
+                  "additionalItems": false,
+                  "id": "/properties/paths/properties//mynewcontacts/properties/get/properties/tags",
+                  "items": {
+                    "id": "/properties/paths/properties//mynewcontacts/properties/get/properties/tags/items",
+                    "type": "string"
+                  },
+                  "type": "array"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "type": "object"
+        },
+        "/newtransformedcontacts": {
+          "id": "/properties/paths/properties//newtransformedcontacts",
+          "properties": {
+            "get": {
+              "id": "/properties/paths/properties//newtransformedcontacts/properties/get",
+              "properties": {
+                "operationId": {
+                  "id": "/properties/paths/properties//newtransformedcontacts/properties/get/properties/operationId",
+                  "type": "string"
+                },
+                "parameters": {
+                  "additionalItems": false,
+                  "id": "/properties/paths/properties//newtransformedcontacts/properties/get/properties/parameters",
+                  "items": {
+                    "id": "/properties/paths/properties//newtransformedcontacts/properties/get/properties/parameters/items",
+                    "properties": {
+                      "description": {
+                        "id": "/properties/paths/properties//newtransformedcontacts/properties/get/properties/parameters/items/properties/description",
+                        "type": "string"
+                      },
+                      "in": {
+                        "id": "/properties/paths/properties//newtransformedcontacts/properties/get/properties/parameters/items/properties/in",
+                        "type": "string"
+                      },
+                      "name": {
+                        "id": "/properties/paths/properties//newtransformedcontacts/properties/get/properties/parameters/items/properties/name",
+                        "type": "string"
+                      },
+                      "required": {
+                        "id": "/properties/paths/properties//newtransformedcontacts/properties/get/properties/parameters/items/properties/required",
+                        "type": "boolean"
+                      },
+                      "type": {
+                        "id": "/properties/paths/properties//newtransformedcontacts/properties/get/properties/parameters/items/properties/type",
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "type": "array"
+                },
+                "responses": {
+                  "id": "/properties/paths/properties//newtransformedcontacts/properties/get/properties/responses",
+                  "properties": {
+                    "200": {
+                      "id": "/properties/paths/properties//newtransformedcontacts/properties/get/properties/responses/properties/200",
+                      "properties": {
+                        "description": {
+                          "id": "/properties/paths/properties//newtransformedcontacts/properties/get/properties/responses/properties/200/properties/description",
+                          "type": "string"
+                        },
+                        "schema": {
+                          "id": "/properties/paths/properties//newtransformedcontacts/properties/get/properties/responses/properties/200/properties/schema",
+                          "properties": {
+                            "$ref": {
+                              "id": "/properties/paths/properties//newtransformedcontacts/properties/get/properties/responses/properties/200/properties/schema/properties/$ref",
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "400": {
+                      "id": "/properties/paths/properties//newtransformedcontacts/properties/get/properties/responses/properties/400",
+                      "properties": {
+                        "description": {
+                          "id": "/properties/paths/properties//newtransformedcontacts/properties/get/properties/responses/properties/400/properties/description",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "401": {
+                      "id": "/properties/paths/properties//newtransformedcontacts/properties/get/properties/responses/properties/401",
+                      "properties": {
+                        "description": {
+                          "id": "/properties/paths/properties//newtransformedcontacts/properties/get/properties/responses/properties/401/properties/description",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "403": {
+                      "id": "/properties/paths/properties//newtransformedcontacts/properties/get/properties/responses/properties/403",
+                      "properties": {
+                        "description": {
+                          "id": "/properties/paths/properties//newtransformedcontacts/properties/get/properties/responses/properties/403/properties/description",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "404": {
+                      "id": "/properties/paths/properties//newtransformedcontacts/properties/get/properties/responses/properties/404",
+                      "properties": {
+                        "description": {
+                          "id": "/properties/paths/properties//newtransformedcontacts/properties/get/properties/responses/properties/404/properties/description",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "405": {
+                      "id": "/properties/paths/properties//newtransformedcontacts/properties/get/properties/responses/properties/405",
+                      "properties": {
+                        "description": {
+                          "id": "/properties/paths/properties//newtransformedcontacts/properties/get/properties/responses/properties/405/properties/description",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "406": {
+                      "id": "/properties/paths/properties//newtransformedcontacts/properties/get/properties/responses/properties/406",
+                      "properties": {
+                        "description": {
+                          "id": "/properties/paths/properties//newtransformedcontacts/properties/get/properties/responses/properties/406/properties/description",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "409": {
+                      "id": "/properties/paths/properties//newtransformedcontacts/properties/get/properties/responses/properties/409",
+                      "properties": {
+                        "description": {
+                          "id": "/properties/paths/properties//newtransformedcontacts/properties/get/properties/responses/properties/409/properties/description",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "415": {
+                      "id": "/properties/paths/properties//newtransformedcontacts/properties/get/properties/responses/properties/415",
+                      "properties": {
+                        "description": {
+                          "id": "/properties/paths/properties//newtransformedcontacts/properties/get/properties/responses/properties/415/properties/description",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "500": {
+                      "id": "/properties/paths/properties//newtransformedcontacts/properties/get/properties/responses/properties/500",
+                      "properties": {
+                        "description": {
+                          "id": "/properties/paths/properties//newtransformedcontacts/properties/get/properties/responses/properties/500/properties/description",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    }
+                  },
+                  "type": "object"
+                },
+                "summary": {
+                  "id": "/properties/paths/properties//newtransformedcontacts/properties/get/properties/summary",
+                  "type": "string"
+                },
+                "tags": {
+                  "additionalItems": false,
+                  "id": "/properties/paths/properties//newtransformedcontacts/properties/get/properties/tags",
+                  "items": {
+                    "id": "/properties/paths/properties//newtransformedcontacts/properties/get/properties/tags/items",
+                    "type": "string"
+                  },
+                  "type": "array"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "type": "object"
+        }
+      },
+      "type": "object"
+    },
+    "swagger": {
+      "id": "/properties/swagger",
+      "type": "string"
+    },
+    "tags": {
+      "additionalItems": false,
+      "id": "/properties/tags",
+      "items": {
+        "id": "/properties/tags/items",
+        "properties": {
+          "description": {
+            "id": "/properties/tags/items/properties/description",
+            "type": "string"
+          },
+          "name": {
+            "id": "/properties/tags/items/properties/name",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "type": "array"
+    }
+  },
+  "type": "object"
+}

--- a/src/test/platform/elementbuilder/assets/elementextend/user.json
+++ b/src/test/platform/elementbuilder/assets/elementextend/user.json
@@ -1,0 +1,6 @@
+{
+  "firstName": "Element",
+  "lastName": "Extend",
+  "email": "elementextend@ce.com",
+  "password": "password"
+}

--- a/src/test/platform/elementbuilder/elementextend.js
+++ b/src/test/platform/elementbuilder/elementextend.js
@@ -156,12 +156,6 @@ suite.forPlatform('element-extend', {}, (test) => {
           .then(() => cloud.delete(`elements/closeio/resources/${resourceId}/parameters/${parameterId}`, (r) => expect(r).to.have.statusCode(404)));
     });
 
-    // it('should return error while updating parameters for system catalog resource', () => {
-    //     let resourceId = baseElement.resources[0].id;
-    //     let parameterId = baseElement.resources[0].parameters[0].id;
-    //     return cloud.put(`elements/closeio/resources/${resourceId}/parameters/${parameterId}`, newParameter, (r) => expect(r).to.have.statusCode(404));
-    // });
-
     // try adding/update parameter to new resource and it should work
     // delete new resource parameter
     it('should CUD a parameter for newly created resource', () => {
@@ -205,17 +199,6 @@ suite.forPlatform('element-extend', {}, (test) => {
           .then(r => cloud.delete(`instances/${instance.id}/transformations/newtransformedcontacts`))
           .then(r => cloud.delete(`instances/${instance.id}/objects/newtransformedcontacts/definitions`))
           .then(r => provisioner.delete(instance.id, 'elements/closeio/instances'));
-    });
-
-    // Get the element with out any authentication details to check if the newly created resource is not present
-    //TODO Pass the authentication value
-    it('should get system catalog element with resources and no account resources', () => {
-      return cloud.get(`elements/closeio/`)
-        .then(r => {
-          expect(r.body).to.not.be.empty;
-          expect(r.body.id).to.not.be.empty;
-          expect(r.body.resources.length == (baseElement.resources.length+1)).to.be.true;
-        })
     });
 
 });

--- a/src/test/platform/elementbuilder/elementextend.js
+++ b/src/test/platform/elementbuilder/elementextend.js
@@ -1,0 +1,221 @@
+'use strict';
+
+const expect = require('chakram').expect;
+const suite = require('core/suite');
+const cloud = require('core/cloud');
+const props = require('core/props');
+const logger = require('winston');
+const defaults = require('core/defaults');
+const provisioner = require('core/provisioner');
+const newResource = require('./assets/elementextend/newresource.json');
+const overrideResource = require('./assets/elementextend/overrideresource.json');
+const newParameter = require('./assets/elementextend/parameter.json');
+const newmodel = require('./assets/elementextend/model.json');
+const objDefPayload = require('./assets/elementextend/modeldefinition.json');
+const transformationPayload = require('./assets/elementextend/modeltransformation.json');
+const swaggerSchema = require('./assets/elementextend/swagger.schema.json');
+const elementSwaggerSchema = require('./assets/elementextend/elementswagger.schema.json');
+const accountPayload = require('./assets/elementextend/account.json');
+const userPayload = require('./assets/elementextend/user.json');
+
+const createNewResource = (original, update) => {
+  return scriptTest(original, { isCleanup: false })
+    .then(r => cloud.put(`/instances/${closeioId}/transformations/contacts`, update, (r) => expect(r).to.have.statusCode(400)))
+    .then(r => cloud.delete(`/instances/${closeioId}/transformations/contacts`))
+    .then(r => cloud.delete(`/instances/${closeioId}/objects/contacts/definitions`));
+};
+
+suite.forPlatform('element-extend', {}, (test) => {
+  let baseElement, newResourceId, overrideResourceId;
+  // Get a system element, count the resources
+  before(() => cloud.get(`elements/closeio`)
+    .then(r => baseElement = r.body));
+
+  //delete new/overide resource should work fine
+  after(() => cloud.delete(`elements/closeio/resources/${newResourceId}`)
+    .then(() => cloud.delete(`elements/closeio/resources/${overrideResourceId}`)));
+
+    // Create a resource under system account
+    it('should create new resource under system catalog element', () => {
+      return cloud.post(`elements/closeio/resources`, newResource)
+        .then(r => {
+          expect(r.body).to.not.be.empty;
+          expect(r.body.id).to.not.be.empty;
+          newResourceId = r.body.id;
+        });
+    });
+
+    // Get the element and check if element resources has the new resource
+    it('should get system catalog element with resources and account resources', () => {
+      return cloud.get(`elements/closeio/`)
+        .then(r => {
+          expect(r.body).to.not.be.empty;
+          expect(r.body.id).to.not.be.empty;
+          expect(r.body.resources.length == (baseElement.resources.length+1)).to.be.true;
+        });
+    });
+
+    // Get all resources to see if the required resource is present
+    it('should get all resources of system catalog element and account resources', () => {
+      return cloud.get(`elements/closeio/resources`)
+        .then(r => {
+          expect(r.body).to.not.be.empty;
+          expect(r.body.length == (baseElement.resources.length+1)).to.be.true;
+        });
+    });
+
+    // Get accountOnly resources to see if the required resource is present
+    it('should get accountOnly resources', () => {
+      return cloud.get(`elements/closeio/resources?accountOnly=true`)
+        .then(r => {
+          expect(r.body).to.not.be.empty;
+          expect(r.body.length == 1).to.be.true;
+        });
+    });
+
+    // Get the newly created resource
+    it('should get the newly created resource for the element', () => {
+      return cloud.get(`elements/closeio/resources/${newResourceId}`)
+        .then(r => {
+          expect(r.body).to.not.be.empty;
+          expect(r.body.path == `/hubs/crm/mynewcontacts`).to.be.true;
+        });
+    });
+
+    // Create a new user
+    // Using new user secrets get the resources to check if the newly created resources are not present
+    // Get resources to check new/overide resources are not present
+    // delete new/overide resource  should fail
+    it('should create a new account and element in new account should not have access to new account resources', () => {
+      let newAccount, newUser;
+      return cloud.post(`accounts`, accountPayload)
+        .then(r => newAccount = r.body)
+        .then(() => cloud.post(`accounts/${newAccount.id}/users`, userPayload))
+        .then(r => newUser = r.body)
+        .then(r => {
+          const secrets = defaults.secrets();
+          const headers = {
+            Authorization: `User ${newUser.secret}, Organization ${secrets.orgSecret}`
+          };
+          return cloud.withOptions({ headers }).get(`elements/closeio/resources`)
+            .then(r => {
+              expect(r.body).to.not.be.empty;
+              expect(r.body.length == (baseElement.resources.length)).to.be.true;
+            });
+        })
+        .then(() => cloud.delete(`users/${newUser.id}`))
+        .then(() => cloud.delete(`accounts/${newAccount.id}`));
+    });
+
+    // Execute the newly created resource and Execute the newly created resource and system resource
+    it('should support creating an instance and execute the newly created instance', () => {
+        let instance;
+        return provisioner.create('closeio')
+          .then(r => instance = r.body)
+          .then(() => cloud.get('hubs/crm/mynewcontacts?pageSize=1', (r) => expect(r).to.have.statusCode(200)))
+          .then(() => cloud.get('hubs/crm/contacts?pageSize=1', (r) => expect(r).to.have.statusCode(200)))
+          .then(r => provisioner.delete(instance.id, 'elements/closeio/instances'));
+    });
+
+    // Override a system resource
+    it('should override the existing system catalog resource as new resource for the element', () => {
+      return cloud.post(`elements/closeio/resources`, overrideResource)
+        .then(r => {
+          expect(r.body).to.not.be.empty;
+          expect(r.body.id).to.not.be.empty;
+          overrideResourceId = r.body.id;
+        });
+    });
+
+    // Get accountOnly resources to see if the 2 resource is present
+    it('should get accountOnly resources', () => {
+      return cloud.get(`elements/closeio/resources?accountOnly=true`)
+        .then(r => {
+          expect(r.body).to.not.be.empty;
+          expect(r.body.length == 2).to.be.true;
+        })
+    });
+
+    // Execute the overriden created resource
+    it('should support creating an instance and execute the newly created instance', () => {
+        let instance;
+        return provisioner.create('closeio')
+          .then(r => instance = r.body)
+          .then(() => cloud.get('hubs/crm/contacts?pageSize=1', (r) => expect(r).to.have.statusCode(200)))
+          .then(r => provisioner.delete(instance.id, 'elements/closeio/instances'));
+    });
+
+    // try adding/update parameter to system resource and it should fail
+    // delete system resource parameter and it should fail
+    it('should return error while adding/updating or deleting parameters for system catalog resource', () => {
+        let systemresource = baseElement.resources[0];
+        let resourceId = systemresource.id;
+        let parameterId = systemresource.parameters[0].id;
+        return cloud.post(`elements/closeio/resources/${resourceId}/parameters`, newParameter, (r) => expect(r).to.have.statusCode(404))
+          .then(() => cloud.put(`elements/closeio/resources/${resourceId}/parameters/${parameterId}`, newParameter, (r) => expect(r).to.have.statusCode(404)))
+          .then(() => cloud.delete(`elements/closeio/resources/${resourceId}/parameters/${parameterId}`, (r) => expect(r).to.have.statusCode(404)));
+    });
+
+    // it('should return error while updating parameters for system catalog resource', () => {
+    //     let resourceId = baseElement.resources[0].id;
+    //     let parameterId = baseElement.resources[0].parameters[0].id;
+    //     return cloud.put(`elements/closeio/resources/${resourceId}/parameters/${parameterId}`, newParameter, (r) => expect(r).to.have.statusCode(404));
+    // });
+
+    // try adding/update parameter to new resource and it should work
+    // delete new resource parameter
+    it('should CUD a parameter for newly created resource', () => {
+        let newParameterId;
+        return cloud.post(`elements/closeio/resources/${newResourceId}/parameters`, newParameter)
+          .then(r => newParameterId = r.body.id)
+          .then(() => cloud.put(`elements/closeio/resources/${newResourceId}/parameters/${newParameterId}`, newParameter))
+          .then(() => cloud.delete(`elements/closeio/resources/${newResourceId}/parameters/${newParameterId}`));
+    });
+
+    // add/delete model to system resource and should fail
+    it('should return error while adding or deleting resource model for system catalog resource', () => {
+        let systemresource = baseElement.resources[0];
+        let resourceId = systemresource.id;
+        return cloud.post(`elements/closeio/resources/${resourceId}/models`, newmodel, (r) => expect(r).to.have.statusCode(404))
+          .then(() => cloud.delete(`elements/closeio/resources/${resourceId}/models`, (r) => expect(r).to.have.statusCode(404)));
+    });
+
+    // add/delete model to new resource
+    it('should be create and delete a model for newly created resource', () => {
+        return cloud.post(`elements/closeio/resources/${newResourceId}/models`, newmodel)
+          .then(() => cloud.delete(`elements/closeio/resources/${newResourceId}/models`));
+    });
+
+    // Should be able to create transformations for newly created model
+    // should be able to execute the transformation
+    // Should be able to delete the transformation on newly created model
+    // add/delete model to new resource
+    it('should be create/execute and delete transformation on the newly created model for newly created resource', () => {
+        let instance;
+        return cloud.post(`elements/closeio/resources/${newResourceId}/models`, newmodel)
+          .then(() => provisioner.create('closeio'))
+          .then(r => instance = r.body)
+          .then(() => cloud.get('hubs/crm/mynewcontacts?pageSize=1', (r) => expect(r).to.have.statusCode(200)))
+          .then(() => cloud.get('hubs/crm/objects/mynewcontacts/metadata'))
+          .then(r => cloud.post(`instances/${instance.id}/objects/newtransformedcontacts/definitions`, objDefPayload))
+          .then(r => cloud.post(`instances/${instance.id}/transformations/newtransformedcontacts`, transformationPayload))
+          .then(r => cloud.get(`instances/${instance.id}/docs`, swaggerSchema))
+          .then(r => cloud.get(`elements/${baseElement.id}/docs`, elementSwaggerSchema))
+          .then(() => cloud.get('hubs/crm/newtransformedcontacts?pageSize=1', (r) => expect(r).to.have.statusCode(200)))
+          .then(r => cloud.delete(`instances/${instance.id}/transformations/newtransformedcontacts`))
+          .then(r => cloud.delete(`instances/${instance.id}/objects/newtransformedcontacts/definitions`))
+          .then(r => provisioner.delete(instance.id, 'elements/closeio/instances'));
+    });
+
+    // Get the element with out any authentication details to check if the newly created resource is not present
+    //TODO Pass the authentication value
+    it('should get system catalog element with resources and no account resources', () => {
+      return cloud.get(`elements/closeio/`)
+        .then(r => {
+          expect(r.body).to.not.be.empty;
+          expect(r.body.id).to.not.be.empty;
+          expect(r.body.resources.length == (baseElement.resources.length+1)).to.be.true;
+        })
+    });
+
+});


### PR DESCRIPTION
## Highlights
* Get a system element, count the resources
* Tests for delete new/override resources
* Tests for creating a resource under system account
* Get all resources to see if the required resource is present
* Tests for get accountOnly resources to see if the required resource is present
* Tests for get the newly created resource
* Tests for accessing the resources by creating a new user under different account
* Execute the newly created resource and Execute the newly created resource and system resource
* Tests for Override a system resource
* Execute the overriden created resource
* Tests for adding/updating parameter to system resource
* Tests for deleting system resource parameter
* Tests for adding/update parameter to new resource
* Tests for delete new resource parameter
* Tests for add/delete model to system resource and should fail
* Tests for add/delete model to new resource
* Tests for creating/deleteing/executing transformations for newly created model
* Tests for add/delete model to new resource

## Examples
```
  element-extend
    ✓ should create new resource under system catalog element (194ms)
    ✓ should get system catalog element with resources and account resources (200ms)
    ✓ should get all resources of system catalog element and account resources (344ms)
    ✓ should get accountOnly resources (198ms)
    ✓ should get the newly created resource for the element (214ms)
    ✓ should create a new account and element in new account should not have access to new account resources (869ms)
    ✓ should support creating an instance and execute the newly created instance (1868ms)
    ✓ should override the existing system catalog resource as new resource for the element (199ms)
    ✓ should get accountOnly resources (209ms)
    ✓ should support creating an instance and execute the newly created instance (1032ms)
    ✓ should return error while adding/updating or deleting parameters for system catalog resource (533ms)
    ✓ should CUD a parameter for newly created resource (1340ms)
    ✓ should return error while adding or deleting resource model for system catalog resource (367ms)
    ✓ should be create and delete a model for newly created resource (364ms)
    ✓ should be create/execute and delete transformation on the newly created model for newly created resource (10885ms)
    ✓ should get system catalog element with resources and no account resources (251ms)
```
