### PR TITLE
Added polling with a flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,9 @@ $ churros test elements/closeio --file 'contacts'
 # Run the entire suite for the sfdc element and during provisioning use the phantomjs browser
 $ churros test elements/sfdc --browser phantomjs
 
+# Run the polling tests if there are any
+$ churros test elements/sfdc --polling
+
 # Run suite on a existing instance(FOR DEVELOPMENT ONLY)
 $ churros test elements/pipedrive --instance 1234
 ```

--- a/src/cli/churros-test.js
+++ b/src/cli/churros-test.js
@@ -27,7 +27,8 @@ const fromOptions = (url, options) => {
       verbose: options.verbose === undefined ? false : options.verbose, // hack...i can't figure out why it's not default to false
       externalAuth: options.externalAuth,
       exclude: options.exclude,
-      instance: options.instance
+      instance: options.instance,
+      polling: options.polling
     });
   });
 };
@@ -96,7 +97,7 @@ const run = (suite, options, cliArgs) => {
   if (cliArgs.browser) args += ` --browser ${cliArgs.browser}`;
   if (cliArgs.externalAuth) args += ` --externalAuth`;
   if (cliArgs.instance) args += ` --instance ${cliArgs.instance}`;
-
+  if (cliArgs.polling) args += ` --polling ${cliArgs.polling}`;
   // loop over each element, constructing the proper paths to pass to mocha
   let cmd = "";
   if (resources.includes('.DS_Store')) resources.splice(resources.indexOf('.DS_Store'), 1);
@@ -159,6 +160,7 @@ commander
   .option('-S, --start <suite>', 'specific suite to start with, everything before this will be skipped')
   .option('-V, --verbose', 'logging verbose mode')
   .option('-i, --instance <instance>', 'element instance ID to run tests against (for development only)')
+  .option('--polling', 'runs the polling tests')
   .on('--help', () => {
     console.log('  Examples:');
     console.log('');
@@ -166,6 +168,7 @@ commander
     console.log('    $ churros test elements/closeio');
     console.log('    $ churros test elements/closeio --test \'contacts\'');
     console.log('    $ churros test elements/closeio --file \'contacts\'');
+    console.log('    $ churros test elements/sfdc --polling');
     console.log('    $ churros test elements');
     console.log('    $ churros test elements --exclude autopilot --exclude bigcommerce');
     console.log('    $ churros test elements --start freshbooks');

--- a/src/core/provisioner.js
+++ b/src/core/provisioner.js
@@ -11,6 +11,7 @@ const o = require('core/oauth');
 const r = require('request');
 const defaults = require('core/defaults');
 const cloud = require('core/cloud');
+const argv = require('optimist').argv;
 
 var exports = module.exports = {};
 
@@ -54,6 +55,7 @@ const parseProps = (element) => {
 };
 
 const getPollerConfig = (element, instance) => {
+  if (!argv.polling) return Promise.resolve(instance);
   let elementObj;
   return cloud.get('/elements/' + element)
   .then(r => elementObj = r.body)

--- a/src/core/suite.js
+++ b/src/core/suite.js
@@ -13,6 +13,7 @@ const props = require('core/props');
 const logger = require('winston');
 const request = require('request');
 const fs = require('fs');
+const argv = require('optimist').argv;
 
 
 var exports = module.exports = {};
@@ -268,7 +269,7 @@ const itPolling = (name, pay, api, options, validationCb, payload) => {
     })
     .then(r => validate(JSON.parse(r)))))
     .then(() => cloud.delete(`${api}/${response.id}`));
-  });
+  }, (argv.polling ? false : true) || (options ? options.skip : false));
 };
 
 const itBulkDownload = (name, hub, metadata, options, apiOverride, opts, endpoint) => {

--- a/test/core/provisioner.test.js
+++ b/test/core/provisioner.test.js
@@ -15,11 +15,12 @@ const expect = chakram.expect;
 const nock = require('nock');
 const props = require('core/props');
 const defaults = require('core/defaults');
-
+const argv = require('optimist').argv;
 const auth = 'User fake, Organization fake';
 const headers = () => new Object({ reqheaders: { 'Authorization': (value) => value === auth } });
 const baseUrl = 'https://api.cloud-elements.com/elements/api-v2;';
-
+// add 'polling' to command line to simulate the '--polling' flag
+argv.polling = 'true';
 const setupProps = () => {
   props({
     'user': 'franky',


### PR DESCRIPTION
## Highlights
* Use the `--polling` flag to explicitly run the polling tests

## Examples
`$ churros test elements/sfdc --polling`

## Closes
* Closes #865 