### PR TITLE
Enhanced bulk tests

### DIFF
--- a/src/core/assets/cleanup.json
+++ b/src/core/assets/cleanup.json
@@ -1,1 +1,1 @@
-[]
+[{"url":"https://snapshot.cloud-elements.com/elements/api-v2/instances/56393","method":"delete","secrets":{"userSecret":"qSgjoR7AGEr7gDUkgiNs8pAiW10CMUMTbqqPpMNQHK8=","orgSecret":"baf7dfd1e51c068803b83ad713a374b6"}}]

--- a/src/core/assets/cleanup.json
+++ b/src/core/assets/cleanup.json
@@ -1,1 +1,1 @@
-[{"url":"https://snapshot.cloud-elements.com/elements/api-v2/instances/56393","method":"delete","secrets":{"userSecret":"qSgjoR7AGEr7gDUkgiNs8pAiW10CMUMTbqqPpMNQHK8=","orgSecret":"baf7dfd1e51c068803b83ad713a374b6"}}]
+[]

--- a/src/core/suite.js
+++ b/src/core/suite.js
@@ -294,7 +294,7 @@ const itPolling = (name, pay, api, options, validationCb, payload, resource, add
   }, (argv.polling ? false : true) || (options ? options.skip : false));
 };
 
-const itBulkDownload = (name, hub, metadata, options, apiOverride, opts, endpoint) => {
+const itBulkDownload = (name, hub, metadata, options, opts, endpoint) => {
   const n = name || `should support bulk download with options`;
   let bulkId, bulkResults, jsonMeta, csvMeta;
   // gets metadata ready for testing csv and json responses
@@ -308,18 +308,18 @@ const itBulkDownload = (name, hub, metadata, options, apiOverride, opts, endpoin
   metadata = tools.updateMetadata(metadata);
   boomGoesTheDynamite(n, () => {
     // start bulk download
-    return cloud.withOptions(metadata).post(apiOverride ? `${apiOverride}` : `/hubs/${hub}/bulk/query`)
+    return cloud.withOptions(metadata).post(`/hubs/${hub}/bulk/query`)
       .then(r => {
         expect(r.body.status).to.equal('CREATED');
         bulkId = r.body.id;
       })
       // gets regular call to later check the validity of the bulk job
       .then(r => cloud.withOptions(metadata)
-        .get(apiOverride ? `${apiOverride}/${endpoint}` : `/hubs/${hub}/${endpoint}`, r => {
+        .get(`/hubs/${hub}/${endpoint}`, r => {
           bulkResults = r.body;
         }))
       // get bulk download status
-      .then(r => tools.wait.upTo(30000).for(() => cloud.get(apiOverride ? `${apiOverride}/status` : `/hubs/${hub}/bulk/${bulkId}/status`, r => {
+      .then(r => tools.wait.upTo(30000).for(() => cloud.get(`/hubs/${hub}/bulk/${bulkId}/status`, r => {
         expect(r.body.status).to.equal('COMPLETED');
         return r;
       })))
@@ -329,21 +329,20 @@ const itBulkDownload = (name, hub, metadata, options, apiOverride, opts, endpoin
       })
       // get bulk query results in JSON
       .then(r => getJson ? cloud.withOptions(jsonMeta)
-        .get(apiOverride ? `${apiOverride}/${bulkId}/${endpoint}` : `/hubs/${hub}/bulk/${bulkId}/${endpoint}`, r => {
-          console.log(r.body);
-          let bulkDownloadResults = tools.getKey(r.body.split('\n').map(obj => { try{ return JSON.parse(obj) } catch(e) { return ''}}), 'id');
+        .get(`/hubs/${hub}/bulk/${bulkId}/${endpoint}`, r => {
+          let bulkDownloadResults = tools.getKey(r.body.split('\n').map(obj => { try { return JSON.parse(obj); } catch(e) { return ''; } }), 'id');
           expect(bulkDownloadResults).to.deep.equal(tools.getKey(bulkResults, 'id'));
         }) : Promise.resolve(null))
       // get bulk query results in CSV
       .then(r => getCsv ? cloud.withOptions(csvMeta)
-        .get(apiOverride ? `${apiOverride}/${bulkId}/${endpoint}` : `/hubs/${hub}/bulk/${bulkId}/${endpoint}`, r => {
+        .get(`/hubs/${hub}/bulk/${bulkId}/${endpoint}`, r => {
           let bulkDownloadResults = tools.getKey(tools.csvParse(r.body), 'id');
           expect(bulkDownloadResults).to.deep.equal(tools.getKey(bulkResults, 'id'));
         }) : Promise.resolve(null));
   }, options ? options.skip : false);
 };
 
-const itBulkUpload = (name, hub, endpoint, metadata, filePath, options, apiOverride, where) => {
+const itBulkUpload = (name, hub, endpoint, metadata, filePath, options, where) => {
   const n = name || `should support bulk upload with options`;
   let bulkId;
   boomGoesTheDynamite(n, () => {
@@ -353,13 +352,13 @@ const itBulkUpload = (name, hub, endpoint, metadata, filePath, options, apiOverr
     expect(file).to.exist;
     logger.info('Running bulk process, may take upto 2 minutes');
     // start bulk upload
-    return cloud.withOptions(metadata).postFile(apiOverride ? `${apiOverride}` : `/hubs/${hub}/bulk/${endpoint}`, filePath)
+    return cloud.withOptions(metadata).postFile(`/hubs/${hub}/bulk/${endpoint}`, filePath)
       .then(r => {
         expect(r.body.status).to.equal('CREATED');
         bulkId = r.body.id;
       })
       // get bulk upload status
-      .then(r => tools.wait.upTo(120000).for(() => cloud.get(apiOverride ? `${apiOverride}/status` : `/hubs/${hub}/bulk/${bulkId}/status`, r => {
+      .then(r => tools.wait.upTo(120000).for(() => cloud.get(`/hubs/${hub}/bulk/${bulkId}/status`, r => {
         expect(r.body.status).to.equal('COMPLETED');
         return r;
       })))
@@ -369,16 +368,13 @@ const itBulkUpload = (name, hub, endpoint, metadata, filePath, options, apiOverr
       })
       .then((r) => {
         const deleteIds = (where) => {
-          return cloud.withOptions({ qs: { where: where } }).get(apiOverride ? `${apiOverride}/${endpoint}` : `/hubs/${hub}/${endpoint}`)
+          return cloud.withOptions({ qs: { where: where } }).get(`/hubs/${hub}/${endpoint}`)
             .then(r => {
               return r.body.filter(obj => obj.id).map(obj => obj.id);
             })
-            .then(ids => ids.map(id => cloud.delete(apiOverride ? `${apiOverride}/${id}` : `/hubs/${hub}/${endpoint}/${id}`)));
+            .then(ids => ids.map(id => cloud.delete(`/hubs/${hub}/${endpoint}/${id}`)));
         };
-        return where ? deleteIds(where) : Promise.all(file.map(obj => {
-          where = tools.createExpression(obj);
-          return deleteIds(where);
-        }));
+        return where ? deleteIds(where) : Promise.all(file.map(obj => deleteIds(tools.createExpression(obj))));
       });
   }, options ? options.skip : false);
 };
@@ -443,7 +439,7 @@ const runTests = (api, payload, validationCb, tests, hub) => {
      * @param {string} object -> object we are calling: contacts, accounts, etc..
      * @memberof module:core/suite.test.should
      */
-    supportBulkDownload: (metadata, opts, object, apiOverride) => itBulkDownload(name, hub, metadata, options, apiOverride, opts, object),
+    supportBulkDownload: (metadata, opts, object) => itBulkDownload(name, hub, metadata, options, opts, object),
     /**
      * Uploads bulk with options to specific object and verifies it completes and that none fail. Deletes records after completion
      * @param {object} metadata -> headers, query string etc...
@@ -454,7 +450,7 @@ const runTests = (api, payload, validationCb, tests, hub) => {
      *     EXAMPLE: Json-> "{"firstName": "Austin", "lastName": "Mahan"}" | Where -> firstName = 'Austin' AND lastName = 'Mahan'
      * @memberof module:core/suite.test.should
      */
-    supportBulkUpload: (metadata, filePath, object, where, apiOverride) => itBulkUpload(name, hub, object, metadata, filePath, options, apiOverride, where),
+    supportBulkUpload: (metadata, filePath, object, where) => itBulkUpload(name, hub, object, metadata, filePath, options, where),
     /**
      * Validates that the given API `page` and `pageSize` pagination.  In order to test this, we create a few objects and then paginate
      * through the results before cleaning up any resources that were created.

--- a/src/core/suite.js
+++ b/src/core/suite.js
@@ -327,21 +327,18 @@ const itBulkDownload = (name, hub, metadata, options, apiOverride, opts, endpoin
         expect(r.body.recordsFailedCount).to.equal(0);
         expect(r.body.recordsCount).to.equal(bulkResults.length);
       })
-      // Checks results match the where statement
-      .then(r => cloud
-        .get(apiOverride ? `${apiOverride}/${bulkId}/${endpoint}` : `/hubs/${hub}/bulk/${bulkId}/${endpoint}`, r => {
-          let bulkDownloadResults = r.body.split('\n').slice(0, -1).map(el => JSON.parse(el));
-          expect(bulkDownloadResults).to.deep.equal(bulkResults);
-        }))
       // get bulk query results in JSON
       .then(r => getJson ? cloud.withOptions(jsonMeta)
         .get(apiOverride ? `${apiOverride}/${bulkId}/${endpoint}` : `/hubs/${hub}/bulk/${bulkId}/${endpoint}`, r => {
-          expect(r.body, 'json').to.not.be.empty;
+          console.log(r.body);
+          let bulkDownloadResults = tools.getKey(r.body.split('\n').map(obj => { try{ return JSON.parse(obj) } catch(e) { return ''}}), 'id');
+          expect(bulkDownloadResults).to.deep.equal(tools.getKey(bulkResults, 'id'));
         }) : Promise.resolve(null))
       // get bulk query results in CSV
       .then(r => getCsv ? cloud.withOptions(csvMeta)
         .get(apiOverride ? `${apiOverride}/${bulkId}/${endpoint}` : `/hubs/${hub}/bulk/${bulkId}/${endpoint}`, r => {
-          expect(r.body, 'csv').to.not.be.empty;
+          let bulkDownloadResults = tools.getKey(tools.csvParse(r.body), 'id');
+          expect(bulkDownloadResults).to.deep.equal(tools.getKey(bulkResults, 'id'));
         }) : Promise.resolve(null));
   }, options ? options.skip : false);
 };

--- a/src/test/elements/hubspot/bulk.js
+++ b/src/test/elements/hubspot/bulk.js
@@ -3,6 +3,6 @@
 const suite = require('core/suite');
 
 suite.forElement('marketing', 'bulk', (test) => {
-  const opts = {json: true, csv: true};
-  test.should.supportBulkDownload({ qs: { q: 'select * from contacts where firstname = \'Kimberly\'' } }, opts, 'contacts');
+  const opts = {csv: true};
+  test.should.supportBulkDownload({ qs: { q: 'select * from contacts where email = \'avnitagulati@fico.com\'' } }, opts, 'contacts');
 });

--- a/src/test/elements/quickbooksonprem/polling.js
+++ b/src/test/elements/quickbooksonprem/polling.js
@@ -13,7 +13,7 @@ const productsPayload = tools.requirePayload(`${__dirname}/assets/products.json`
 const purchaseOrdersPayload = require('./assets/purchase-orders');
 const salesOrdersPayload = require('./assets/sales-orders');
 const salesReceiptsPayload = require('./assets/sales-receipts');
-const vendorPayload = tools.requirePayload(`${__dirname}/assets/vendor.json`);
+const vendorPayload = tools.requirePayload(`${__dirname}/assets/vendors.json`);
 
 suite.forElement('finance', 'polling', null, (test) => {
   test.withApi('/hubs/finance/credit-memos').should.supportPolling(creditMemosPayload, 'credit-memos');

--- a/test/core/assets/suite-helper.js
+++ b/test/core/assets/suite-helper.js
@@ -48,7 +48,14 @@ exports.mock = (baseUrl, headers, eventHeaders) => {
     .reply(404, (uri, requestBody) => {
       return { message: 'No resource found at /foo/bad/file' };
     })
-    .post('/bulk')
+    .post('/hubs/fakehub/bulk/endpoint')
+    .reply(200, (uri, requestBody) => {
+      var out = {};
+      out.status = 'CREATED';
+      out.id = 123;
+      return out;
+    })
+    .post('/hubs/fakehub/bulk/query')
     .reply(200, (uri, requestBody) => {
       var out = {};
       out.status = 'CREATED';
@@ -86,12 +93,10 @@ exports.mock = (baseUrl, headers, eventHeaders) => {
     .get('/foo/search')
     .query({ foo: 'bar' })
     .reply(200, () => [genPayload({ id: 123 })])
-    .get('/bulk/endpoint')
+    .get('/hubs/fakehub/endpoint')
     .query({where: 'id = 123'})
-    .reply(200, () => new Array(10).fill({id:123}))
-    .get('/bulk/endpoint')
-    .reply(200, () => new Array(10).fill({id:123}))
-    .get('/bulk/status')
+    .reply(200, () => new Array(10).fill({id:'123'}))
+    .get('/hubs/fakehub/bulk/123/status')
     .reply(200, (uri, requestBody) => {
       var out = {};
       out.status = 'COMPLETED';
@@ -101,8 +106,6 @@ exports.mock = (baseUrl, headers, eventHeaders) => {
     })
     .get('/bulk/errors')
     .reply(200, () => {})
-    .get('/bulk/123/endpoint')
-    .reply(200, () => new Array(10).fill(JSON.stringify({id:123})).join('\n') + '\n')
     .get('/elements/123/metadata')
     .reply(200, () => {
       return {
@@ -114,11 +117,11 @@ exports.mock = (baseUrl, headers, eventHeaders) => {
     });
 
     nock(baseUrl, { reqheaders: { accept: "application/json" } })
-    .get('/bulk/123/endpoint')
-    .reply(200, () => JSON.stringify(new Array(10).fill({id:123})));
+    .get('/hubs/fakehub/bulk/123/endpoint')
+    .reply(200, () => new Array(10).fill(JSON.stringify({"id":'123'})).join('\n'));
     nock(baseUrl, { reqheaders: { accept: "text/csv" } })
-    .get('/bulk/123/endpoint')
-    .reply(200, () => JSON.stringify(new Array(10).fill({id:123})));
+    .get('/hubs/fakehub/bulk/123/endpoint')
+    .reply(200, () => ["id"].concat(new Array(10).fill('123')).join('\n').concat('\n'));
 
 
   /** PATCH && PUT **/
@@ -237,7 +240,7 @@ exports.mock = (baseUrl, headers, eventHeaders) => {
     .reply(200, (uri, requestBody) => ({}))
     .delete('/foo/456')
     .reply(404, (uri, requestBody) => ({ message: 'No foo found with the given ID' }))
-    .delete('/bulk/123')
+    .delete('/hubs/fakehub/endpoint/123')
     .reply(200, (uri, requestBody) => ({}))
     .delete('/foo/pagination/123')
     .reply(200, (uri, requestBody) => ({}))

--- a/test/core/suite.test.js
+++ b/test/core/suite.test.js
@@ -38,6 +38,8 @@ describe('suite', () => {
   /* Not passing in any suite options */
   suite.forElement('fakehub', 'resource', (test) => {
     it('should support suite for element', () => expect(test.api).to.equal('/hubs/fakehub/resource'));
+    test.should.supportBulkUpload(null, `${__dirname}/assets/testBulk.json`, 'endpoint', 'id = 123');
+    test.should.supportBulkDownload(null, {json: true, csv: true}, 'endpoint');
   });
 
   /* Not passing in any suite options */
@@ -131,8 +133,6 @@ describe('suite', () => {
     test.should.supportCs();
     test.should.supportCeqlSearch('id');
     test.should.supportCeqlSearchForMultipleRecords('id');
-    test.should.supportBulkUpload(null, `${__dirname}/assets/testBulk.json`, 'endpoint', null, '/bulk');
-    test.should.supportBulkDownload(null, {json: true, csv: true}, 'endpoint', '/bulk');
 
     /* overriding the default API that was passed in as the default in the `suite.forPlatform` */
     test


### PR DESCRIPTION
## Highlights
* You must specify bulk to accept json, csv, or both
* `apiOverride` is no longer an argument, use `.withApi` instead
* Updated the tests with the removed `apiOverride` arg