### PR TITLE
Added validation to check the AWS hostname in docs when provider is AWS

### DIFF
--- a/src/test/platform/docs/docs.js
+++ b/src/test/platform/docs/docs.js
@@ -50,6 +50,7 @@ suite.forPlatform('docs', {}, () => {
     .then(r => {
         expect(r.body).to.not.be.empty;
         expect(r.body.paths['/accounts'].get.parameters[1].name).to.equal('x-api-key');
+        expect(r.body.host).to.equal('aws-api.cloud-elements.com');
     });
   });
 });


### PR DESCRIPTION
## Highlights
* Added validation to check the AWS hostname in docs when provider is AWS
