### PR TITLE
Dropbox GET /folders/metadata for root

### DIFF
--- a/src/test/elements/dropbox/folders.js
+++ b/src/test/elements/dropbox/folders.js
@@ -1,0 +1,17 @@
+'use strict';
+
+const expect = require('chakram').expect;
+const suite = require('core/suite');
+const cloud = require('core/cloud');
+
+suite.forElement('documents', 'folders', null, (test) => {
+
+  it('should allow GET /folders/metadata for root folder by path & ID', () => {
+    let rootPath = "/";
+    let path = { path: rootPath };
+    return cloud.withOptions({qs: path}).get("/hubs/documents/folders/metadata")
+      .then(r => encodeURIComponent(r.body.id))
+      .then(r => cloud.get(`/hubs/documents/folders/${r}/metadata`))
+      .then(r => expect(r).to.have.statusCode(200))
+  });
+});

--- a/src/test/elements/dropbox/folders.js
+++ b/src/test/elements/dropbox/folders.js
@@ -12,6 +12,10 @@ suite.forElement('documents', 'folders', null, (test) => {
     return cloud.withOptions({qs: query}).get("/hubs/documents/folders/metadata")
       .then(r => encodeURIComponent(r.body.id))
       .then(r => cloud.get(`/hubs/documents/folders/${r}/metadata`))
-      .then(r => expect(r).to.have.statusCode(200))
+      .then(r => {
+        expect(r).to.have.statusCode(200);
+        expect(r.body.path).to.equal(rootPath);
+        expect(r.body.directory).to.equal(true);
+      })
   });
 });

--- a/src/test/elements/dropbox/folders.js
+++ b/src/test/elements/dropbox/folders.js
@@ -8,8 +8,8 @@ suite.forElement('documents', 'folders', null, (test) => {
 
   it('should allow GET /folders/metadata for root folder by path & ID', () => {
     let rootPath = "/";
-    let path = { path: rootPath };
-    return cloud.withOptions({qs: path}).get("/hubs/documents/folders/metadata")
+    let query = { path: rootPath };
+    return cloud.withOptions({qs: query}).get("/hubs/documents/folders/metadata")
       .then(r => encodeURIComponent(r.body.id))
       .then(r => cloud.get(`/hubs/documents/folders/${r}/metadata`))
       .then(r => expect(r).to.have.statusCode(200))

--- a/src/test/elements/dropbox/folders.js
+++ b/src/test/elements/dropbox/folders.js
@@ -5,11 +5,10 @@ const suite = require('core/suite');
 const cloud = require('core/cloud');
 
 suite.forElement('documents', 'folders', (test) => {
+  let rootId = "%2F";
+  let rootPath = "/";
 
-  it('should allow GET /folders/metadata for root folder by path & ID', () => {
-    let id;
-    let rootId = "%2F";
-    let rootPath = "/";
+  it('should allow GET /folders/metadata for root folder', () => {
     let query = { path: rootPath };
     return cloud.withOptions({qs: query}).get("/hubs/documents/folders/metadata")
       .then(r => {
@@ -18,14 +17,16 @@ suite.forElement('documents', 'folders', (test) => {
         expect(r.body.path).to.equal(rootPath);
         expect(r.body.directory).to.equal(true);
       });
-
-    id = encodeURIComponent(rootId);
-    return cloud.get(`/hubs/documents/folders/${rootId}/metadata`)
-    .then(r => {
-      expect(r).to.have.statusCode(200);
-      expect(r.body.id).to.equal(rootId);
-      expect(r.body.path).to.equal(rootPath);
-      expect(r.body.directory).to.equal(true);
-    });
   });
+
+  it('should allow GET /folders/{id}/metadata for root folder', () => {
+    let folderId = encodeURIComponent(rootId);
+    return cloud.get(`/hubs/documents/folders/${folderId}/metadata`)
+      .then(r => {
+        expect(r).to.have.statusCode(200);
+        expect(r.body.id).to.equal(rootId);
+        expect(r.body.path).to.equal(rootPath);
+        expect(r.body.directory).to.equal(true);
+      });
+   });
 });

--- a/src/test/elements/dropbox/folders.js
+++ b/src/test/elements/dropbox/folders.js
@@ -4,18 +4,28 @@ const expect = require('chakram').expect;
 const suite = require('core/suite');
 const cloud = require('core/cloud');
 
-suite.forElement('documents', 'folders', null, (test) => {
+suite.forElement('documents', 'folders', (test) => {
 
   it('should allow GET /folders/metadata for root folder by path & ID', () => {
+    let id;
+    let rootId = "%2F";
     let rootPath = "/";
     let query = { path: rootPath };
     return cloud.withOptions({qs: query}).get("/hubs/documents/folders/metadata")
-      .then(r => encodeURIComponent(r.body.id))
-      .then(r => cloud.get(`/hubs/documents/folders/${r}/metadata`))
       .then(r => {
         expect(r).to.have.statusCode(200);
+        expect(r.body.id).to.equal(rootId);
         expect(r.body.path).to.equal(rootPath);
         expect(r.body.directory).to.equal(true);
-      })
+      });
+
+    id = encodeURIComponent(rootId);
+    return cloud.get(`/hubs/documents/folders/${rootId}/metadata`)
+    .then(r => {
+      expect(r).to.have.statusCode(200);
+      expect(r.body.id).to.equal(rootId);
+      expect(r.body.path).to.equal(rootPath);
+      expect(r.body.directory).to.equal(true);
+    });
   });
 });

--- a/src/test/elements/dropboxbusiness/folders.js
+++ b/src/test/elements/dropboxbusiness/folders.js
@@ -4,19 +4,29 @@ const expect = require('chakram').expect;
 const suite = require('core/suite');
 const cloud = require('core/cloud');
 
-suite.forElement('documents', 'folders', null, (test) => {
+suite.forElement('documents', 'folders', (test) => {
 
   it('should allow GET /folders/metadata for root folder by path & ID', () => {
-    let memberId = "developer@cloud-elements.com";
+    let id;
+    let rootId = "%2F";
     let rootPath = "/";
+    let memberId = "developer@cloud-elements.com";
     let query = { path: rootPath };
-    return cloud.withOptions({ qs: query, headers: { "Elements-As-Team-Member": memberId } }).get("/hubs/documents/folders/metadata")
-      .then(r => encodeURIComponent(r.body.id))
-      .then(r => cloud.get(`/hubs/documents/folders/${r}/metadata`))
+    return cloud.withOptions({qs: query, headers: { "Elements-As-Team-Member": memberId }}).get("/hubs/documents/folders/metadata")
       .then(r => {
         expect(r).to.have.statusCode(200);
+        expect(r.body.id).to.equal(rootId);
         expect(r.body.path).to.equal(rootPath);
         expect(r.body.directory).to.equal(true);
-      })
+      });
+
+    id = encodeURIComponent(rootId);
+    return cloud.withOptions({headers: { "Elements-As-Team-Member": memberId }}).get(`/hubs/documents/folders/${rootId}/metadata`)
+    .then(r => {
+      expect(r).to.have.statusCode(200);
+      expect(r.body.id).to.equal(rootId);
+      expect(r.body.path).to.equal(rootPath);
+      expect(r.body.directory).to.equal(true);
+    });
   });
 });

--- a/src/test/elements/dropboxbusiness/folders.js
+++ b/src/test/elements/dropboxbusiness/folders.js
@@ -3,11 +3,12 @@
 const expect = require('chakram').expect;
 const suite = require('core/suite');
 const cloud = require('core/cloud');
+const props = require('core/props');
 
 suite.forElement('documents', 'folders', (test) => {
   let rootId = "%2F";
   let rootPath = "/";
-  let memberId = "developer@cloud-elements.com";
+  let memberId = props.getForKey('dropboxbusinessv2', 'username');
 
   it('should allow GET /folders/metadata for root folder', () => {
     let query = { path: rootPath };

--- a/src/test/elements/dropboxbusiness/folders.js
+++ b/src/test/elements/dropboxbusiness/folders.js
@@ -13,6 +13,10 @@ suite.forElement('documents', 'folders', null, (test) => {
     return cloud.withOptions({ qs: query, headers: { "Elements-As-Team-Member": memberId } }).get("/hubs/documents/folders/metadata")
       .then(r => encodeURIComponent(r.body.id))
       .then(r => cloud.get(`/hubs/documents/folders/${r}/metadata`))
-      .then(r => expect(r).to.have.statusCode(200))
+      .then(r => {
+        expect(r).to.have.statusCode(200);
+        expect(r.body.path).to.equal(rootPath);
+        expect(r.body.directory).to.equal(true);
+      })
   });
 });

--- a/src/test/elements/dropboxbusiness/folders.js
+++ b/src/test/elements/dropboxbusiness/folders.js
@@ -5,12 +5,11 @@ const suite = require('core/suite');
 const cloud = require('core/cloud');
 
 suite.forElement('documents', 'folders', (test) => {
+  let rootId = "%2F";
+  let rootPath = "/";
+  let memberId = "developer@cloud-elements.com";
 
-  it('should allow GET /folders/metadata for root folder by path & ID', () => {
-    let id;
-    let rootId = "%2F";
-    let rootPath = "/";
-    let memberId = "developer@cloud-elements.com";
+  it('should allow GET /folders/metadata for root folder', () => {
     let query = { path: rootPath };
     return cloud.withOptions({qs: query, headers: { "Elements-As-Team-Member": memberId }}).get("/hubs/documents/folders/metadata")
       .then(r => {
@@ -19,14 +18,16 @@ suite.forElement('documents', 'folders', (test) => {
         expect(r.body.path).to.equal(rootPath);
         expect(r.body.directory).to.equal(true);
       });
-
-    id = encodeURIComponent(rootId);
-    return cloud.withOptions({headers: { "Elements-As-Team-Member": memberId }}).get(`/hubs/documents/folders/${rootId}/metadata`)
-    .then(r => {
-      expect(r).to.have.statusCode(200);
-      expect(r.body.id).to.equal(rootId);
-      expect(r.body.path).to.equal(rootPath);
-      expect(r.body.directory).to.equal(true);
     });
-  });
+
+  it('should allow GET /folders/{id}/metadata for root folder', () => {
+    let folderId = encodeURIComponent(rootId);
+    return cloud.withOptions({headers: { "Elements-As-Team-Member": memberId }}).get(`/hubs/documents/folders/${folderId}/metadata`)
+      .then(r => {
+        expect(r).to.have.statusCode(200);
+        expect(r.body.id).to.equal(rootId);
+        expect(r.body.path).to.equal(rootPath);
+        expect(r.body.directory).to.equal(true);
+      });
+   });
 });

--- a/src/test/elements/dropboxbusiness/folders.js
+++ b/src/test/elements/dropboxbusiness/folders.js
@@ -1,0 +1,18 @@
+'use strict';
+
+const expect = require('chakram').expect;
+const suite = require('core/suite');
+const cloud = require('core/cloud');
+
+suite.forElement('documents', 'folders', null, (test) => {
+
+  it('should allow GET /folders/metadata for root folder by path & ID', () => {
+    let memberId = "developer@cloud-elements.com";
+    let rootPath = "/";
+    let query = { path: rootPath };
+    return cloud.withOptions({ qs: query, headers: { "Elements-As-Team-Member": memberId } }).get("/hubs/documents/folders/metadata")
+      .then(r => encodeURIComponent(r.body.id))
+      .then(r => cloud.get(`/hubs/documents/folders/${r}/metadata`))
+      .then(r => expect(r).to.have.statusCode(200))
+  });
+});

--- a/src/test/elements/dropboxbusinessv2/folders.js
+++ b/src/test/elements/dropboxbusinessv2/folders.js
@@ -4,19 +4,29 @@ const expect = require('chakram').expect;
 const suite = require('core/suite');
 const cloud = require('core/cloud');
 
-suite.forElement('documents', 'folders', null, (test) => {
+suite.forElement('documents', 'folders', (test) => {
 
   it('should allow GET /folders/metadata for root folder by path & ID', () => {
+    let id;
+    let rootId = "%2F";
     let rootPath = "/";
     let memberId = "developer@cloud-elements.com";
     let query = { path: rootPath };
-    return cloud.withOptions({ qs: query, headers: { "Elements-As-Team-Member": memberId } }).get("/hubs/documents/folders/metadata")
-      .then(r => encodeURIComponent(r.body.id))
-      .then(r => cloud.get(`/hubs/documents/folders/${r}/metadata`))
+    return cloud.withOptions({qs: query, headers: { "Elements-As-Team-Member": memberId }}).get("/hubs/documents/folders/metadata")
       .then(r => {
         expect(r).to.have.statusCode(200);
+        expect(r.body.id).to.equal(rootId);
         expect(r.body.path).to.equal(rootPath);
         expect(r.body.directory).to.equal(true);
-      })
+      });
+
+    id = encodeURIComponent(rootId);
+    return cloud.withOptions({headers: { "Elements-As-Team-Member": memberId }}).get(`/hubs/documents/folders/${rootId}/metadata`)
+    .then(r => {
+      expect(r).to.have.statusCode(200);
+      expect(r.body.id).to.equal(rootId);
+      expect(r.body.path).to.equal(rootPath);
+      expect(r.body.directory).to.equal(true);
+    });
   });
 });

--- a/src/test/elements/dropboxbusinessv2/folders.js
+++ b/src/test/elements/dropboxbusinessv2/folders.js
@@ -1,0 +1,18 @@
+'use strict';
+
+const expect = require('chakram').expect;
+const suite = require('core/suite');
+const cloud = require('core/cloud');
+
+suite.forElement('documents', 'folders', null, (test) => {
+
+  it('should allow GET /folders/metadata for root folder by path & ID', () => {
+    let rootPath = "/";
+    let memberId = "developer@cloud-elements.com";
+    let query = { path: rootPath };
+    return cloud.withOptions({ qs: query, headers: { "Elements-As-Team-Member": memberId } }).get("/hubs/documents/folders/metadata")
+      .then(r => encodeURIComponent(r.body.id))
+      .then(r => cloud.get(`/hubs/documents/folders/${r}/metadata`))
+      .then(r => expect(r).to.have.statusCode(200))
+  });
+});

--- a/src/test/elements/dropboxbusinessv2/folders.js
+++ b/src/test/elements/dropboxbusinessv2/folders.js
@@ -13,6 +13,10 @@ suite.forElement('documents', 'folders', null, (test) => {
     return cloud.withOptions({ qs: query, headers: { "Elements-As-Team-Member": memberId } }).get("/hubs/documents/folders/metadata")
       .then(r => encodeURIComponent(r.body.id))
       .then(r => cloud.get(`/hubs/documents/folders/${r}/metadata`))
-      .then(r => expect(r).to.have.statusCode(200))
+      .then(r => {
+        expect(r).to.have.statusCode(200);
+        expect(r.body.path).to.equal(rootPath);
+        expect(r.body.directory).to.equal(true);
+      })
   });
 });

--- a/src/test/elements/dropboxbusinessv2/folders.js
+++ b/src/test/elements/dropboxbusinessv2/folders.js
@@ -3,11 +3,13 @@
 const expect = require('chakram').expect;
 const suite = require('core/suite');
 const cloud = require('core/cloud');
+const props = require('core/props');
 
 suite.forElement('documents', 'folders', (test) => {
   let rootId = "%2F";
   let rootPath = "/";
-  let memberId = "developer@cloud-elements.com";
+  let memberId = props.getForKey('dropboxbusinessv2', 'username');
+
 
   it('should allow GET /folders/metadata for root folder', () => {
     let query = { path: rootPath };

--- a/src/test/elements/dropboxbusinessv2/folders.js
+++ b/src/test/elements/dropboxbusinessv2/folders.js
@@ -5,12 +5,11 @@ const suite = require('core/suite');
 const cloud = require('core/cloud');
 
 suite.forElement('documents', 'folders', (test) => {
+  let rootId = "%2F";
+  let rootPath = "/";
+  let memberId = "developer@cloud-elements.com";
 
-  it('should allow GET /folders/metadata for root folder by path & ID', () => {
-    let id;
-    let rootId = "%2F";
-    let rootPath = "/";
-    let memberId = "developer@cloud-elements.com";
+  it('should allow GET /folders/metadata for root folder', () => {
     let query = { path: rootPath };
     return cloud.withOptions({qs: query, headers: { "Elements-As-Team-Member": memberId }}).get("/hubs/documents/folders/metadata")
       .then(r => {
@@ -19,14 +18,16 @@ suite.forElement('documents', 'folders', (test) => {
         expect(r.body.path).to.equal(rootPath);
         expect(r.body.directory).to.equal(true);
       });
-
-    id = encodeURIComponent(rootId);
-    return cloud.withOptions({headers: { "Elements-As-Team-Member": memberId }}).get(`/hubs/documents/folders/${rootId}/metadata`)
-    .then(r => {
-      expect(r).to.have.statusCode(200);
-      expect(r.body.id).to.equal(rootId);
-      expect(r.body.path).to.equal(rootPath);
-      expect(r.body.directory).to.equal(true);
     });
-  });
+
+  it('should allow GET /folders/{id}/metadata for root folder', () => {
+    let folderId = encodeURIComponent(rootId);
+    return cloud.withOptions({headers: { "Elements-As-Team-Member": memberId }}).get(`/hubs/documents/folders/${folderId}/metadata`)
+      .then(r => {
+        expect(r).to.have.statusCode(200);
+        expect(r.body.id).to.equal(rootId);
+        expect(r.body.path).to.equal(rootPath);
+        expect(r.body.directory).to.equal(true);
+      });
+   });
 });

--- a/src/test/elements/dropboxv2/folders.js
+++ b/src/test/elements/dropboxv2/folders.js
@@ -12,6 +12,10 @@ suite.forElement('documents', 'folders', null, (test) => {
     return cloud.withOptions({qs: query}).get("/hubs/documents/folders/metadata")
       .then(r => encodeURIComponent(r.body.id))
       .then(r => cloud.get(`/hubs/documents/folders/${r}/metadata`))
-      .then(r => expect(r).to.have.statusCode(200))
+      .then(r => {
+        expect(r).to.have.statusCode(200);
+        expect(r.body.path).to.equal(rootPath);
+        expect(r.body.directory).to.equal(true);
+      })
   });
 });

--- a/src/test/elements/dropboxv2/folders.js
+++ b/src/test/elements/dropboxv2/folders.js
@@ -1,0 +1,17 @@
+'use strict';
+
+const expect = require('chakram').expect;
+const suite = require('core/suite');
+const cloud = require('core/cloud');
+
+suite.forElement('documents', 'folders', null, (test) => {
+
+  it('should allow GET /folders/metadata for root folder by path & ID', () => {
+    let rootPath = "/";
+    let query = { path: rootPath };
+    return cloud.withOptions({qs: query}).get("/hubs/documents/folders/metadata")
+      .then(r => encodeURIComponent(r.body.id))
+      .then(r => cloud.get(`/hubs/documents/folders/${r}/metadata`))
+      .then(r => expect(r).to.have.statusCode(200))
+  });
+});

--- a/src/test/elements/dropboxv2/folders.js
+++ b/src/test/elements/dropboxv2/folders.js
@@ -5,11 +5,10 @@ const suite = require('core/suite');
 const cloud = require('core/cloud');
 
 suite.forElement('documents', 'folders', (test) => {
+  let rootId = "%2F";
+  let rootPath = "/";
 
-  it('should allow GET /folders/metadata for root folder by path & ID', () => {
-    let id;
-    let rootId = "%2F";
-    let rootPath = "/";
+  it('should allow GET /folders/metadata for root folder', () => {
     let query = { path: rootPath };
     return cloud.withOptions({qs: query}).get("/hubs/documents/folders/metadata")
       .then(r => {
@@ -18,14 +17,16 @@ suite.forElement('documents', 'folders', (test) => {
         expect(r.body.path).to.equal(rootPath);
         expect(r.body.directory).to.equal(true);
       });
-
-    id = encodeURIComponent(rootId);
-    return cloud.get(`/hubs/documents/folders/${rootId}/metadata`)
-    .then(r => {
-      expect(r).to.have.statusCode(200);
-      expect(r.body.id).to.equal(rootId);
-      expect(r.body.path).to.equal(rootPath);
-      expect(r.body.directory).to.equal(true);
-    });
   });
+
+  it('should allow GET /folders/{id}/metadata for root folder', () => {
+    let folderId = encodeURIComponent(rootId);
+    return cloud.get(`/hubs/documents/folders/${folderId}/metadata`)
+      .then(r => {
+        expect(r).to.have.statusCode(200);
+        expect(r.body.id).to.equal(rootId);
+        expect(r.body.path).to.equal(rootPath);
+        expect(r.body.directory).to.equal(true);
+      });
+   });
 });

--- a/src/test/elements/dropboxv2/folders.js
+++ b/src/test/elements/dropboxv2/folders.js
@@ -4,18 +4,28 @@ const expect = require('chakram').expect;
 const suite = require('core/suite');
 const cloud = require('core/cloud');
 
-suite.forElement('documents', 'folders', null, (test) => {
+suite.forElement('documents', 'folders', (test) => {
 
   it('should allow GET /folders/metadata for root folder by path & ID', () => {
+    let id;
+    let rootId = "%2F";
     let rootPath = "/";
     let query = { path: rootPath };
     return cloud.withOptions({qs: query}).get("/hubs/documents/folders/metadata")
-      .then(r => encodeURIComponent(r.body.id))
-      .then(r => cloud.get(`/hubs/documents/folders/${r}/metadata`))
       .then(r => {
         expect(r).to.have.statusCode(200);
+        expect(r.body.id).to.equal(rootId);
         expect(r.body.path).to.equal(rootPath);
         expect(r.body.directory).to.equal(true);
-      })
+      });
+
+    id = encodeURIComponent(rootId);
+    return cloud.get(`/hubs/documents/folders/${rootId}/metadata`)
+    .then(r => {
+      expect(r).to.have.statusCode(200);
+      expect(r.body.id).to.equal(rootId);
+      expect(r.body.path).to.equal(rootPath);
+      expect(r.body.directory).to.equal(true);
+    });
   });
 });


### PR DESCRIPTION
## Highlights
* Added testing for pre-defined response of `GET /folders/metadata where path = /` & `GET /folders/%2F/metadata` where `%2F` is the Dropbox ID of the root folder
