### PR TITLE
Added ability to run churros on previously created instance

### DIFF
--- a/src/cli/churros-test.js
+++ b/src/cli/churros-test.js
@@ -26,7 +26,8 @@ const fromOptions = (url, options) => {
       browser: options.browser,
       verbose: options.verbose === undefined ? false : options.verbose, // hack...i can't figure out why it's not default to false
       externalAuth: options.externalAuth,
-      exclude: options.exclude
+      exclude: options.exclude,
+      instance: options.instance
     });
   });
 };
@@ -94,6 +95,7 @@ const run = (suite, options, cliArgs) => {
   if (cliArgs.verbose) args += ` --verbose ${cliArgs.verbose}`;
   if (cliArgs.browser) args += ` --browser ${cliArgs.browser}`;
   if (cliArgs.externalAuth) args += ` --externalAuth`;
+  if (cliArgs.instance) args += ` --instance ${cliArgs.instance}`;
 
   // loop over each element, constructing the proper paths to pass to mocha
   let cmd = "";
@@ -109,7 +111,6 @@ const run = (suite, options, cliArgs) => {
       console.log('Invalid suite: %s', suite);
       process.exit(1);
     }
-
     // add the suite next, unless a specific file was passed
     if (file.length < 1) allMochaPaths.push(testPath);
     else {
@@ -156,6 +157,7 @@ commander
   .option('-s, --exclude <resource>', 'element(s) or platform resource(s) to exclude if running all tests', collect, [])
   .option('-S, --start <suite>', 'specific suite to start with, everything before this will be skipped')
   .option('-V, --verbose', 'logging verbose mode')
+  .option('-I, --instance <instance>', 'instance to run tests on')
   .on('--help', () => {
     console.log('  Examples:');
     console.log('');

--- a/src/cli/churros-test.js
+++ b/src/cli/churros-test.js
@@ -157,7 +157,7 @@ commander
   .option('-s, --exclude <resource>', 'element(s) or platform resource(s) to exclude if running all tests', collect, [])
   .option('-S, --start <suite>', 'specific suite to start with, everything before this will be skipped')
   .option('-V, --verbose', 'logging verbose mode')
-  .option('-I, --instance <instance>', 'instance to run tests on')
+  .option('-i, --instance <instance>', 'instance to run tests on')
   .on('--help', () => {
     console.log('  Examples:');
     console.log('');

--- a/src/cli/churros-test.js
+++ b/src/cli/churros-test.js
@@ -157,7 +157,7 @@ commander
   .option('-s, --exclude <resource>', 'element(s) or platform resource(s) to exclude if running all tests', collect, [])
   .option('-S, --start <suite>', 'specific suite to start with, everything before this will be skipped')
   .option('-V, --verbose', 'logging verbose mode')
-  .option('-i, --instance <instance>', 'instance to run tests on')
+  .option('-i, --instance <instance>', 'element instance ID to run tests against (for development only)')
   .on('--help', () => {
     console.log('  Examples:');
     console.log('');

--- a/src/test/elements/lifecycle.js
+++ b/src/test/elements/lifecycle.js
@@ -37,6 +37,7 @@ before(() => {
       getInstance = cloud.get(`/instances/${argv.instance}`)
       .then(r => {
         defaults.token(r.body.token);
+        expect(r.body.element.key).to.equal(tools.getBaseElement(element));
         return r;
       });
     } else {
@@ -47,12 +48,9 @@ before(() => {
     return getInstance
       .then(r => {
         expect(r).to.have.statusCode(200);
-        expect(r.body.element.key).to.equal(tools.getBaseElement(element));
         instanceId = r.body.id;
         element = tools.getBaseElement(element);
-        return r;
-      })
-      .then(r => {
+
         // object definitions file exists? create the object definitions on the instance
         const objectDefinitionsFile = `${__dirname}/assets/object.definitions`;
         if (fs.existsSync(objectDefinitionsFile + '.json')) {

--- a/src/test/elements/lifecycle.js
+++ b/src/test/elements/lifecycle.js
@@ -38,17 +38,16 @@ before(() => {
       .then(r => {
         defaults.token(r.body.token);
         return r;
-      })
+      });
     } else {
       getInstance = provisioner
-        .create(element)
+        .create(element);
     }
 
     return getInstance
       .then(r => {
         expect(r).to.have.statusCode(200);
         expect(r.body.element.key).to.equal(tools.getBaseElement(element));
-        // console.log(r.body);
         instanceId = r.body.id;
         element = tools.getBaseElement(element);
         return r;

--- a/src/test/elements/lifecycle.js
+++ b/src/test/elements/lifecycle.js
@@ -32,18 +32,13 @@ before(() => {
   }
   return tools.runFile(element, `${__dirname}/${element}/assets/scripts.js`, 'before')
   .then(() => {
-    let getInstance;
-    if (argv.instance) {
-      getInstance = cloud.get(`/instances/${argv.instance}`)
+    const getInstance = argv.instance ? cloud.get(`/instances/${argv.instance}`)
       .then(r => {
         defaults.token(r.body.token);
         expect(r.body.element.key).to.equal(tools.getBaseElement(element));
         return r;
-      });
-    } else {
-      getInstance = provisioner
+      }) : provisioner
         .create(element);
-    }
 
     return getInstance
       .then(r => {


### PR DESCRIPTION
## Highlights
* can use a instance that is already available
* Use `-i ${instanceId}` or `--instance ${instanceId}`

## Examples
`churros test elements/intacct -I 1243`

