### PR TITLE
Fix for #859: use utf8 sauce when initing from github

### DIFF
--- a/src/cli/churros-init.js
+++ b/src/cli/churros-init.js
@@ -57,7 +57,7 @@ const saveSauce = (answers) => {
       github.authenticate({ type: 'oauth', token: token});
       github.repos.getContent({ user: user, repo: repo, path: path }, function(err, resp) {
         if (err) reject('Error writing sauce template from repo');
-        fs.writeFileSync(to, new Buffer(resp.content, 'base64').toString('ascii'));
+        fs.writeFileSync(to, new Buffer(resp.content, 'base64').toString('utf8'));
         resolve({ frm: frm, to: to });
       });
     } else {


### PR DESCRIPTION
## Highlights
* Fixes `churros init --template <github>` with utf8 sauce.

## Examples
After this fix:
```
$ churros init --template https://${token}@github.com/cloud-elements/churros-sauce/sauce.json
? Default user to run tests: charlie@cloud-elements.com
? User's password: *********************
? Cloud Elements URL snapshot.cloud-elements.com
Making sauce directory
Writing sauce template from repo
Writing sauce file
Churros initialization successful!
```

## Closes
* Closes #859 
