### PR TITLE
Netsuitefinance: Fixed the failing churros 

### DIFF
--- a/src/test/elements/assets/object.definitions.json
+++ b/src/test/elements/assets/object.definitions.json
@@ -517,6 +517,12 @@
       "type": "string"
     }]
   },
+  "subsidiaries": {
+    "fields": [{
+      "path": "id",
+      "type": "string"
+    }]
+  },
   "groups": {
     "fields": [{
       "path": "id",

--- a/src/test/elements/netsuitefinancev2/assets/vendors.json
+++ b/src/test/elements/netsuitefinancev2/assets/vendors.json
@@ -8,7 +8,7 @@
     "internalId":"1",
     "name":"Honeycomb Mfg."
   },
-  "companyName":"<<company.companyName>>",
+  "companyName":"<<random.word>>",
   "isPerson":false,
   "isJobResourceVend":false,
   "terms":{

--- a/src/test/elements/netsuitefinancev2/classifications.js
+++ b/src/test/elements/netsuitefinancev2/classifications.js
@@ -2,9 +2,9 @@
 
 const suite = require('core/suite');
 const payload = require('core/tools').requirePayload(`${__dirname}/assets/classifications.json`);
-
+const payloadPost = require('core/tools').requirePayload(`${__dirname}/assets/classifications.json`);
 suite.forElement('finance', 'classifications', { payload: payload }, (test) => {
   	test.should.supportCruds();
 	test.withOptions({ qs: { page: 1, pageSize: 5}}).should.supportPagination();
-  	test.should.supportCeqlSearch('name');
+  	test.should.supportCeqlSearch('name',payloadPost);
 });

--- a/src/test/elements/netsuitefinancev2/customers.js
+++ b/src/test/elements/netsuitefinancev2/customers.js
@@ -3,11 +3,11 @@
 const suite = require('core/suite');
 const tools = require('core/tools');
 const payload = tools.requirePayload(`${__dirname}/assets/customers.json`);
-
+const payloadPost = tools.requirePayload(`${__dirname}/assets/customers.json`);
 suite.forElement('finance', 'customers', { payload: payload }, (test) => {
     test.should.supportCruds();
 	  test.withOptions({ qs: { page: 1, pageSize: 5}}).should.supportPagination();
-  	test.should.supportCeqlSearch('id');
+  	test.should.supportCeqlSearch('id',payloadPost);
     test.withOptions({ qs: { page: 1,
                              pageSize: 5,
                              where : "savedSearchId = '18'"

--- a/src/test/elements/netsuitefinancev2/polling.js
+++ b/src/test/elements/netsuitefinancev2/polling.js
@@ -14,7 +14,7 @@ const vendorPaymentsPayload = require('./assets/vendor-payments');
 const vendorsPayload = tools.requirePayload(`${__dirname}/assets/vendors.json`);
 
 // Polling not working right now, uncomment when fixed
-suite.forElement('finance', 'polling', {skip: true}, (test) => {
+suite.forElement('finance', 'polling',  (test) => {
   test.withApi('/hubs/finance/customers').should.supportPolling(customersPayload, 'customers');
   test.withApi('/hubs/finance/employees').should.supportPolling(employeesPayload, 'employees');
   test.withApi('/hubs/finance/invoices').should.supportPolling(invoicesPayload, 'invoices');

--- a/src/test/elements/netsuitefinancev2/tax-codes.js
+++ b/src/test/elements/netsuitefinancev2/tax-codes.js
@@ -7,7 +7,7 @@ suite.forElement('finance', 'tax-codes', (test) => {
   it('should support GET /tax-codes and GET /tax-codes/:id', () => {
     let taxId;
     return cloud.get(test.api)
-      .then(r => taxId = r.body[0].internalId)
+      .then(r => taxId = r.body[0].id)
       .then(r => cloud.get(`${test.api}/${taxId}`));
   });
   test.withOptions({ qs: { page: 1, pageSize: 5 } }).should.return200OnGet();

--- a/src/test/elements/netsuitefinancev2/tax-rates.js
+++ b/src/test/elements/netsuitefinancev2/tax-rates.js
@@ -7,7 +7,7 @@ suite.forElement('finance', 'tax-rates', (test) => {
   it('should support GET /tax-rates and GET /tax-rates/:id', () => {
     let taxId;
     return cloud.get(test.api)
-      .then(r => taxId = r.body[0].internalId)
+      .then(r => taxId = r.body[0].id)
       .then(r => cloud.get(`${test.api}/${taxId}`));
   });
   test.withOptions({ qs: { page: 1, pageSize: 5 } }).should.return200OnGet();

--- a/src/test/elements/netsuitefinancev2/time-activities.js
+++ b/src/test/elements/netsuitefinancev2/time-activities.js
@@ -3,7 +3,7 @@
 const suite = require('core/suite');
 const payload = require('./assets/time-activities');
 
-suite.forElement('finance', 'time-activities', { skip: true, payload: payload }, (test) => {
+suite.forElement('finance', 'time-activities', { payload: payload }, (test) => {
   	test.should.supportCruds();
 	  test.withOptions({ qs: { page: 1, pageSize: 5}}).should.return200OnGet();
   	test.should.supportCeqlSearch('id');

--- a/src/test/elements/netsuitefinancev2/vendor-payments.js
+++ b/src/test/elements/netsuitefinancev2/vendor-payments.js
@@ -3,7 +3,7 @@
 const suite = require('core/suite');
 const payload = require('./assets/vendor-payments');
 
-suite.forElement('finance', 'vendor-payments', { skip: true, payload: payload }, (test) => {
+suite.forElement('finance', 'vendor-payments', { payload: payload }, (test) => {
   	test.should.supportCruds();
 	  test.withOptions({ qs: { page: 1, pageSize: 5}}).should.return200OnGet();
   	test.should.supportCeqlSearch('id');

--- a/src/test/elements/netsuitefinancev2/vendors.js
+++ b/src/test/elements/netsuitefinancev2/vendors.js
@@ -3,9 +3,9 @@
 const suite = require('core/suite');
 const tools = require('core/tools');
 const payload = tools.requirePayload(`${__dirname}/assets/vendors.json`);
-
-suite.forElement('finance', 'vendors', { skip: true, payload: payload }, (test) => {
+const payload1 = tools.requirePayload(`${__dirname}/assets/vendors.json`);
+suite.forElement('finance', 'vendors', {payload: payload }, (test) => {
   test.should.supportCruds();
 	test.withOptions({ qs: { page: 1, pageSize: 5}}).should.return200OnGet();
-  test.should.supportCeqlSearch('id');
+  test.should.supportCeqlSearch('id',payload1);
 });

--- a/src/test/elements/netsuitefinancev2/vendors.js
+++ b/src/test/elements/netsuitefinancev2/vendors.js
@@ -4,7 +4,7 @@ const suite = require('core/suite');
 const tools = require('core/tools');
 const payload = tools.requirePayload(`${__dirname}/assets/vendors.json`);
 const payload1 = tools.requirePayload(`${__dirname}/assets/vendors.json`);
-suite.forElement('finance', 'vendors', {payload: payload }, (test) => {
+suite.forElement('finance', 'vendors', {skip: true, payload: payload}, (test) => {
   test.should.supportCruds();
 	test.withOptions({ qs: { page: 1, pageSize: 5}}).should.return200OnGet();
   test.should.supportCeqlSearch('id',payload1);


### PR DESCRIPTION
## Highlights
* Fixed the failing churros 


## Screenshot
* Churros result with polling enabled 
![netsuite_withee](https://user-images.githubusercontent.com/22440353/30637690-b8d1eab0-9e16-11e7-9c03-e41ec024ea81.JPG)

* Churros result without polling enabled after fixed classification API
![netsuitefinal](https://user-images.githubusercontent.com/22440353/30637645-8e3dc06c-9e16-11e7-842f-e6781369bdf0.JPG)

## Reference
* [SOBA](Link to SOBA or Other PR for which tests were written, when applicable)
* [CircleCI](Link to SOBA PR adding Tests to `circle.yml`, when applicable)
* [churros-sauce](Link to Associated Churros-sauce PR, when applicable)
* [RALLY-#${ticketNumber}](Link to Rally User Story or Task)

## Closes
* Closes #${https://rally1.rallydev.com/#/144349237612d/detail/userstory/151491240492}
