### PR TITLE
Added activities/top API to test

### DIFF
--- a/src/test/elements/mixpanel/activities.js
+++ b/src/test/elements/mixpanel/activities.js
@@ -5,4 +5,5 @@ const payload = require('./assets/activities');
 
 suite.forElement('general', 'activities', { payload: payload }, (test) => {
   test.should.return200OnPost(payload);
+  test.withOptions({ qs: { where: `type = 'general'` } }).withApi('/hubs/general/activities/top').should.return200OnGet();
 });


### PR DESCRIPTION
## Highlights
* Added activities/top API to test

```
venkats-mbp:churros ramana$ churros test elements/mixpanel
sleep: using busy loop fallback


info: Running tests for element: mixpanel
info: Provisioned with instance id of 6035
  - should not allow provisioning with bad credentials
  activities
    ✓ should allow POST for /hubs/general/activities (7532ms)
    ✓ should allow GET for /hubs/general/activities/top (417ms)

  bulk
error: Failed to retrieve or validate: /hubs/general/bulk/5164/status
error: Failed to retrieve or validate: /hubs/general/bulk/5164/status
error: Failed to retrieve or validate: /hubs/general/bulk/5164/status
    ✓ should support bulk download of activities (10084ms)
error: Failed to retrieve or validate: /hubs/general/bulk/5165/status
error: Failed to retrieve or validate: /hubs/general/bulk/5165/status
error: Failed to retrieve or validate: /hubs/general/bulk/5165/status
error: Failed to retrieve or validate: /hubs/general/bulk/5165/status
error: Failed to retrieve or validate: /hubs/general/bulk/5165/status
error: Failed to retrieve or validate: /hubs/general/bulk/5165/status
error: Failed to retrieve or validate: /hubs/general/bulk/5165/status
error: Failed to retrieve or validate: /hubs/general/bulk/5165/status
    ✓ should support bulk download of users (25292ms)

  users
    ✓ should allow CUDS for /users (8645ms)


  5 passing (1m)
  1 pending

```