### PR TITLE
Modelbuilder swagger tests

### DIFF
--- a/src/test/platform/elementbuilder/assets/objects/onemodel_element.json
+++ b/src/test/platform/elementbuilder/assets/objects/onemodel_element.json
@@ -223,17 +223,6 @@
       "hooks": [],
       "parameters": [
         {
-          "vendorType": "path",
-          "dataType": "string",
-          "name": "id",
-          "description": "The contacts ID",
-          "vendorDataType": "string",
-          "source": "request",
-          "type": "path",
-          "vendorName": "id",
-          "required": true
-        },
-        {
           "vendorType": "body",
           "dataType": "contacts",
           "name": "contacts",

--- a/src/test/platform/elementbuilder/assets/objects/onemodel_element.json
+++ b/src/test/platform/elementbuilder/assets/objects/onemodel_element.json
@@ -120,6 +120,7 @@
       ],
       "object": {
         "name": "contacts",
+        "type": "array",
         "fields": [
           {
             "name": "id",

--- a/src/test/platform/elementbuilder/element-objects.js
+++ b/src/test/platform/elementbuilder/element-objects.js
@@ -50,12 +50,7 @@ suite.forPlatform('element-objects', {}, (test) => {
           expect(postbodyParam.schema).to.not.be.empty;
           expect(postbodyParam.schema.properties).to.not.be.empty;
           expect(postbodyParam.schema['x-vendor-objectname']).to.not.be.empty;
-          swaggerParser.validate(r.body, (err, api) => {
-            if (err) {
-              reject(err);
-            }
-            resolve();
-          });
+          swaggerParser.validate(r.body);
       });
   });
 

--- a/src/test/platform/elementbuilder/element-objects.js
+++ b/src/test/platform/elementbuilder/element-objects.js
@@ -6,6 +6,7 @@ const cloud = require('core/cloud');
 const provisioner = require('core/provisioner');
 const oneModelElementJson = require('./assets/objects/onemodel_element.json');
 const contactsMetadata = require('./assets/objects/contacts_metadata.json');
+const swaggerParser = require('swagger-parser');
 
 suite.forPlatform('element-objects', {}, (test) => {
   let oneModelElement;
@@ -31,6 +32,30 @@ suite.forPlatform('element-objects', {}, (test) => {
           expect(r.body.fields).to.be.array;
           expect(r.body.fields).to.have.length(8);
           expect(r.body).to.deep.equal(contactsMetadata);
+      });
+  });
+
+
+  it('should support calling generating swagger docs for the instance', () => {
+      return cloud.get(`/elements/${oneModelElement.id}/docs`, (r) => {
+          expect(r.body).to.not.be.empty;
+          let docs = r.body;
+          expect(docs.paths).to.not.be.empty;
+          expect(docs.paths['/contacts']).to.not.be.empty;
+          let contacts = docs.paths['/contacts'];
+          expect(contacts.post).to.not.be.empty;
+          expect(contacts.post.parameters).to.not.be.empty;
+          let postbodyParam = contacts.post.parameters.filter(p => p['in'] === 'body')[0];
+          expect(postbodyParam).to.not.be.empty;
+          expect(postbodyParam.schema).to.not.be.empty;
+          expect(postbodyParam.schema.properties).to.not.be.empty;
+          expect(postbodyParam.schema['x-vendor-objectname']).to.not.be.empty;
+          swaggerParser.validate(r.body, (err, api) => {
+            if (err) {
+              reject(err);
+            }
+            resolve();
+          });
       });
   });
 

--- a/src/test/platform/elementbuilder/elementextend.js
+++ b/src/test/platform/elementbuilder/elementextend.js
@@ -137,7 +137,7 @@ suite.forPlatform('element-extend', {}, (test) => {
       return cloud.withOptions({ qs: { accountOnly: true } }).get(`elements/closeio/resources`)
         .then(r => {
           expect(r.body).to.not.be.empty;
-          expect(r.body.length === 2).to.be.true;
+          expect(r.body.length === 1).to.be.true;
         });
     });
 


### PR DESCRIPTION
## Highlights
* Modelbuilder swagger tests

## Examples
```
venkats-mbp:churros ramana$ churros test platform/elementbuilder --file element-objects
sleep: using busy loop fallback


  element-objects
    ✓ should support calling objectnames for instance (1573ms)
    ✓ should support calling objects metadata for instance (169ms)
    ✓ should support calling generating swagger docs for the instance (199ms)


  3 passing (4s)

```

