### PR TITLE
Stripe : Removed extra field from POST /transfers payload

### DIFF
--- a/src/test/elements/stripe/assets/transfers.json
+++ b/src/test/elements/stripe/assets/transfers.json
@@ -1,5 +1,4 @@
 {
-  "statement_descriptor": "aaa",
   "amount": 400,
   "metadata": {},
   "destination": "acct_188ReCA6PwQn1VtN",


### PR DESCRIPTION
## Highlights
* Removed extra field "statement_descriptor" from `POST /transfers` payload for Churros.

## Closes
* Closes #910 
