### PR TITLE
Added a test case for Salesforce single quote

### DIFF
--- a/src/test/elements/sfdc/leads.js
+++ b/src/test/elements/sfdc/leads.js
@@ -12,6 +12,8 @@ suite.forElement('crm', 'leads', { payload: payload }, (test) => {
   test.should.supportCeqlSearch('id');
   test.should.supportCruds();
   test.should.return404OnGet('0');
+  test.withOptions({ qs: { where: "email=''" } }).should.return200OnGet();
+
   it('should allow CRUDS for /hubs/crm/leads/:id/activites', () => {
     let leadId;
     return cloud.post(test.api, payload)


### PR DESCRIPTION
## Highlights
* Added a churros test.withOptions() to test with email='' for Salesforce Sales Cloud single quote issue

## Examples


## Closes
* Closes #${DE4}
