### PR TITLE
IBM: Updated churros payload for HubspotCRM

### DIFF
--- a/src/test/elements/hubspotcrm/assets/leads.json
+++ b/src/test/elements/hubspotcrm/assets/leads.json
@@ -1,5 +1,7 @@
 {
-    "firstName": "Churros Lead",
-    "lastName": "Churros Name",
-    "email":"fakeemail@churros.bs"
+  "properties": {
+    "firstName": "Tasty",
+    "lastName": "Churros",
+    "email": "churros.test@delete.mq"
+  }
 }


### PR DESCRIPTION
## Highlights
* For `leads` resource, enclosed the churros payload in `properties` key as per updated model.