### PR TITLE
Added some test cases for Salesforce Files `GET /search` API

### DIFF
--- a/src/test/elements/sfdcdocuments/search.js
+++ b/src/test/elements/sfdcdocuments/search.js
@@ -2,8 +2,6 @@
 
 const suite = require('core/suite');
 const tools = require('core/tools');
-const cloud = require('core/cloud');
-const chakram = require('chakram');
 const expect = require('chakram').expect;
 
 suite.forElement('documents', 'search', null, (test) => {
@@ -20,5 +18,5 @@ suite.forElement('documents', 'search', null, (test) => {
   test.withOptions({ qs: { path: '/Test folder' } })
     .withValidation((r) => {
       expect(r).to.have.statusCode(400);
-    })
+    });
 });

--- a/src/test/elements/sfdcdocuments/search.js
+++ b/src/test/elements/sfdcdocuments/search.js
@@ -10,8 +10,8 @@ suite.forElement('documents', 'search', null, (test) => {
 
   test.withOptions({ qs: { startDate: '2015-06-15T09:15:04Z', endDate: '2015-06-15T09:40:04Z' } })
     .should.return200OnGet()
-    .expect(r).to.have.statusCode(200);
-  .expect(r.response.headers['elements-returned-count']).to.equal(2);
+    .expect(r).to.have.statusCode(200)
+    .expect(r.response.headers['elements-returned-count']).to.equal(2);
 
   test.withOptions({ qs: { path: '/' } })
     .expect(r).to.have.statusCode(200);

--- a/src/test/elements/sfdcdocuments/search.js
+++ b/src/test/elements/sfdcdocuments/search.js
@@ -3,32 +3,22 @@
 const suite = require('core/suite');
 const tools = require('core/tools');
 const cloud = require('core/cloud');
+const chakram = require('chakram');
+const expect = require('chakram').expect;
 
 suite.forElement('documents', 'search', null, (test) => {
   test.withOptions({ qs: { text: tools.random() } }).should.return200OnGet();
 
   test.should.supportPagination();
 
-  return cloud.GET(test.api)
-    .then(r => cloud.withOptions({ qs: { startDate: '2015-06-15T09:15:04Z', endDate: '2015-06-15T09:40:04Z' } }).get(test.api))
-    .expect(r).to.have.statusCode(200)
-    .expect(r.body.length).to.equal(2);
+  test.withOptions({ qs: { path: '/' } })
+    .should.return200OnGet();
 
-  /*  test.withOptions({ qs: { startDate: '2015-06-15T09:15:04Z', endDate: '2015-06-15T09:40:04Z' } })
-      .expect(r).to.have.statusCode(200)
-      .expect(r.response.headers['elements-returned-count']).to.equal(2); */
+  test.withOptions({ qs: { startDate: '2015-06-15T09:15:04Z', endDate: '2015-06-15T09:40:04Z' } })
+    .should.return200OnGet();
 
-  return cloud.GET(test.api)
-    .then(r => cloud.withOptions({ qs: { path: '/' } }).get(test.api))
-    .expect(r).to.have.statusCode(200);
-
-  /*  test.withOptions({ qs: { path: '/' } })
-      .expect(r).to.have.statusCode(200); */
-
-  return cloud.GET(test.api)
-    .then(r => cloud.withOptions({ qs: { path: '/Test folder' } }).get(test.api))
-    .expect(r).to.have.statusCode(400);
-
-  /* test.withOptions({ qs: { path: '/Test folder' } })
-    .expect(r).to.have.statusCode(400); */
+  test.withOptions({ qs: { path: '/Test folder' } })
+    .withValidation((r) => {
+      expect(r).to.have.statusCode(400);
+    })
 });

--- a/src/test/elements/sfdcdocuments/search.js
+++ b/src/test/elements/sfdcdocuments/search.js
@@ -6,14 +6,15 @@ const tools = require('core/tools');
 suite.forElement('documents', 'search', null, (test) => {
   test.withOptions({ qs: { text: tools.random() } }).should.return200OnGet();
 
-  test.withOptions({ qs: { pageSize: 3, page: 1 } })
-    .should.return200OnGet()
-    .expect(r.response.headers['elements-returned-count']).to.be.below(3);
+  test.should.supportPagination();
 
   test.withOptions({ qs: { startDate: '2015-06-15T09:15:04Z', endDate: '2015-06-15T09:40:04Z' } })
     .should.return200OnGet()
     .expect(r).to.have.statusCode(200);
-    .expect(r.response.headers['elements-returned-count']).to.be.below(2);
+    .expect(r.response.headers['elements-returned-count']).to.equal(2);
+
+    test.withOptions({ qs: { path: '/' } })
+      .expect(r).to.have.statusCode(200);
 
   test.withOptions({ qs: { path: '/Test folder' } })
     .expect(r).to.have.statusCode(400);

--- a/src/test/elements/sfdcdocuments/search.js
+++ b/src/test/elements/sfdcdocuments/search.js
@@ -5,4 +5,16 @@ const tools = require('core/tools');
 
 suite.forElement('documents', 'search', null, (test) => {
   test.withOptions({ qs: { text: tools.random() } }).should.return200OnGet();
+
+  test.withOptions({ qs: { pageSize: 3, page: 1 } })
+    .should.return200OnGet()
+    .expect(r.response.headers['elements-returned-count']).to.be.below(3);
+
+  test.withOptions({ qs: { startDate: '2015-06-15T09:15:04Z', endDate: '2015-06-15T09:40:04Z' } })
+    .should.return200OnGet()
+    .expect(r).to.have.statusCode(200);
+    .expect(r.response.headers['elements-returned-count']).to.be.below(2);
+
+  test.withOptions({ qs: { path: '/Test folder' } })
+    .expect(r).to.have.statusCode(400);
 });

--- a/src/test/elements/sfdcdocuments/search.js
+++ b/src/test/elements/sfdcdocuments/search.js
@@ -11,10 +11,10 @@ suite.forElement('documents', 'search', null, (test) => {
   test.withOptions({ qs: { startDate: '2015-06-15T09:15:04Z', endDate: '2015-06-15T09:40:04Z' } })
     .should.return200OnGet()
     .expect(r).to.have.statusCode(200);
-    .expect(r.response.headers['elements-returned-count']).to.equal(2);
+  .expect(r.response.headers['elements-returned-count']).to.equal(2);
 
-    test.withOptions({ qs: { path: '/' } })
-      .expect(r).to.have.statusCode(200);
+  test.withOptions({ qs: { path: '/' } })
+    .expect(r).to.have.statusCode(200);
 
   test.withOptions({ qs: { path: '/Test folder' } })
     .expect(r).to.have.statusCode(400);

--- a/src/test/elements/sfdcdocuments/search.js
+++ b/src/test/elements/sfdcdocuments/search.js
@@ -2,20 +2,33 @@
 
 const suite = require('core/suite');
 const tools = require('core/tools');
+const cloud = require('core/cloud');
 
 suite.forElement('documents', 'search', null, (test) => {
   test.withOptions({ qs: { text: tools.random() } }).should.return200OnGet();
 
   test.should.supportPagination();
 
-  test.withOptions({ qs: { startDate: '2015-06-15T09:15:04Z', endDate: '2015-06-15T09:40:04Z' } })
-    .should.return200OnGet()
+  return cloud.GET(test.api)
+    .then(r => cloud.withOptions({ qs: { startDate: '2015-06-15T09:15:04Z', endDate: '2015-06-15T09:40:04Z' } }).get(test.api))
     .expect(r).to.have.statusCode(200)
-    .expect(r.response.headers['elements-returned-count']).to.equal(2);
+    .expect(r.body.length).to.equal(2);
 
-  test.withOptions({ qs: { path: '/' } })
+  /*  test.withOptions({ qs: { startDate: '2015-06-15T09:15:04Z', endDate: '2015-06-15T09:40:04Z' } })
+      .expect(r).to.have.statusCode(200)
+      .expect(r.response.headers['elements-returned-count']).to.equal(2); */
+
+  return cloud.GET(test.api)
+    .then(r => cloud.withOptions({ qs: { path: '/' } }).get(test.api))
     .expect(r).to.have.statusCode(200);
 
-  test.withOptions({ qs: { path: '/Test folder' } })
+  /*  test.withOptions({ qs: { path: '/' } })
+      .expect(r).to.have.statusCode(200); */
+
+  return cloud.GET(test.api)
+    .then(r => cloud.withOptions({ qs: { path: '/Test folder' } }).get(test.api))
     .expect(r).to.have.statusCode(400);
+
+  /* test.withOptions({ qs: { path: '/Test folder' } })
+    .expect(r).to.have.statusCode(400); */
 });


### PR DESCRIPTION
## Highlights
Added test cases for `GET /search` for the following scenarios:
* `startDate` and `endDate` filters
* Pagination
* `path` parameter

## Closes
* Closes #5883 #3834
