### PR TITLE
Adds ability to only check unique identifiers for pagination

### DIFF
--- a/src/core/suite.js
+++ b/src/core/suite.js
@@ -108,20 +108,17 @@ const itPagination = (name, api, options, validationCb, unique) => {
     .then(nextPage => getWithOptions(nextPage ? { qs: { pageSize: pageSize, nextPage: nextPage, page: page+1 }} : options2, result2))
     .then(nextPage => getWithOptions(nextPage ? { qs: { pageSize: pageSize * 2}} : options3, result3))
     .then(() => {
-      if (result3.body.length === pageSize*2 && result1.body.length === pageSize && result2.body.length === pageSize) {
-        if (unique) {
-          const value = tools.getKey(unique);
-          expect(tools.getKey(result3.body[0], unique)).to.deep.equal(tools.getKey(result1.body[0], unique));
-          expect(tools.getKey(result3.body[result3.body.length - 1], unique)).to.deep.equal(tools.getKey(result2.body[result2.body.length - 1], unique));
-          expect(tools.getKey(result3.body[pageSize], unique)).to.deep.equal(tools.getKey(result2.body[0], unique));
-        } else {
-          expect(result3.body[0]).to.deep.equal(result1.body[0]);
-          expect(result3.body[result3.body.length - 1]).to.deep.equal(result2.body[result2.body.length - 1]);
-          expect(result3.body[pageSize]).to.deep.equal(result2.body[0]);
-        }
+      if (unique) {
+        result3.body = tools.getKey(result3.body, unique);
+        result2.body = tools.getKey(result2.body, unique);
+        result1.body = tools.getKey(result1.body, unique);
       }
-      return unique ? expect(tools.getKey(result3.body, unique)).to.deep.equal(tools.getKey(result1.body.concat(result2.body), unique)) :
-        expect(result3.body).to.deep.equal(result1.body.concat(result2.body));
+      if (result3.body.length === pageSize*2 && result1.body.length === pageSize && result2.body.length === pageSize) {
+        expect(result3.body[0]).to.deep.equal(result1.body[0]);
+        expect(result3.body[result3.body.length - 1]).to.deep.equal(result2.body[result2.body.length - 1]);
+        expect(result3.body[pageSize]).to.deep.equal(result2.body[0]);
+      }
+      return expect(result3.body).to.deep.equal(result1.body.concat(result2.body));
     });
   }, options ? options.skip : false);
 };

--- a/src/core/suite.js
+++ b/src/core/suite.js
@@ -386,6 +386,7 @@ const runTests = (api, payload, validationCb, tests, hub) => {
     /**
      * Validates that the given API `page` and `pageSize` pagination.  In order to test this, we create a few objects and then paginate
      * through the results before cleaning up any resources that were created.
+     * @param {string} unique -> A unique identifier for each page to validate correct pagination
      * @memberof module:core/suite.test.should
      */
     supportPagination: (unique) => itPagination(name, api, options, validationCb, unique),

--- a/src/core/tools.js
+++ b/src/core/tools.js
@@ -185,3 +185,17 @@ exports.createExpression = (obj) => {
   });
   return where;
 };
+const getKey = (obj, key, acc) => {
+  acc = acc ? acc : [];
+  if (typeof obj == 'object') {
+    let objKeys = Object.keys(obj);
+    if (objKeys.includes(key)) {
+      acc.push(obj[key]);
+      return acc;
+    }
+    objKeys.forEach(k => getKey(obj[k], key, acc));
+    return acc;
+  }
+  return acc;
+}
+exports.getKey = (obj, key) => getKey(obj, key)

--- a/src/core/tools.js
+++ b/src/core/tools.js
@@ -187,7 +187,7 @@ exports.createExpression = (obj) => {
 };
 const getKey = (obj, key, acc) => {
   acc = acc ? acc : [];
-  if (typeof obj == 'object') {
+  if (typeof obj === 'object') {
     let objKeys = Object.keys(obj);
     if (objKeys.includes(key)) {
       acc.push(obj[key]);
@@ -197,5 +197,5 @@ const getKey = (obj, key, acc) => {
     return acc;
   }
   return acc;
-}
-exports.getKey = (obj, key) => getKey(obj, key)
+};
+exports.getKey = (obj, key) => getKey(obj, key);

--- a/src/test/elements/desk/organizations.js
+++ b/src/test/elements/desk/organizations.js
@@ -31,6 +31,6 @@ suite.forElement('helpdesk', 'organizations', { payload: organizationsCreate() }
       .then(r => cloud.get(`${test.api}/${organiztionId}/contacts`))
       .then(r => cloud.get(`${test.api}/${organiztionId}/incidents`));
   });
-  test.should.supportPagination();
+  test.should.supportPagination('id');
   test.withApi(`${test.api}/search`).withOptions({ qs: { query: 'desk.com' } }).should.return200OnGet();
 });

--- a/src/test/elements/mailchimpv3/assets/lists.json
+++ b/src/test/elements/mailchimpv3/assets/lists.json
@@ -26,7 +26,7 @@
   "name": "Churros List",
   "beamer_address": "us9-b1529c233e-dd902aebb8@inbound.mailchimp.com",
   "default_language": "en",
-  "web_id": "422757",
+  "web_id": 422757,
   "list_rating": 0,
   "email_type_option": false,
   "permission_reminder": "Churros test",

--- a/src/test/elements/mailchimpv3/campaigns.js
+++ b/src/test/elements/mailchimpv3/campaigns.js
@@ -31,7 +31,7 @@ const options = {
 };
 
 suite.forElement('marketing', 'campaigns', { payload: payload }, (test) => {
-  test.should.supportPagination();
+  test.should.supportPagination('id');
   test.withOptions(options).should.supportCruds();
   test.withOptions({ qs: { where: 'since_create_time=\'2016-01-23T17:55:00+00:00\'' } }).should.return200OnGet();
 

--- a/src/test/elements/mailchimpv3/lists.js
+++ b/src/test/elements/mailchimpv3/lists.js
@@ -39,7 +39,7 @@ const options = {
 };
 
 suite.forElement('marketing', 'lists', { payload: payload }, (test) => {
-  test.should.supportPagination();
+  test.should.supportPagination('id');
   test.withOptions(options).should.supportCruds();
   test.withOptions({ qs: { where: 'since_date_created=\'2016-01-23T17:55:00+00:00\'' } }).should.return200OnGet();
 

--- a/src/test/elements/salesforcemarketingcloud/campaigns.js
+++ b/src/test/elements/salesforcemarketingcloud/campaigns.js
@@ -5,5 +5,5 @@ const payload = require('./assets/campaigns');
 
 suite.forElement('marketing', 'campaigns', { payload: payload}, (test) => {
   test.should.supportCrds();
-  test.should.supportPagination();
+  test.should.supportPagination('id');
 });

--- a/src/test/elements/wufoo/forms.js
+++ b/src/test/elements/wufoo/forms.js
@@ -45,5 +45,5 @@ suite.forElement('general', 'forms', { payload: payload }, (test) => {
     return cloud.get(`${test.api}`)
       .then(r => cloud.post(`${test.api}/${r.body[0].Hash}/entries`, payload));
   });
-  test.should.supportPagination();
+  test.should.supportPagination('Hash');
 });

--- a/src/test/elements/wufoo/reports.js
+++ b/src/test/elements/wufoo/reports.js
@@ -31,5 +31,5 @@ suite.forElement('general', 'reports', (test) => {
     return cloud.get(`${test.api}`)
       .then(r => cloud.get(`${test.api}/${r.body[0].Hash}/widgets`));
   });
-  test.should.supportPagination();
+  test.should.supportPagination('Hash');
 });

--- a/src/test/elements/wufoo/users.js
+++ b/src/test/elements/wufoo/users.js
@@ -4,5 +4,5 @@ const suite = require('core/suite');
 
 suite.forElement('general', 'users', (test) => {
   test.should.return200OnGet();
-  test.should.supportPagination();
+  test.should.supportPagination('Hash');
 });

--- a/test/core/suite.test.js
+++ b/test/core/suite.test.js
@@ -105,6 +105,9 @@ describe('suite', () => {
     test
       .withApi('/foo/pagination')
       .should.supportPagination();
+    test
+    .withApi('/foo/pagination')
+    .should.supportPagination('id');
 
     /* no with... functions, which will just use the defaults that were passed in to the `suite.forPlatform` above */
     test.should.return200OnPost();

--- a/test/core/tools.test.js
+++ b/test/core/tools.test.js
@@ -138,4 +138,7 @@ Josh,Wyse,2
     const obj = [[{user: {ids: {id: "someId"}}},[{id:"nextId"}]],{allPeeps: [[{user1: {anotherfield: {stuff: [{id: "lastId"}]}}}]]}];
     expect(tools.getKey(obj, 'id')).to.deep.equal(['someId', 'nextId', 'lastId']);
   });
+  it('should return empty array if object is not a Object', () => {
+    expect(tools.getKey('', 'id')).to.deep.equal([]);
+  });
 });

--- a/test/core/tools.test.js
+++ b/test/core/tools.test.js
@@ -130,4 +130,12 @@ Josh,Wyse,2
     const where = `firstName = 'Austin' AND lastName = 'Mahan' AND id = '12'`;
     expect(tools.createExpression(obj)).to.equal(where);
   });
+  it('should get the key value on top layer', () => {
+    const obj = {id: 'randoId', name: 'Austin'};
+    expect(tools.getKey(obj, 'id')).to.deep.equal(['randoId']);
+  });
+  it('should get the key value from complex structures', () => {
+    const obj = [[{user: {ids: {id: "someId"}}},[{id:"nextId"}]],{allPeeps: [[{user1: {anotherfield: {stuff: [{id: "lastId"}]}}}]]}];
+    expect(tools.getKey(obj, 'id')).to.deep.equal(['someId', 'nextId', 'lastId']);
+  });
 });


### PR DESCRIPTION
## Highlights
* Can now only validate the unique identifier
* Pass the identifier as a string to the `supportPagination` test

## Examples
test.should.supportPagination('id');

## Closes
* Closes #764
