### PR TITLE
CE-4133 Added Churros for mailThread API.

### DIFF
--- a/src/test/elements/pipedrive/emails.js
+++ b/src/test/elements/pipedrive/emails.js
@@ -3,7 +3,7 @@
 const suite = require('core/suite');
 const cloud = require('core/cloud');
 
-suite.forElement('crm', 'emailThreads',{ skip: true }, (test) => {
+suite.forElement('crm', 'emailThreads', { skip: true }, (test) => {
 
   it('should support RS for emailsThreads', () => {
     let emailThreadId;

--- a/src/test/elements/pipedrive/emails.js
+++ b/src/test/elements/pipedrive/emails.js
@@ -23,7 +23,7 @@ suite.forElement('crm', 'emailThreads', { skip: true }, (test) => {
         }
         id = r.body[0].id;
         return cloud.get(`/hubs/crm/mailThreads/${id}`)
-          .then(r => cloud.delete(`/hubs/crm/mailThreads/${id}`))
+          .then(r => cloud.delete(`/hubs/crm/mailThreads/${id}`));
       });
   });
 

--- a/src/test/elements/pipedrive/emails.js
+++ b/src/test/elements/pipedrive/emails.js
@@ -11,8 +11,6 @@ suite.forElement('crm', 'emailThreads', { skip: true }, (test) => {
       .then(r => emailThreadId = r.body[0].id)
       .then(r => cloud.get(`${test.api}/${emailThreadId}/emails`))
       .then(r => cloud.get(`/hubs/crm/mailMessages/${emailThreadId}`));
-
-
   });
 
   it('should support RUD for mailThread', () => {
@@ -28,6 +26,5 @@ suite.forElement('crm', 'emailThreads', { skip: true }, (test) => {
           .then(r => cloud.delete(`/hubs/crm/mailThreads/${id}`))
       });
   });
-
 
 });

--- a/src/test/elements/pipedrive/emails.js
+++ b/src/test/elements/pipedrive/emails.js
@@ -4,7 +4,6 @@ const suite = require('core/suite');
 const cloud = require('core/cloud');
 
 suite.forElement('crm', 'emailThreads', { skip: true }, (test) => {
-
   it('should support RS for emailsThreads', () => {
     let emailThreadId;
     return cloud.get(`${test.api}`)
@@ -14,7 +13,6 @@ suite.forElement('crm', 'emailThreads', { skip: true }, (test) => {
   });
 
   it('should support RUD for mailThread', () => {
-
     let id;
     return cloud.withOptions({ qs: { folder: "inbox" } }).get(`/hubs/crm/mailThreads`)
       .then(r => {

--- a/src/test/elements/pipedrive/emails.js
+++ b/src/test/elements/pipedrive/emails.js
@@ -3,9 +3,9 @@
 const suite = require('core/suite');
 const cloud = require('core/cloud');
 
-suite.forElement('crm', 'emailThreads', (test) => {
+suite.forElement('crm', 'emailThreads',{ skip: true }, (test) => {
 
-  it.skip('should support RS for emailsThreads', () => {
+  it('should support RS for emailsThreads', () => {
     let emailThreadId;
     return cloud.get(`${test.api}`)
       .then(r => emailThreadId = r.body[0].id)
@@ -15,7 +15,7 @@ suite.forElement('crm', 'emailThreads', (test) => {
 
   });
 
-  it.skip('should support RUD for mailThread', () => {
+  it('should support RUD for mailThread', () => {
 
     let id;
     return cloud.withOptions({ qs: { folder: "inbox" } }).get(`/hubs/crm/mailThreads`)

--- a/src/test/elements/pipedrive/emails.js
+++ b/src/test/elements/pipedrive/emails.js
@@ -3,16 +3,31 @@
 const suite = require('core/suite');
 const cloud = require('core/cloud');
 
-suite.forElement('crm', 'emailThreads', { skip: true }, (test) => {
+suite.forElement('crm', 'emailThreads', (test) => {
 
-  it('should support RS for emailsThreads,GET deals and ', () => {
+  it.skip('should support RS for emailsThreads', () => {
     let emailThreadId;
     return cloud.get(`${test.api}`)
       .then(r => emailThreadId = r.body[0].id)
       .then(r => cloud.get(`${test.api}/${emailThreadId}/emails`))
-      .then(r => cloud.get(`/hubs/crm/mailMessages/${emailThreadId}`))
-      .then(r => cloud.withOptions({ qs: { folder: "sent" } }).get(`/hubs/crm/mailThreads`));
+      .then(r => cloud.get(`/hubs/crm/mailMessages/${emailThreadId}`));
 
 
   });
+
+  it.skip('should support RUD for mailThread', () => {
+
+    let id;
+    return cloud.withOptions({ qs: { folder: "inbox" } }).get(`/hubs/crm/mailThreads`)
+      .then(r => {
+        if (r.body.length <= 0) {
+          return;
+        }
+        id = r.body[0].id;
+        return cloud.get(`/hubs/crm/mailThreads/${id}`)
+          .then(r => cloud.delete(`/hubs/crm/mailThreads/${id}`))
+      });
+  });
+
+
 });


### PR DESCRIPTION
## Highlights
* Added the Churros Test for RUD operations of mailThread API.
* Added the skip in the suite, as emailThread API is deprecated and now vendor is not supported and for mailThread API we are not doing the POST mailThread Hence we need to skip RUD operation of mailThread. 

## Closes
* Closes #$4133