### PR TITLE
Added churros for retryStatusCode validation on formula steps

### DIFF
--- a/src/test/platform/formulas/assets/formulas/formula-with-invalid-status-code-properties.json
+++ b/src/test/platform/formulas/assets/formulas/formula-with-invalid-status-code-properties.json
@@ -1,0 +1,31 @@
+{
+  "name": "Formula with invalid elementRequest step property",
+  "description": "I contain an invalid elementRequest step, so I better fail",
+  "steps": [{
+    "name": "invalid-element-request-step",
+    "type": "elementRequest",
+    "properties": {
+      "method": "GET",
+      "api": "/hubs/crm/accounts",
+      "elementInstanceId": "${sfdc.instance.id}",
+      "retryDelay": 500,
+      "retryAttempts": 2,
+	  "retryStatusCodes":"401-,400"
+    }
+  }],
+  "triggers": [{
+    "type": "event",
+    "onSuccess": [
+      "invalid-element-request-step"
+    ],
+    "properties": {
+      "elementInstanceId": "${sfdc.instance.id}"
+    }
+  }],
+  "configuration": [{
+    "key": "sfdc.instance.id",
+    "name": "sfdcInstance",
+    "type": "elementInstance",
+    "description": "The SFDC CRM element instance"
+  }]
+}

--- a/src/test/platform/formulas/assets/formulas/formula-with-valid-status-code-properties.json
+++ b/src/test/platform/formulas/assets/formulas/formula-with-valid-status-code-properties.json
@@ -1,0 +1,31 @@
+{
+  "name": "Formula with invalid elementRequest step property",
+  "description": "I contain an invalid elementRequest step, so I better fail",
+  "steps": [{
+    "name": "invalid-element-request-step",
+    "type": "elementRequest",
+    "properties": {
+      "method": "GET",
+      "api": "/hubs/crm/accounts",
+      "elementInstanceId": "${sfdc.instance.id}",
+      "retryDelay": 500,
+      "retryAttempts": 2,
+	  "retryStatusCodes":"401-405,500"
+    }
+  }],
+  "triggers": [{
+    "type": "event",
+    "onSuccess": [
+      "invalid-element-request-step"
+    ],
+    "properties": {
+      "elementInstanceId": "${sfdc.instance.id}"
+    }
+  }],
+  "configuration": [{
+    "key": "sfdc.instance.id",
+    "name": "sfdcInstance",
+    "type": "elementInstance",
+    "description": "The SFDC CRM element instance"
+  }]
+}

--- a/src/test/platform/formulas/assets/formulas/formula-with-valid-status-code-properties.json
+++ b/src/test/platform/formulas/assets/formulas/formula-with-valid-status-code-properties.json
@@ -1,8 +1,8 @@
 {
-  "name": "Formula with invalid elementRequest step property",
-  "description": "I contain an invalid elementRequest step, so I better fail",
+  "name": "Formula with valid elementRequest step property",
+  "description": "I contain an valid elementRequest step, so I better pass",
   "steps": [{
-    "name": "invalid-element-request-step",
+    "name": "valid-element-request-step",
     "type": "elementRequest",
     "properties": {
       "method": "GET",
@@ -16,7 +16,7 @@
   "triggers": [{
     "type": "event",
     "onSuccess": [
-      "invalid-element-request-step"
+      "valid-element-request-step"
     ],
     "properties": {
       "elementInstanceId": "${sfdc.instance.id}"

--- a/src/test/platform/formulas/steps.js
+++ b/src/test/platform/formulas/steps.js
@@ -27,7 +27,7 @@ suite.forPlatform('formulas', { name: 'formula steps', schema: schema }, (test) 
   test
     .withName('should allow creating a formula with a step that has an valid retryStatusCodes property')
     .withJson(validStatusCodeJson)
-    .should.return400OnPost();
+    .should.return200OnPost();
 
 	/* make sure step properties are being validated properly when adding a step to an existing formula */
   it('should not allow adding a step to a formula that has an invalid retryAttempts property', () => {

--- a/src/test/platform/formulas/steps.js
+++ b/src/test/platform/formulas/steps.js
@@ -5,6 +5,8 @@ const cloud = require('core/cloud');
 const common = require('./assets/common');
 const expect = require('chakram').expect;
 const invalidJson = require('./assets/formulas/formula-with-invalid-step-properties');
+const invalidStatusCodeJson = require('./assets/formulas/formula-with-invalid-status-code-properties');
+const validStatusCodeJson = require('./assets/formulas/formula-with-valid-status-code-properties');
 const suite = require('core/suite');
 const schema = require('./assets/schemas/formula.schema');
 
@@ -17,7 +19,17 @@ suite.forPlatform('formulas', { name: 'formula steps', schema: schema }, (test) 
     .withJson(invalidJson)
     .should.return400OnPost();
 
-  /* make sure step properties are being validated properly when adding a step to an existing formula */
+  test
+    .withName('should not allow creating a formula with a step that has an invalid retryStatusCodes property')
+    .withJson(invalidStatusCodeJson)
+    .should.return400OnPost();
+
+  test
+    .withName('should allow creating a formula with a step that has an valid retryStatusCodes property')
+    .withJson(validStatusCodeJson)
+    .should.return400OnPost();
+
+	/* make sure step properties are being validated properly when adding a step to an existing formula */
   it('should not allow adding a step to a formula that has an invalid retryAttempts property', () => {
     const validator = (r) => {
       expect(r).to.have.statusCode(400);

--- a/src/test/platform/formulas/steps.js
+++ b/src/test/platform/formulas/steps.js
@@ -24,12 +24,14 @@ suite.forPlatform('formulas', { name: 'formula steps', schema: schema }, (test) 
     .withJson(invalidStatusCodeJson)
     .should.return400OnPost();
 
-  test
-    .withName('should allow creating a formula with a step that has an valid retryStatusCodes property')
-    .withJson(validStatusCodeJson)
-    .should.return200OnPost();
+  it('should allow creating a formula with a step that has an valid retryStatusCodes property', () => {
+    let validFormulaId;
+    return cloud.post(test.api, validStatusCodeJson)
+      .then(r => validFormulaId = r.body.id)
+      .then(r => cloud.delete(`formulas/${validFormulaId}`));
+  });
 
-	/* make sure step properties are being validated properly when adding a step to an existing formula */
+  /* make sure step properties are being validated properly when adding a step to an existing formula */
   it('should not allow adding a step to a formula that has an invalid retryAttempts property', () => {
     const validator = (r) => {
       expect(r).to.have.statusCode(400);


### PR DESCRIPTION
## Highlights
* Added a tests for the newly added support for range in `retryStatusCode` field of the `request` type steps

## Closes
* Closes #5630
