### PR TITLE
Freshdesk V2 : Fixed payload for POST /accounts

### DIFF
--- a/src/test/elements/freshdeskv2/assets/accounts.json
+++ b/src/test/elements/freshdeskv2/assets/accounts.json
@@ -1,4 +1,5 @@
 {
-    "name": "sampleChurros",
-    "description": "random description"
+  "customer": {
+      "name": "qwertylkb"
+  }
 }


### PR DESCRIPTION
## Non-Customer Highlights
* Fixed payload for POST /accounts. It takes `customer` field as a complex object and within which `name` is required.
* While running churros after fixing the issue https://github.com/cloud-elements/soba/issues/7360, churros test failed only for this specific API. Hence corrected the same.