### PR TITLE
Added tests to search SFDC accounts and contacts when a field value has one or more single quotes in it

### DIFF
--- a/src/test/elements/sfdc/accounts.js
+++ b/src/test/elements/sfdc/accounts.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const expect = require('chakram').expect;
 const suite = require('core/suite');
 const payload = require('./assets/accounts');
 const activities = require('./assets/activities');
@@ -31,6 +32,25 @@ suite.forElement('crm', 'accounts', { payload: payload }, (test) => {
     return cloud.post(test.api, payload)
       .then(r => accountId = r.body.id)
       .then(r => cloud.cruds(`${test.api}/${accountId}/tasks`, tasks))
+      .then(r => cloud.delete(`${test.api}/${accountId}`));
+  });
+  it('should find account with quote in name', () => {
+    let accountId;
+    let accountPayload = {
+      "name": "Churro's Test Account",
+      "type": "Prospect",
+      "phone": "555-666-7777",
+      "website": "http://www.superawesome.com"
+    };
+    let query = { where: "Name='Churro''s Test Account'" };
+
+    return cloud.post(test.api, accountPayload)
+      .then(r => accountId = r.body.id)
+      .then(r => cloud.withOptions({ qs: query }).get(test.api))
+      .then(r => expect(r).to.have.statusCode(200) && expect(r.body).to.not.be.null &&
+        expect(r.body).to.be.a('array') && expect(r.body).to.have.length(1) &&
+        expect(r.body[0]).to.contain.key('Name') &&
+        expect(r.body[0].Name).to.equal("Churro's Test Account"))
       .then(r => cloud.delete(`${test.api}/${accountId}`));
   });
 });


### PR DESCRIPTION
## Highlights
* Added tests to search SFDC accounts and contacts when a field value has one or more single quotes in it

## Closes
* Closes #937 
