### PR TITLE
4478 cancel formula execution

### DIFF
--- a/src/test/platform/formulas/assets/formulas/formula-waitForIt-selfContained.json
+++ b/src/test/platform/formulas/assets/formulas/formula-waitForIt-selfContained.json
@@ -1,0 +1,99 @@
+{
+    "id": 22,
+    "name": "Wait for it (self-contained)",
+    "userId": 1,
+    "accountId": 1,
+    "createdDate": "2017-05-12T20:22:01Z",
+    "steps": [
+        {
+            "id": 23,
+            "onSuccess": [
+                "rando"
+            ],
+            "onFailure": [
+                "slackmsg"
+            ],
+            "name": "Loop",
+            "type": "loop",
+            "properties": {
+                "list": "steps.SetLoop.loop"
+            }
+        },
+        {
+            "id": 22,
+            "onSuccess": [
+                "Loop"
+            ],
+            "onFailure": [],
+            "name": "SetLoop",
+            "type": "script",
+            "properties": {
+                "body": "let loop = [...Array(20).keys()];\n\ndone({loop: loop});"
+            }
+        },
+        {
+            "id": 24,
+            "onSuccess": [
+                "Loop"
+            ],
+            "onFailure": [],
+            "name": "rando",
+            "type": "script",
+            "properties": {
+                "body": "let tangent = 0;\n\nlet num = Math.floor(Math.random() * (1000000 - 500)) + 500;\n\nfor (let i = 0; i < num; i++) {\n  tangent = Math.tan(i);\n}\n\ndone({done: tangent})"
+            }
+        },
+        {
+            "id": 25,
+            "onSuccess": [
+                "callslack"
+            ],
+            "onFailure": [],
+            "name": "slackmsg",
+            "type": "script",
+            "properties": {
+                "body": "\nlet emojis = [\":yay:\", \":rocket:\", \":party_parrot:\", \":charmander:\", \":smile:\"];\nlet emoji = \" \" + emojis[Math.floor(Math.random() * emojis.length)];\n\n\nlet message = {\"text\": \"Yay, \" + emoji + \" I'm done with execution number \" + info.formulaExecutionId + \" \" + new Date(info.stepEndTime)};\n\ndone({payload: message});"
+            }
+        },
+        {
+            "id": 27,
+            "onSuccess": [],
+            "onFailure": [],
+            "name": "Done",
+            "type": "script",
+            "properties": {
+                "body": "done({done: true});"
+            }
+        },
+        {
+            "id": 26,
+            "onSuccess": [
+                "Done"
+            ],
+            "onFailure": [],
+            "name": "callslack",
+            "type": "httpRequest",
+            "properties": {
+                "method": "POST",
+                "url": "https://hooks.slack.com/services/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",
+                "body": "${steps.slackmsg.payload}"
+            }
+        }
+    ],
+    "triggers": [
+        {
+            "id": 18,
+            "onSuccess": [
+                "SetLoop"
+            ],
+            "onFailure": [],
+            "type": "manual",
+            "async": true,
+            "name": "trigger",
+            "properties": {}
+        }
+    ],
+    "active": true,
+    "singleThreaded": false,
+    "configuration": []
+}

--- a/src/test/platform/formulas/executions.js
+++ b/src/test/platform/formulas/executions.js
@@ -69,7 +69,7 @@ const generateXSingleSfdcPollingEvents = (instanceId, x, fileName) => {
 
 
 suite.forPlatform('formulas', { name: 'formula executions' }, (test) => {
-  /*let sfdcId, dropboxId;
+  let sfdcId, dropboxId;
   before(() => {
     return provisioner.create('dropbox')
       .then(r => dropboxId = r.body.id)
@@ -91,7 +91,7 @@ suite.forPlatform('formulas', { name: 'formula executions' }, (test) => {
         done();
       });
   });
-*/
+
   const testWrapper = (kickOffDatFormulaCb, f, fi, numEs, numSes, numSevs, executionValidator, executionStatus) => {
     if (fi.configuration && fi.configuration['trigger-instance'] === '<replace-me>') fi.configuration['trigger-instance'] = sfdcId;
     return common.testWrapper(test, kickOffDatFormulaCb, f, fi, numEs, numSes, numSevs, common.execValidatorWrapper(executionValidator), null, executionStatus);

--- a/src/test/platform/formulas/executions.js
+++ b/src/test/platform/formulas/executions.js
@@ -630,7 +630,7 @@ suite.forPlatform('formulas', { name: 'formula executions' }, (test) => {
 
   it('should cancel a running formula instance execution and not attempt to cancel an already cancelled/finished execution', () => {
 
-    const myCustomTestWrapper = (test, kickOffDatFormulaCb, f, fi, numEs, numSes, numSevs, execValidator, instanceValidator, executionStatus, numInstances) => {
+    const cancelTestCustomTestWrapper = (test, kickOffDatFormulaCb, f, fi, numEs, numSes, numSevs, execValidator, instanceValidator, executionStatus, numInstances) => {
 
     const instanceValidatorWrapper = fId => {
       if (typeof instanceValidator === 'function') { return instanceValidator(fId); }
@@ -691,40 +691,40 @@ suite.forPlatform('formulas', { name: 'formula executions' }, (test) => {
       .then(() => tools.wait.upTo(10000).for(fetchAndValidateInstances(fId)))
       .then(() => Promise.all(fiIds.map(fiId => common.deleteFormulaInstance(fId, fiId))))
       .then(() => common.deleteFormula(fId));
-  };
+    };
 
-  const myTestWrapper = (kickOffDatFormulaCb, f, fi, numEs, numSes, numSevs, executionValidator, executionStatus) => {
-  if (fi.configuration && fi.configuration['trigger-instance'] === '<replace-me>') fi.configuration['trigger-instance'] = sfdcId;
-  return myCustomTestWrapper(test, kickOffDatFormulaCb, f, fi, numEs, numSes, numSevs, common.execValidatorWrapper(executionValidator), null, executionStatus);
-  };
+    const cancelTestWrapper = (kickOffDatFormulaCb, f, fi, numEs, numSes, numSevs, executionValidator, executionStatus) => {
+    if (fi.configuration && fi.configuration['trigger-instance'] === '<replace-me>') fi.configuration['trigger-instance'] = sfdcId;
+    return cancelTestCustomTestWrapper(test, kickOffDatFormulaCb, f, fi, numEs, numSes, numSevs, common.execValidatorWrapper(executionValidator), null, executionStatus);
+    };
 
-  const myManualTriggerTest = (fName, configuration, trigger, numSevs, validator, executionStatus) => {
-  const f = require(`./assets/formulas/${fName}`);
-  let fi = { name: 'churros-manual-formula-instance' };
+    const cancelManualTriggerTest = (fName, configuration, trigger, numSevs, validator, executionStatus) => {
+      const f = require(`./assets/formulas/${fName}`);
+      let fi = { name: 'churros-manual-formula-instance' };
 
-  if (configuration) {
-    fi.configuration = configuration;
-  }
+      if (configuration) {
+        fi.configuration = configuration;
+      }
 
-  const validatorWrapper = (executions) => {
-    executions.map(e => {
-      e.stepExecutions.filter(se => se.stepName === 'trigger')
-        .map(t => {
-          expect(t.stepExecutionValues.length).to.equal(1);
-          const sev = t.stepExecutionValues[0];
-          expect(sev).to.have.property('key').and.equal('trigger.args');
+      const validatorWrapper = (executions) => {
+        executions.map(e => {
+          e.stepExecutions.filter(se => se.stepName === 'trigger')
+            .map(t => {
+              expect(t.stepExecutionValues.length).to.equal(1);
+              const sev = t.stepExecutionValues[0];
+              expect(sev).to.have.property('key').and.equal('trigger.args');
+            });
         });
-    });
-    if (typeof validator === 'function') validator(executions);
-  };
+        if (typeof validator === 'function') validator(executions);
+      };
 
-  const triggerCb = (fId, fiId) => cloud.post(`/formulas/${fId}/instances/${fiId}/executions`, trigger);
-  const numSes = f.steps.length + 1; // steps + trigger
-  return myTestWrapper(triggerCb, f, fi, 1, numSes, numSevs, validatorWrapper, executionStatus);
-  };
+      const triggerCb = (fId, fiId) => cloud.post(`/formulas/${fId}/instances/${fiId}/executions`, trigger);
+      const numSes = f.steps.length + 1; // steps + trigger
+      return cancelTestWrapper(triggerCb, f, fi, 1, numSes, numSevs, validatorWrapper, executionStatus);
+    };
 
-  var f = myManualTriggerTest('formula-waitForIt-selfContained', null, { foo: 'bar' }, 2, common.defaultValidator, 'success');
-  console.log("manual trigger state", f);
-  return f;
+    var f = cancelManualTriggerTest('formula-waitForIt-selfContained', null, { foo: 'bar' }, 2, common.defaultValidator, 'success');
+    console.log("manual trigger state", f);
+    return f;
   });
 });

--- a/src/test/platform/formulas/executions.js
+++ b/src/test/platform/formulas/executions.js
@@ -633,6 +633,7 @@ suite.forPlatform('formulas', { name: 'formula executions' }, (test) => {
     ////////////////////
     // modified from common.testwrapper()
     const myCustomTestWrapper = (test, kickOffDatFormulaCb, f, fi, numEs, numSes, numSevs, execValidator, instanceValidator, executionStatus, numInstances) => {
+      /*
       const fetchAndValidateExecutions = (fId, fiId) => () => new Promise((res, rej) => {
         return getFormulaInstanceExecutions(fiId)
         .then(r => Promise.all(r.body.map(fie => getFormulaInstanceExecutionWithSteps(fie.id))))
@@ -641,6 +642,7 @@ suite.forPlatform('formulas', { name: 'formula executions' }, (test) => {
         .then(v => res(v))
         .catch(e => rej(e));
       });
+      */
 
       const instanceValidatorWrapper = fId => {
         if (typeof instanceValidator === 'function') { return instanceValidator(fId); }
@@ -679,7 +681,7 @@ suite.forPlatform('formulas', { name: 'formula executions' }, (test) => {
               return new Promise(function(resolve, reject) {
                 setTimeout(() => {
                   resolve();
-                }, 2500) //time in ms
+                }, 2500); //time in ms
               });
             })
             // cancel, expect a 200
@@ -691,7 +693,7 @@ suite.forPlatform('formulas', { name: 'formula executions' }, (test) => {
               return new Promise(function(resolve, reject) {
                 setTimeout(() => {
                   resolve();
-                }, 1000) //time in ms
+                }, 1000); //time in ms
               });
             })
             // cancel again, expect 406 (can't cancel already completed formula)
@@ -699,10 +701,7 @@ suite.forPlatform('formulas', { name: 'formula executions' }, (test) => {
             .then(() => cloud.patch(`/formulas/instances/executions/${exId}`, {'status': 'cancelled'}, (r) => expect(r).to.have.statusCode(406)))
             // cancel non-existent execution ID, expect 404
             .then(() => logger.debug(`cancelling non-existent execution ID ${exId + 100}, expecting 404...`))
-            .then(() => cloud.patch(`/formulas/instances/executions/${exId + 100}`, {'status': 'cancelled'}, (r) => expect(r).to.have.statusCode(404)))
-            //.then(s => expect(s).to.have.status(406))
-            //.then(() => tools.wait.upTo(30000).for(common.allExecutionsCompleted(fId, fiId, numEs, numSevs)))
-            //.then(() => tools.wait.upTo(30000).for(fetchAndValidateExecutions(fId, fiId)));
+            .then(() => cloud.patch(`/formulas/instances/executions/${exId + 100}`, {'status': 'cancelled'}, (r) => expect(r).to.have.statusCode(404)));
         })))
         .then(() => tools.wait.upTo(10000).for(fetchAndValidateInstances(fId)))
         .then(() => Promise.all(fiIds.map(fiId => common.deleteFormulaInstance(fId, fiId))))

--- a/src/test/platform/formulas/executions.js
+++ b/src/test/platform/formulas/executions.js
@@ -637,11 +637,7 @@ suite.forPlatform('formulas', { name: 'formula executions' }, (test) => {
       return Promise.resolve(fId);
     };
 
-    const fetchAndValidateInstances = fId => () => new Promise ((res, rej) => {
-      instanceValidatorWrapper(fId)
-      .then(v => res(v))
-      .catch(e => rej(e));
-    });
+    const fetchAndValidateInstances = fId => () => instanceValidatorWrapper(fId)
 
     let fId;
     const fiIds = [];

--- a/src/test/platform/formulas/executions.js
+++ b/src/test/platform/formulas/executions.js
@@ -630,120 +630,101 @@ suite.forPlatform('formulas', { name: 'formula executions' }, (test) => {
 
   it('should cancel a running formula instance execution and not attempt to cancel an already cancelled/finished execution', () => {
 
-    ////////////////////
-    // modified from common.testwrapper()
     const myCustomTestWrapper = (test, kickOffDatFormulaCb, f, fi, numEs, numSes, numSevs, execValidator, instanceValidator, executionStatus, numInstances) => {
-      /*
-      const fetchAndValidateExecutions = (fId, fiId) => () => new Promise((res, rej) => {
-        return getFormulaInstanceExecutions(fiId)
-        .then(r => Promise.all(r.body.map(fie => getFormulaInstanceExecutionWithSteps(fie.id))))
-        .then(executions => execValidator(executions, numEs, numSes, executionStatus, fId, fiId))
-        //.then(() => console.log(executions))
-        .then(v => res(v))
-        .catch(e => rej(e));
-      });
-      */
 
-      const instanceValidatorWrapper = fId => {
-        if (typeof instanceValidator === 'function') { return instanceValidator(fId); }
-        return Promise.resolve(fId);
-      };
-
-      const fetchAndValidateInstances = fId => () => new Promise ((res, rej) => {
-        instanceValidatorWrapper(fId)
-        .then(v => res(v))
-        .catch(e => rej(e));
-      });
-
-      let fId;
-      const fiIds = [];
-      let exId;
-      return common.createFormula(f)
-        .then(f => fId = f.id)
-        .then(() => tools.times(numInstances || 1)(() => common.createFormulaInstance(fId, fi)))//cloud.post(`/formulas/${fId}/instances`, fi, fiSchema)))
-        .then(ps => Promise.all(ps.map(p => {
-          let fiId;
-          return p
-            .then(fi => {
-              fiId = fi.id;
-              fiIds.push(fiId);
-            })
-            .then(() => kickOffDatFormulaCb(fId, fiId))
-              .then(() => logger.debug("formula ID  ", fId, "\ninstance ID ", fiId))
-            // get first execution
-            .then(() => cloud.get(`/formulas/${fId}/instances/${fiId}/executions`))
-            .then(r => {
-              exId = r.body[0].id;
-              //console.log(r.body[0]);
-            })
-              .then(() => logger.debug("execution ID", exId))
-            .then(() => {
-              return new Promise(function(resolve, reject) {
-                setTimeout(() => {
-                  resolve();
-                }, 2500); //time in ms
-              });
-            })
-            // cancel, expect a 200
-            .then(() => logger.debug(`cancelling execution ID ${exId} ...`))
-            .then(() => cloud.patch(`/formulas/instances/executions/${exId}`, {'status': 'cancelled'}))
-            .then(r => expect(r).to.have.statusCode(200))
-              //.then(r => console.log(r.statusCode.statusCode))
-            .then(() => {
-              return new Promise(function(resolve, reject) {
-                setTimeout(() => {
-                  resolve();
-                }, 1000); //time in ms
-              });
-            })
-            // cancel again, expect 400 (can't cancel already completed formula)
-            .then(() => logger.debug(`cancelling execution ID ${exId} again ...`))
-            .then(() => cloud.patch(`/formulas/instances/executions/${exId}`, {'status': 'cancelled'}, (r) => expect(r).to.have.statusCode(400)))
-            // cancel non-existent execution ID, expect 404
-            .then(() => logger.debug(`cancelling non-existent execution ID ${exId + 100}, expecting 404...`))
-            .then(() => cloud.patch(`/formulas/instances/executions/${exId + 100}`, {'status': 'cancelled'}, (r) => expect(r).to.have.statusCode(404)));
-        })))
-        .then(() => tools.wait.upTo(10000).for(fetchAndValidateInstances(fId)))
-        .then(() => Promise.all(fiIds.map(fiId => common.deleteFormulaInstance(fId, fiId))))
-        .then(() => common.deleteFormula(fId));
+    const instanceValidatorWrapper = fId => {
+      if (typeof instanceValidator === 'function') { return instanceValidator(fId); }
+      return Promise.resolve(fId);
     };
 
-    // from testWrapper()
-    const myTestWrapper = (kickOffDatFormulaCb, f, fi, numEs, numSes, numSevs, executionValidator, executionStatus) => {
-      if (fi.configuration && fi.configuration['trigger-instance'] === '<replace-me>') fi.configuration['trigger-instance'] = sfdcId;
-      return myCustomTestWrapper(test, kickOffDatFormulaCb, f, fi, numEs, numSes, numSevs, common.execValidatorWrapper(executionValidator), null, executionStatus);
-    };
+    const fetchAndValidateInstances = fId => () => new Promise ((res, rej) => {
+      instanceValidatorWrapper(fId)
+      .then(v => res(v))
+      .catch(e => rej(e));
+    });
 
-    // from manualTriggerTest()
-    const myManualTriggerTest = (fName, configuration, trigger, numSevs, validator, executionStatus) => {
-      const f = require(`./assets/formulas/${fName}`);
-      let fi = { name: 'churros-manual-formula-instance' };
-
-      if (configuration) {
-        fi.configuration = configuration;
-      }
-
-      const validatorWrapper = (executions) => {
-        executions.map(e => {
-          e.stepExecutions.filter(se => se.stepName === 'trigger')
-            .map(t => {
-              expect(t.stepExecutionValues.length).to.equal(1);
-              const sev = t.stepExecutionValues[0];
-              expect(sev).to.have.property('key').and.equal('trigger.args');
+    let fId;
+    const fiIds = [];
+    let exId;
+    return common.createFormula(f)
+      .then(f => fId = f.id)
+      .then(() => tools.times(numInstances || 1)(() => common.createFormulaInstance(fId, fi)))//cloud.post(`/formulas/${fId}/instances`, fi, fiSchema)))
+      .then(ps => Promise.all(ps.map(p => {
+        let fiId;
+        return p
+          .then(fi => {
+            fiId = fi.id;
+            fiIds.push(fiId);
+          })
+          .then(() => kickOffDatFormulaCb(fId, fiId))
+            .then(() => logger.debug("formula ID  ", fId, "\ninstance ID ", fiId))
+          .then(() => cloud.get(`/formulas/${fId}/instances/${fiId}/executions`))
+          .then(r => {
+            exId = r.body[0].id;
+          })
+            .then(() => logger.debug("execution ID", exId))
+          .then(() => {
+            return new Promise(function(resolve, reject) {
+              setTimeout(() => {
+                resolve();
+              }, 2500);
             });
+          })
+          // cancel, expect a 200
+          .then(() => logger.debug(`cancelling execution ID ${exId} ...`))
+          .then(() => cloud.patch(`/formulas/instances/executions/${exId}`, {'status': 'cancelled'}))
+          .then(r => expect(r).to.have.statusCode(200))
+          .then(() => {
+            return new Promise(function(resolve, reject) {
+              setTimeout(() => {
+                resolve();
+              }, 1000); 
+            });
+          })
+          // cancel again, expect 400 (can't cancel already completed formula)
+          .then(() => logger.debug(`cancelling execution ID ${exId} again ...`))
+          .then(() => cloud.patch(`/formulas/instances/executions/${exId}`, {'status': 'cancelled'}, (r) => expect(r).to.have.statusCode(400)))
+          // cancel non-existent execution ID, expect 404
+          .then(() => logger.debug(`cancelling non-existent execution ID ${exId + 100}, expecting 404...`))
+          .then(() => cloud.patch(`/formulas/instances/executions/${exId + 100}`, {'status': 'cancelled'}, (r) => expect(r).to.have.statusCode(404)));
+      })))
+      .then(() => tools.wait.upTo(10000).for(fetchAndValidateInstances(fId)))
+      .then(() => Promise.all(fiIds.map(fiId => common.deleteFormulaInstance(fId, fiId))))
+      .then(() => common.deleteFormula(fId));
+  };
+
+  const myTestWrapper = (kickOffDatFormulaCb, f, fi, numEs, numSes, numSevs, executionValidator, executionStatus) => {
+  if (fi.configuration && fi.configuration['trigger-instance'] === '<replace-me>') fi.configuration['trigger-instance'] = sfdcId;
+  return myCustomTestWrapper(test, kickOffDatFormulaCb, f, fi, numEs, numSes, numSevs, common.execValidatorWrapper(executionValidator), null, executionStatus);
+  };
+
+  const myManualTriggerTest = (fName, configuration, trigger, numSevs, validator, executionStatus) => {
+  const f = require(`./assets/formulas/${fName}`);
+  let fi = { name: 'churros-manual-formula-instance' };
+
+  if (configuration) {
+    fi.configuration = configuration;
+  }
+
+  const validatorWrapper = (executions) => {
+    executions.map(e => {
+      e.stepExecutions.filter(se => se.stepName === 'trigger')
+        .map(t => {
+          expect(t.stepExecutionValues.length).to.equal(1);
+          const sev = t.stepExecutionValues[0];
+          expect(sev).to.have.property('key').and.equal('trigger.args');
         });
-        if (typeof validator === 'function') validator(executions);
-      };
+    });
+    if (typeof validator === 'function') validator(executions);
+  };
 
-      const triggerCb = (fId, fiId) => cloud.post(`/formulas/${fId}/instances/${fiId}/executions`, trigger);
-      const numSes = f.steps.length + 1; // steps + trigger
-      return myTestWrapper(triggerCb, f, fi, 1, numSes, numSevs, validatorWrapper, executionStatus);
-    };
-    ////////////////////    
+  const triggerCb = (fId, fiId) => cloud.post(`/formulas/${fId}/instances/${fiId}/executions`, trigger);
+  const numSes = f.steps.length + 1; // steps + trigger
+  return myTestWrapper(triggerCb, f, fi, 1, numSes, numSevs, validatorWrapper, executionStatus);
+  };
 
-    // trigger the formula - no configuration needed
-    var f = myManualTriggerTest('formula-waitForIt-selfContained', null, { foo: 'bar' }, 2, common.defaultValidator, 'success');
-    console.log("manual trigger state", f);
-    return f;
+  var f = myManualTriggerTest('formula-waitForIt-selfContained', null, { foo: 'bar' }, 2, common.defaultValidator, 'success');
+  console.log("manual trigger state", f);
+  return f;
   });
 });

--- a/src/test/platform/formulas/executions.js
+++ b/src/test/platform/formulas/executions.js
@@ -637,7 +637,7 @@ suite.forPlatform('formulas', { name: 'formula executions' }, (test) => {
       return Promise.resolve(fId);
     };
 
-    const fetchAndValidateInstances = fId => () => instanceValidatorWrapper(fId)
+    const fetchAndValidateInstances = fId => () => instanceValidatorWrapper(fId);
 
     let fId;
     const fiIds = [];

--- a/src/test/platform/formulas/executions.js
+++ b/src/test/platform/formulas/executions.js
@@ -69,7 +69,7 @@ const generateXSingleSfdcPollingEvents = (instanceId, x, fileName) => {
 
 
 suite.forPlatform('formulas', { name: 'formula executions' }, (test) => {
-  let sfdcId, dropboxId;
+  /*let sfdcId, dropboxId;
   before(() => {
     return provisioner.create('dropbox')
       .then(r => dropboxId = r.body.id)
@@ -91,7 +91,7 @@ suite.forPlatform('formulas', { name: 'formula executions' }, (test) => {
         done();
       });
   });
-
+*/
   const testWrapper = (kickOffDatFormulaCb, f, fi, numEs, numSes, numSevs, executionValidator, executionStatus) => {
     if (fi.configuration && fi.configuration['trigger-instance'] === '<replace-me>') fi.configuration['trigger-instance'] = sfdcId;
     return common.testWrapper(test, kickOffDatFormulaCb, f, fi, numEs, numSes, numSevs, common.execValidatorWrapper(executionValidator), null, executionStatus);
@@ -696,9 +696,9 @@ suite.forPlatform('formulas', { name: 'formula executions' }, (test) => {
                 }, 1000); //time in ms
               });
             })
-            // cancel again, expect 406 (can't cancel already completed formula)
+            // cancel again, expect 400 (can't cancel already completed formula)
             .then(() => logger.debug(`cancelling execution ID ${exId} again ...`))
-            .then(() => cloud.patch(`/formulas/instances/executions/${exId}`, {'status': 'cancelled'}, (r) => expect(r).to.have.statusCode(406)))
+            .then(() => cloud.patch(`/formulas/instances/executions/${exId}`, {'status': 'cancelled'}, (r) => expect(r).to.have.statusCode(400)))
             // cancel non-existent execution ID, expect 404
             .then(() => logger.debug(`cancelling non-existent execution ID ${exId + 100}, expecting 404...`))
             .then(() => cloud.patch(`/formulas/instances/executions/${exId + 100}`, {'status': 'cancelled'}, (r) => expect(r).to.have.statusCode(404)));

--- a/src/test/platform/formulas/executions.js
+++ b/src/test/platform/formulas/executions.js
@@ -627,4 +627,124 @@ suite.forPlatform('formulas', { name: 'formula executions' }, (test) => {
     };
     return manualTriggerTest('documents-stream', configuration, { foo: 'bar' }, 4, validator);
   });
+
+  it('should cancel a running formula instance execution and not attempt to cancel an already cancelled/finished execution', () => {
+
+    ////////////////////
+    // modified from common.testwrapper()
+    const myCustomTestWrapper = (test, kickOffDatFormulaCb, f, fi, numEs, numSes, numSevs, execValidator, instanceValidator, executionStatus, numInstances) => {
+      const fetchAndValidateExecutions = (fId, fiId) => () => new Promise((res, rej) => {
+        return getFormulaInstanceExecutions(fiId)
+        .then(r => Promise.all(r.body.map(fie => getFormulaInstanceExecutionWithSteps(fie.id))))
+        .then(executions => execValidator(executions, numEs, numSes, executionStatus, fId, fiId))
+        //.then(() => console.log(executions))
+        .then(v => res(v))
+        .catch(e => rej(e));
+      });
+
+      const instanceValidatorWrapper = fId => {
+        if (typeof instanceValidator === 'function') { return instanceValidator(fId); }
+        return Promise.resolve(fId);
+      };
+
+      const fetchAndValidateInstances = fId => () => new Promise ((res, rej) => {
+        instanceValidatorWrapper(fId)
+        .then(v => res(v))
+        .catch(e => rej(e));
+      });
+
+      let fId;
+      const fiIds = [];
+      let exId;
+      return common.createFormula(f)
+        .then(f => fId = f.id)
+        .then(() => tools.times(numInstances || 1)(() => common.createFormulaInstance(fId, fi)))//cloud.post(`/formulas/${fId}/instances`, fi, fiSchema)))
+        .then(ps => Promise.all(ps.map(p => {
+          let fiId;
+          return p
+            .then(fi => {
+              fiId = fi.id;
+              fiIds.push(fiId);
+            })
+            .then(() => kickOffDatFormulaCb(fId, fiId))
+              .then(() => logger.debug("formula ID  ", fId, "\ninstance ID ", fiId))
+            // get first execution
+            .then(() => cloud.get(`/formulas/${fId}/instances/${fiId}/executions`))
+            .then(r => {
+              exId = r.body[0].id;
+              //console.log(r.body[0]);
+            })
+              .then(() => logger.debug("execution ID", exId))
+            .then(() => {
+              return new Promise(function(resolve, reject) {
+                setTimeout(() => {
+                  resolve();
+                }, 2500) //time in ms
+              });
+            })
+            // cancel, expect a 200
+            .then(() => logger.debug(`cancelling execution ID ${exId} ...`))
+            .then(() => cloud.patch(`/formulas/instances/executions/${exId}`, {'status': 'cancelled'}))
+            .then(r => expect(r).to.have.statusCode(200))
+              //.then(r => console.log(r.statusCode.statusCode))
+            .then(() => {
+              return new Promise(function(resolve, reject) {
+                setTimeout(() => {
+                  resolve();
+                }, 1000) //time in ms
+              });
+            })
+            // cancel again, expect 406 (can't cancel already completed formula)
+            .then(() => logger.debug(`cancelling execution ID ${exId} again ...`))
+            .then(() => cloud.patch(`/formulas/instances/executions/${exId}`, {'status': 'cancelled'}, (r) => expect(r).to.have.statusCode(406)))
+            // cancel non-existent execution ID, expect 404
+            .then(() => logger.debug(`cancelling non-existent execution ID ${exId + 100}, expecting 404...`))
+            .then(() => cloud.patch(`/formulas/instances/executions/${exId + 100}`, {'status': 'cancelled'}, (r) => expect(r).to.have.statusCode(404)))
+            //.then(s => expect(s).to.have.status(406))
+            //.then(() => tools.wait.upTo(30000).for(common.allExecutionsCompleted(fId, fiId, numEs, numSevs)))
+            //.then(() => tools.wait.upTo(30000).for(fetchAndValidateExecutions(fId, fiId)));
+        })))
+        .then(() => tools.wait.upTo(10000).for(fetchAndValidateInstances(fId)))
+        .then(() => Promise.all(fiIds.map(fiId => common.deleteFormulaInstance(fId, fiId))))
+        .then(() => common.deleteFormula(fId));
+    };
+
+    // from testWrapper()
+    const myTestWrapper = (kickOffDatFormulaCb, f, fi, numEs, numSes, numSevs, executionValidator, executionStatus) => {
+      if (fi.configuration && fi.configuration['trigger-instance'] === '<replace-me>') fi.configuration['trigger-instance'] = sfdcId;
+      return myCustomTestWrapper(test, kickOffDatFormulaCb, f, fi, numEs, numSes, numSevs, common.execValidatorWrapper(executionValidator), null, executionStatus);
+    };
+
+    // from manualTriggerTest()
+    const myManualTriggerTest = (fName, configuration, trigger, numSevs, validator, executionStatus) => {
+      const f = require(`./assets/formulas/${fName}`);
+      let fi = { name: 'churros-manual-formula-instance' };
+
+      if (configuration) {
+        fi.configuration = configuration;
+      }
+
+      const validatorWrapper = (executions) => {
+        executions.map(e => {
+          e.stepExecutions.filter(se => se.stepName === 'trigger')
+            .map(t => {
+              expect(t.stepExecutionValues.length).to.equal(1);
+              const sev = t.stepExecutionValues[0];
+              expect(sev).to.have.property('key').and.equal('trigger.args');
+            });
+        });
+        if (typeof validator === 'function') validator(executions);
+      };
+
+      const triggerCb = (fId, fiId) => cloud.post(`/formulas/${fId}/instances/${fiId}/executions`, trigger);
+      const numSes = f.steps.length + 1; // steps + trigger
+      return myTestWrapper(triggerCb, f, fi, 1, numSes, numSevs, validatorWrapper, executionStatus);
+    };
+    ////////////////////    
+
+    // trigger the formula - no configuration needed
+    var f = myManualTriggerTest('formula-waitForIt-selfContained', null, { foo: 'bar' }, 2, common.defaultValidator, 'success');
+    console.log("manual trigger state", f);
+    return f;
+  });
 });


### PR DESCRIPTION
## Highlights

- Added churros for new PATCH method to cancel a formula
- tests canceling a formula, canceling a formula that's completed (406), and canceling a formula that doesn't exist (404)

## Closes
* Closes [#4478](https://github.com/cloud-elements/soba/issues/4478)
