### PR TITLE
Tests for element object metadata and object names enhancements 

### DIFF
--- a/src/test/platform/elementbuilder/assets/models/contacts_metadata.json
+++ b/src/test/platform/elementbuilder/assets/models/contacts_metadata.json
@@ -2,155 +2,739 @@
   "fields": [
     {
       "type": "string",
-      "vendorPath": "data.address.city"
+      "vendorPath": "data.address.city",
+      "method": [
+        {
+          "response": true,
+          "name": "GET"
+        },
+        {
+          "request": false,
+          "response": true,
+          "name": "POST"
+        },
+        {
+          "request": false,
+          "response": true,
+          "name": "PATCH"
+        }
+      ]
     },
     {
       "type": "string",
-      "vendorPath": "data.address.country"
+      "vendorPath": "data.address.country",
+      "method": [
+        {
+          "response": true,
+          "name": "GET"
+        },
+        {
+          "request": false,
+          "response": true,
+          "name": "POST"
+        },
+        {
+          "request": false,
+          "response": true,
+          "name": "PATCH"
+        }
+      ]
     },
     {
       "type": "string",
-      "vendorPath": "data.address.line1"
+      "vendorPath": "data.address.line1",
+      "method": [
+        {
+          "response": true,
+          "name": "GET"
+        },
+        {
+          "request": false,
+          "response": true,
+          "name": "POST"
+        },
+        {
+          "request": false,
+          "response": true,
+          "name": "PATCH"
+        }
+      ]
     },
     {
       "type": "string",
-      "vendorPath": "data.address.postal_code"
+      "vendorPath": "data.address.postal_code",
+      "method": [
+        {
+          "response": true,
+          "name": "GET"
+        },
+        {
+          "request": false,
+          "response": true,
+          "name": "POST"
+        },
+        {
+          "request": false,
+          "response": true,
+          "name": "PATCH"
+        }
+      ]
     },
     {
       "type": "string",
-      "vendorPath": "data.address.state"
+      "vendorPath": "data.address.state",
+      "method": [
+        {
+          "response": true,
+          "name": "GET"
+        },
+        {
+          "request": false,
+          "response": true,
+          "name": "POST"
+        },
+        {
+          "request": false,
+          "response": true,
+          "name": "PATCH"
+        }
+      ]
     },
     {
       "type": "string",
-      "vendorPath": "data.created_at"
+      "vendorPath": "data.created_at",
+      "method": [
+        {
+          "response": true,
+          "name": "GET"
+        },
+        {
+          "request": true,
+          "response": false,
+          "name": "POST"
+        },
+        {
+          "request": true,
+          "response": false,
+          "name": "PATCH"
+        }
+      ]
     },
     {
       "type": "number",
-      "vendorPath": "data.creator_id"
+      "vendorPath": "data.creator_id",
+      "method": [
+        {
+          "response": true,
+          "name": "GET"
+        },
+        {
+          "request": true,
+          "response": true,
+          "name": "POST"
+        },
+        {
+          "request": true,
+          "response": true,
+          "name": "PATCH"
+        }
+      ]
     },
     {
       "type": "number",
-      "vendorPath": "data.custom_field_values[*].custom_field.data.id"
+      "vendorPath": "data.custom_field_values[*].custom_field.data.id",
+      "method": [
+        {
+          "response": true,
+          "name": "GET"
+        },
+        {
+          "request": false,
+          "response": true,
+          "name": "POST"
+        },
+        {
+          "request": false,
+          "response": true,
+          "name": "PATCH"
+        }
+      ]
     },
     {
       "type": "string",
-      "vendorPath": "data.custom_field_values[*].custom_field.data.name"
+      "vendorPath": "data.custom_field_values[*].custom_field.data.name",
+      "method": [
+        {
+          "response": true,
+          "name": "GET"
+        },
+        {
+          "request": false,
+          "response": true,
+          "name": "POST"
+        },
+        {
+          "request": false,
+          "response": true,
+          "name": "PATCH"
+        }
+      ]
     },
     {
       "type": "string",
-      "vendorPath": "data.custom_field_values[*].custom_field.data.resource_type"
+      "vendorPath": "data.custom_field_values[*].custom_field.data.resource_type",
+      "method": [
+        {
+          "response": true,
+          "name": "GET"
+        },
+        {
+          "request": false,
+          "response": true,
+          "name": "POST"
+        },
+        {
+          "request": false,
+          "response": true,
+          "name": "PATCH"
+        }
+      ]
     },
     {
       "type": "string",
-      "vendorPath": "data.custom_field_values[*].custom_field.data.type"
+      "vendorPath": "data.custom_field_values[*].custom_field.data.type",
+      "method": [
+        {
+          "response": true,
+          "name": "GET"
+        },
+        {
+          "request": false,
+          "response": true,
+          "name": "POST"
+        },
+        {
+          "request": false,
+          "response": true,
+          "name": "PATCH"
+        }
+      ]
     },
     {
       "type": "boolean",
-      "vendorPath": "data.custom_field_values[*].value"
+      "vendorPath": "data.custom_field_values[*].value",
+      "method": [
+        {
+          "response": true,
+          "name": "GET"
+        },
+        {
+          "request": false,
+          "response": true,
+          "name": "POST"
+        },
+        {
+          "request": false,
+          "response": true,
+          "name": "PATCH"
+        }
+      ]
     },
     {
       "type": "string",
-      "vendorPath": "data.customer_status"
+      "vendorPath": "data.customer_status",
+      "method": [
+        {
+          "response": true,
+          "name": "GET"
+        },
+        {
+          "request": true,
+          "response": true,
+          "name": "POST"
+        },
+        {
+          "request": true,
+          "response": true,
+          "name": "PATCH"
+        }
+      ]
     },
     {
       "type": "unknown",
-      "vendorPath": "data.description"
+      "vendorPath": "data.description",
+      "method": [
+        {
+          "response": true,
+          "name": "GET"
+        },
+        {
+          "request": true,
+          "response": false,
+          "name": "POST"
+        },
+        {
+          "request": true,
+          "response": false,
+          "name": "PATCH"
+        }
+      ]
     },
     {
       "type": "unknown",
-      "vendorPath": "data.facebook"
+      "vendorPath": "data.facebook",
+      "method": [
+        {
+          "response": true,
+          "name": "GET"
+        },
+        {
+          "request": true,
+          "response": true,
+          "name": "POST"
+        },
+        {
+          "request": true,
+          "response": true,
+          "name": "PATCH"
+        }
+      ]
     },
     {
       "type": "number",
-      "vendorPath": "data.id"
+      "vendorPath": "data.id",
+      "method": [
+        {
+          "response": true,
+          "name": "GET"
+        },
+        {
+          "request": true,
+          "response": true,
+          "name": "POST"
+        },
+        {
+          "request": true,
+          "response": true,
+          "name": "PATCH"
+        }
+      ]
     },
     {
       "type": "string",
-      "vendorPath": "data.last_name"
+      "vendorPath": "data.last_name",
+      "method": [
+        {
+          "response": true,
+          "name": "GET"
+        },
+        {
+          "request": true,
+          "response": true,
+          "name": "POST"
+        },
+        {
+          "request": true,
+          "response": true,
+          "name": "PATCH"
+        }
+      ]
     },
     {
       "type": "string",
-      "vendorPath": "data.mobile"
+      "vendorPath": "data.mobile",
+      "method": [
+        {
+          "response": true,
+          "name": "GET"
+        },
+        {
+          "request": true,
+          "response": true,
+          "name": "POST"
+        },
+        {
+          "request": true,
+          "response": true,
+          "name": "PATCH"
+        }
+      ]
     },
     {
       "type": "string",
-      "vendorPath": "data.name"
+      "vendorPath": "data.name",
+      "method": [
+        {
+          "response": true,
+          "name": "GET"
+        },
+        {
+          "request": true,
+          "response": true,
+          "name": "POST"
+        },
+        {
+          "request": true,
+          "response": true,
+          "name": "PATCH"
+        }
+      ]
     },
     {
       "type": "number",
-      "vendorPath": "data.owner_id"
+      "vendorPath": "data.owner_id",
+      "method": [
+        {
+          "response": true,
+          "name": "GET"
+        },
+        {
+          "request": true,
+          "response": false,
+          "name": "POST"
+        },
+        {
+          "request": true,
+          "response": false,
+          "name": "PATCH"
+        }
+      ]
     },
     {
       "type": "string",
-      "vendorPath": "data.phone"
+      "vendorPath": "data.phone",
+      "method": [
+        {
+          "response": true,
+          "name": "GET"
+        },
+        {
+          "request": true,
+          "response": true,
+          "name": "POST"
+        },
+        {
+          "request": true,
+          "response": true,
+          "name": "PATCH"
+        }
+      ]
     },
     {
       "type": "unknown",
-      "vendorPath": "data.shipping_address"
+      "vendorPath": "data.shipping_address",
+      "method": [
+        {
+          "response": true,
+          "name": "GET"
+        },
+        {
+          "request": true,
+          "response": true,
+          "name": "POST"
+        },
+        {
+          "request": true,
+          "response": true,
+          "name": "PATCH"
+        }
+      ]
     },
     {
       "type": "unknown",
-      "vendorPath": "data.website"
-    },
-    {
-      "type": "unknown",
-      "vendorPath": "data.billing_address"
-    },
-    {
-      "type": "number",
-      "vendorPath": "data.contact_id"
+      "vendorPath": "data.website",
+      "method": [
+        {
+          "response": true,
+          "name": "GET"
+        },
+        {
+          "request": true,
+          "response": true,
+          "name": "POST"
+        },
+        {
+          "request": true,
+          "response": true,
+          "name": "PATCH"
+        }
+      ]
     },
     {
       "type": "string",
-      "vendorPath": "data.email"
+      "vendorPath": "data.email",
+      "method": [
+        {
+          "request": true,
+          "response": true,
+          "name": "POST"
+        },
+        {
+          "response": true,
+          "name": "GET"
+        },
+        {
+          "request": true,
+          "response": true,
+          "name": "PATCH"
+        }
+      ]
     },
     {
       "type": "unknown",
-      "vendorPath": "data.fax"
+      "vendorPath": "data.fax",
+      "method": [
+        {
+          "request": true,
+          "response": true,
+          "name": "POST"
+        },
+        {
+          "response": true,
+          "name": "GET"
+        },
+        {
+          "request": true,
+          "response": true,
+          "name": "PATCH"
+        }
+      ]
     },
     {
       "type": "string",
-      "vendorPath": "data.first_name"
-    },
-    {
-      "type": "unknown",
-      "vendorPath": "data.industry"
+      "vendorPath": "data.first_name",
+      "method": [
+        {
+          "request": true,
+          "response": true,
+          "name": "POST"
+        },
+        {
+          "response": true,
+          "name": "GET"
+        },
+        {
+          "request": true,
+          "response": true,
+          "name": "PATCH"
+        }
+      ]
     },
     {
       "type": "boolean",
-      "vendorPath": "data.is_organization"
-    },
-    {
-      "type": "unknown",
-      "vendorPath": "data.linkedin"
+      "vendorPath": "data.is_organization",
+      "method": [
+        {
+          "request": true,
+          "response": true,
+          "name": "POST"
+        },
+        {
+          "response": true,
+          "name": "GET"
+        },
+        {
+          "request": true,
+          "response": true,
+          "name": "PATCH"
+        }
+      ]
     },
     {
       "type": "string",
-      "vendorPath": "data.prospect_status"
-    },
-    {
-      "type": "unknown",
-      "vendorPath": "data.skype"
-    },
-    {
-      "type": "string",
-      "vendorPath": "data.title"
-    },
-    {
-      "type": "unknown",
-      "vendorPath": "data.twitter"
+      "vendorPath": "data.prospect_status",
+      "method": [
+        {
+          "request": true,
+          "response": true,
+          "name": "POST"
+        },
+        {
+          "response": true,
+          "name": "GET"
+        },
+        {
+          "request": true,
+          "response": true,
+          "name": "PATCH"
+        }
+      ]
     },
     {
       "type": "number",
-      "vendorPath": "data.tags[*].data.id"
+      "vendorPath": "data.tags[*].data.id",
+      "method": [
+        {
+          "request": false,
+          "response": true,
+          "name": "POST"
+        },
+        {
+          "response": true,
+          "name": "GET"
+        },
+        {
+          "request": false,
+          "response": true,
+          "name": "PATCH"
+        }
+      ]
     },
     {
       "type": "string",
-      "vendorPath": "data.tags[*].data.name"
+      "vendorPath": "data.tags[*].data.name",
+      "method": [
+        {
+          "request": false,
+          "response": true,
+          "name": "POST"
+        },
+        {
+          "response": true,
+          "name": "GET"
+        },
+        {
+          "request": false,
+          "response": true,
+          "name": "PATCH"
+        }
+      ]
     },
     {
       "type": "string",
-      "vendorPath": "data.tags[*].data.resource_type"
+      "vendorPath": "data.tags[*].data.resource_type",
+      "method": [
+        {
+          "request": false,
+          "response": true,
+          "name": "POST"
+        },
+        {
+          "response": true,
+          "name": "GET"
+        },
+        {
+          "request": false,
+          "response": true,
+          "name": "PATCH"
+        }
+      ]
+    },
+    {
+      "type": "unknown",
+      "vendorPath": "data.twitter",
+      "method": [
+        {
+          "request": true,
+          "response": true,
+          "name": "POST"
+        },
+        {
+          "response": true,
+          "name": "GET"
+        },
+        {
+          "request": true,
+          "response": true,
+          "name": "PATCH"
+        }
+      ]
+    },
+    {
+      "type": "unknown",
+      "vendorPath": "data.billing_address",
+      "method": [
+        {
+          "request": true,
+          "response": false,
+          "name": "POST"
+        },
+        {
+          "request": true,
+          "response": false,
+          "name": "PATCH"
+        }
+      ]
+    },
+    {
+      "type": "number",
+      "vendorPath": "data.contact_id",
+      "method": [
+        {
+          "request": true,
+          "response": false,
+          "name": "POST"
+        },
+        {
+          "request": true,
+          "response": false,
+          "name": "PATCH"
+        }
+      ]
+    },
+    {
+      "type": "unknown",
+      "vendorPath": "data.industry",
+      "method": [
+        {
+          "request": true,
+          "response": false,
+          "name": "POST"
+        },
+        {
+          "request": true,
+          "response": false,
+          "name": "PATCH"
+        }
+      ]
+    },
+    {
+      "type": "unknown",
+      "vendorPath": "data.linkedin",
+      "method": [
+        {
+          "request": true,
+          "response": false,
+          "name": "POST"
+        },
+        {
+          "request": true,
+          "response": false,
+          "name": "PATCH"
+        }
+      ]
+    },
+    {
+      "type": "unknown",
+      "vendorPath": "data.skype",
+      "method": [
+        {
+          "request": true,
+          "response": false,
+          "name": "POST"
+        },
+        {
+          "request": true,
+          "response": false,
+          "name": "PATCH"
+        }
+      ]
+    },
+    {
+      "type": "string",
+      "vendorPath": "data.title",
+      "method": [
+        {
+          "request": true,
+          "response": false,
+          "name": "POST"
+        },
+        {
+          "request": true,
+          "response": false,
+          "name": "PATCH"
+        }
+      ]
     }
   ]
 }

--- a/src/test/platform/elementbuilder/assets/models/onemodel_element.json
+++ b/src/test/platform/elementbuilder/assets/models/onemodel_element.json
@@ -270,7 +270,7 @@
       "model": {
         "requestName": "contactsPost",
         "transform": false,
-        "name": "contacts",
+        "name": "contactsPostRes",
         "requestSwagger": {
           "data": {
             "id": "data",
@@ -632,7 +632,7 @@
       "model": {
         "requestName": "contactsPatch",
         "transform": false,
-        "name": "contacts",
+        "name": "contactsPatchResponse",
         "requestSwagger": {
           "contactsPatch": {
             "id": "contactsPatch",

--- a/src/test/platform/elementbuilder/models.js
+++ b/src/test/platform/elementbuilder/models.js
@@ -15,6 +15,16 @@ suite.forPlatform('element-model', {}, (test) => {
       .then(r => provisioner.create('onemodel', undefined, 'elements/onemodel/instances'))
       .then(r => oneModelInstance = r.body));
 
+
+  it('should support calling combined/merged objectnames for instance', () => {
+      return cloud.get(`/hubs/general/objects`, (r) => {
+          expect(r.body).to.not.be.empty;
+          expect(r.body).to.be.array;
+          expect(r.body).to.have.length(1);
+          expect(r.body[0]).to.equal('contacts');
+      });
+  });
+
   it('should support calling combined/merged metadata for instance', () => {
       return cloud.get(`/hubs/general/objects/contacts/metadata`, (r) => {
           expect(r.body).to.not.be.empty;


### PR DESCRIPTION
## Highlights
* Added tests for element `/objects` to be resource names, even if the model names are different
* Added tests for element `/objects/{objectName}/metadata` to be superset of all models for the resource with method at the field level
