### PR TITLE
Mixpanel element tests

### DIFF
--- a/src/test/elements/mixpanel/activities.js
+++ b/src/test/elements/mixpanel/activities.js
@@ -1,0 +1,8 @@
+'use strict';
+
+const suite = require('core/suite');
+const payload = require('./assets/activities');
+
+suite.forElement('general', 'activities', { payload: payload }, (test) => {
+  test.should.return200OnPost(payload);
+});

--- a/src/test/elements/mixpanel/assets/activities.json
+++ b/src/test/elements/mixpanel/assets/activities.json
@@ -1,0 +1,7 @@
+{
+    "event": "Signed Up",
+    "properties": {
+        "distinct_id": "12157",
+        "Referred By": "Friend"
+    }
+}

--- a/src/test/elements/mixpanel/assets/users.json
+++ b/src/test/elements/mixpanel/assets/users.json
@@ -1,0 +1,17 @@
+{
+  "$set": {
+    "$os": "Mac OS X",
+    "$browser": "Chrome",
+    "$browser_version": 59,
+    "$initial_referrer": "$direct",
+    "$initial_referring_domain": "$direct",
+    "$email": "seven@example.com",
+    "$city": "Dallas",
+    "$created": "2011-03-16 16:53:54",
+    "$last_login": "2017-07-19T22:03:47",
+    "credits": 150,
+    "gender": "Male",
+    "Name": "Seven"
+  },
+  "$distinct_id": "12157"
+}

--- a/src/test/elements/mixpanel/bulk.js
+++ b/src/test/elements/mixpanel/bulk.js
@@ -1,0 +1,50 @@
+'use strict';
+
+const suite = require('core/suite');
+const cloud = require('core/cloud');
+const tools = require('core/tools');
+const expect = require('chakram').expect;
+
+suite.forElement('general', 'bulk', null, (test) => {
+
+  it('should support bulk download of activities', () => {
+    let bulkId;
+    var priorDate = new Date().setDate(new Date().getDate()-30);
+    const opts = { qs: { q: 'select * from activities', from : new Date(priorDate).toISOString() } };
+
+    // start bulk download
+    return cloud.withOptions(opts).post('/hubs/general/bulk/query')
+      .then(r => {
+        expect(r.body.status).to.equal('CREATED');
+        bulkId = r.body.id;
+      })
+      // get bulk download status
+      .then(r => tools.wait.upTo(30000).for(() => cloud.get(`/hubs/general/bulk/${bulkId}/status`, r => {
+        expect(r.body.status).to.equal('COMPLETED');
+        expect(r.body.recordsFailedCount).to.equal(0);
+      })))
+      // get bulk download errors
+      .then(r => cloud.get(`/hubs/general/bulk/${bulkId}/errors`));
+  });
+
+  it('should support bulk download of users', () => {
+    let bulkId;
+    var priorDate = new Date().setDate(new Date().getDate()-30);
+    const opts = { qs: { q: 'select * from users where query = \'(properties["$created"]  > "2011-03-14T09:53:54")\''} };
+
+    // start bulk download
+    return cloud.withOptions(opts).post('/hubs/general/bulk/query')
+      .then(r => {
+        expect(r.body.status).to.equal('CREATED');
+        bulkId = r.body.id;
+      })
+      // get bulk download status
+      .then(r => tools.wait.upTo(30000).for(() => cloud.get(`/hubs/general/bulk/${bulkId}/status`, r => {
+        expect(r.body.status).to.equal('COMPLETED');
+        expect(r.body.recordsFailedCount).to.equal(0);
+      })))
+      // get bulk download errors
+      .then(r => cloud.get(`/hubs/general/bulk/${bulkId}/errors`));
+  });
+
+});

--- a/src/test/elements/mixpanel/bulk.js
+++ b/src/test/elements/mixpanel/bulk.js
@@ -29,7 +29,6 @@ suite.forElement('general', 'bulk', null, (test) => {
 
   it('should support bulk download of users', () => {
     let bulkId;
-    var priorDate = new Date().setDate(new Date().getDate()-30);
     const opts = { qs: { q: 'select * from users where query = \'(properties["$created"]  > "2011-03-14T09:53:54")\''} };
 
     // start bulk download

--- a/src/test/elements/mixpanel/users.js
+++ b/src/test/elements/mixpanel/users.js
@@ -1,0 +1,19 @@
+'use strict';
+
+const suite = require('core/suite');
+const tools = require('core/tools');
+const cloud = require('core/cloud');
+const payload = require('./assets/users');
+
+
+suite.forElement('general', 'users', { payload: payload }, (test) => {
+  it('should allow CUDS for /users', () => {
+    let id;
+    return cloud.post(test.api, payload)
+      .then(r => id = r.body.$distinct_id)
+      .then(r => cloud.patch(`${test.api}/${id}`, payload))
+      .then(r => cloud.withOptions({ qs: { where: `"$city"='Dallas'` } }).get(`${test.api}`))
+      .then(r => cloud.withOptions({ qs: { where: `query = '(properties[\"$city\"] == \"Dallas\")'` } }).get(`${test.api}`))
+      .then(r => cloud.delete(`${test.api}/${id}`));
+  });
+});

--- a/src/test/elements/mixpanel/users.js
+++ b/src/test/elements/mixpanel/users.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const suite = require('core/suite');
-const tools = require('core/tools');
 const cloud = require('core/cloud');
 const payload = require('./assets/users');
 


### PR DESCRIPTION
## Highlights
* Mixpanel element tests for activities, users and bulk

## Examples
```
churros test elements/mixpanel
sleep: using busy loop fallback

info: Running tests for element: mixpanel
info: Provisioned with instance id of 5882
  - should not allow provisioning with bad credentials
  activities
    ✓ should allow POST for /hubs/general/activities (754ms)

  bulk
error: Failed to retrieve or validate: /hubs/general/bulk/5138/status
error: Failed to retrieve or validate: /hubs/general/bulk/5138/status
error: Failed to retrieve or validate: /hubs/general/bulk/5138/status
    ✓ should support bulk download of activities (10138ms)
error: Failed to retrieve or validate: /hubs/general/bulk/5139/status
    ✓ should support bulk download of users (3375ms)

  users
    ✓ should allow CUDS for /users (1930ms)


  4 passing (24s)
  1 pending
```
