### PR TITLE
Fixing Search churros for SFDC documents

### DIFF
--- a/src/test/elements/sfdcdocuments/search.js
+++ b/src/test/elements/sfdcdocuments/search.js
@@ -5,7 +5,6 @@ const tools = require('core/tools');
 const expect = require('chakram').expect;
 
 suite.forElement('documents', 'search', null, (test) => {
-  test.withOptions({ qs: { text: tools.random() } }).should.return200OnGet();
 
   test.should.supportPagination();
 
@@ -15,7 +14,7 @@ suite.forElement('documents', 'search', null, (test) => {
   test.withOptions({ qs: { startDate: '2015-06-15T09:15:04Z', endDate: '2015-06-15T09:40:04Z' } })
     .should.return200OnGet();
 
-  test.withOptions({ qs: { path: '/Test folder' } })
+  test.withOptions({ qs: { path: '/Test folder',text: tools.random() } })
     .withValidation((r) => {
       expect(r).to.have.statusCode(400);
     });


### PR DESCRIPTION
## Highlights
Searching within  "text" query with any random text should return 400 error. 

## Closes
* Closes [#US1357-TA608-sfdcdocuments](https://rally1.rallydev.com/#/144349237612d/detail/task/153578211224?fdp=true)

