### PR TITLE
Account roles tests

### DIFF
--- a/src/core/suite.js
+++ b/src/core/suite.js
@@ -194,7 +194,7 @@ const itUpdate403 = (name, api, payload, method, chakramUpdateCb, options) => {
 };
 
 const itUpdate400 = (name, api, payload, method, chakramUpdateCb, options) => {
-  const n = name || `should throw a 400 when trying to ${method} ${api} with improper permissions`;
+  const n = name || `should throw a 400 when trying to ${method} ${api} with invalid params`;
   boomGoesTheDynamite(n, () => cloud.withOptions(options).update(api, (payload || {}), (r) => expect(r).to.have.statusCode(400), chakramUpdateCb), options ? options.skip : false);
 };
 
@@ -399,7 +399,7 @@ const runTests = (api, payload, validationCb, tests, hub) => {
      */
     return400OnPost: () => itPostError(name, 400, api, payload, options),
     /**
-     * HTTP POST that validates that the response is a 400
+     * HTTP PUT that validates that the response is a 400
      * @memberof module:core/suite.test.should
      */
     return400OnPut: () => itUpdate400(name, api, payload, 'PUT', chakram.put, options),
@@ -415,7 +415,7 @@ const runTests = (api, payload, validationCb, tests, hub) => {
      */
     return404OnPatch: (invalidId) => itUpdate404(name, api, payload, invalidId, 'PATCH', chakram.patch, options),
     /**
-     * HTTP PUT that validates that the response is a 404
+     * HTTP PUT that validates that the response is a 403
      * @param {string} [invalidId=-1] The invalid ID
      * @memberof module:core/suite.test.should
      */

--- a/src/core/suite.js
+++ b/src/core/suite.js
@@ -188,6 +188,16 @@ const itUpdate404 = (name, api, payload, invalidId, method, chakramUpdateCb, opt
   boomGoesTheDynamite(n, () => cloud.withOptions(options).update(api, (payload || {}), (r) => expect(r).to.have.statusCode(404), chakramUpdateCb), options ? options.skip : false);
 };
 
+const itUpdate403 = (name, api, payload, method, chakramUpdateCb, options) => {
+  const n = name || `should throw a 403 when trying to ${method} ${api} with improper permissions`;
+  boomGoesTheDynamite(n, () => cloud.withOptions(options).update(api, (payload || {}), (r) => expect(r).to.have.statusCode(403), chakramUpdateCb), options ? options.skip : false);
+};
+
+const itUpdate400 = (name, api, payload, method, chakramUpdateCb, options) => {
+  const n = name || `should throw a 400 when trying to ${method} ${api} with improper permissions`;
+  boomGoesTheDynamite(n, () => cloud.withOptions(options).update(api, (payload || {}), (r) => expect(r).to.have.statusCode(400), chakramUpdateCb), options ? options.skip : false);
+};
+
 const itPostError = (name, httpCode, api, payload, options) => {
   const suffix = payload ? 'invalid JSON body' : 'empty JSON body';
   let n = name || `should throw a ${httpCode} when trying to create a(n) ${api} with an ${suffix}`;
@@ -389,6 +399,11 @@ const runTests = (api, payload, validationCb, tests, hub) => {
      */
     return400OnPost: () => itPostError(name, 400, api, payload, options),
     /**
+     * HTTP POST that validates that the response is a 400
+     * @memberof module:core/suite.test.should
+     */
+    return400OnPut: () => itUpdate400(name, api, payload, 'PUT', chakram.put, options),
+    /**
      * HTTP POST that validates that the response is a 409
      * @memberof module:core/suite.test.should
      */
@@ -399,6 +414,12 @@ const runTests = (api, payload, validationCb, tests, hub) => {
      * @memberof module:core/suite.test.should
      */
     return404OnPatch: (invalidId) => itUpdate404(name, api, payload, invalidId, 'PATCH', chakram.patch, options),
+    /**
+     * HTTP PUT that validates that the response is a 404
+     * @param {string} [invalidId=-1] The invalid ID
+     * @memberof module:core/suite.test.should
+     */
+    return403OnPut: () => itUpdate403(name, api, payload, 'PUT', chakram.put, options),
     /**
      * HTTP PUT that validates that the response is a 404
      * @param {string} [invalidId=-1] The invalid ID

--- a/src/test/platform/accounts/accounts.js
+++ b/src/test/platform/accounts/accounts.js
@@ -30,7 +30,6 @@ suite.forPlatform('accounts', { payload: account, schema: accountSchema }, (test
       return cloud.post(`/accounts/`, account)
         .then(r => {
           accountId = r.body.id;
-          console.log(`Account ID: ${accountId}`);
         });
     });
 

--- a/src/test/platform/accounts/accounts.js
+++ b/src/test/platform/accounts/accounts.js
@@ -9,6 +9,13 @@ const chakram = require('chakram');
 const expect = require('chakram').expect;
 const suite = require('core/suite');
 const cloud = require('core/cloud');
+const userPayload = {
+  firstName: 'frank',
+  lastName: 'ricard',
+  email: 'frank@oldschool.com',
+  password: 'password'
+};
+
 
 suite.forPlatform('accounts', { payload: account, schema: accountSchema }, (test) => {
 
@@ -78,19 +85,6 @@ suite.forPlatform('accounts', { payload: account, schema: accountSchema }, (test
     test
       .withApi('/accounts/1/roles/foo')
       .should.return400OnPut();
-
-    it.skip('should support granting admin role by admin account', () => {
-      return cloud.get('/accounts')
-        .then(r => {
-          expect(r.body.length).to.be.at.least(1) &&
-            expect(r.body[0]).to.contain.key('defaultAccount') &&
-            expect(r.body[0].defaultAccount).to.equal(true);
-          accountId = r.body[0].id;
-        })
-        .then(r => cloud.post(`/accounts/${accountId}/roles`, payload)
-          .then(r => expect(r).to.have.statusCode(200))
-          .then(r => cloud.delete(`/accounts/${accountId}/roles/${roleKey}`)));
-    });
   });
 
   after(() =>

--- a/src/test/platform/accounts/accounts.js
+++ b/src/test/platform/accounts/accounts.js
@@ -51,19 +51,19 @@ suite.forPlatform('accounts', { payload: account, schema: accountSchema }, (test
       .withApi('/accounts/-1/roles/admin')
       .should.return404OnPut();
 
-    /* 401 on PUT where account does not belong in user's org
+    /* 403 on PUT where account does not belong in user's org
     NOTE: Don't run this test as the system user. */
     test
       .withApi('/accounts/1/roles/admin')
       .should.return403OnPut();
 
-    /* 401 on PUT where user does not have permissions to grant the role.
+    /* 403 on PUT where user does not have permissions to grant the role.
     NOTE: Don't run this test as the system user. */
     test
       .withApi('/accounts/1/roles/admin')
       .should.return403OnPut();
 
-    it('should return a 401 on PUT where user does not have permission to grant the role', () => {
+    it('should return a 403 on PUT where user does not have permission to grant the role', () => {
       cloud.put(`/accounts/${accountId}/roles/sys-admin`, null, r => {
         expect(r).to.have.statusCode(403);
       });

--- a/src/test/platform/accounts/accounts.js
+++ b/src/test/platform/accounts/accounts.js
@@ -57,19 +57,13 @@ suite.forPlatform('accounts', { payload: account, schema: accountSchema }, (test
       .withApi('/accounts/1/roles/admin')
       .should.return403OnPut();
 
-    /* 403 on PUT where user does not have permissions to grant the role.
-    NOTE: Don't run this test as the system user. */
-    test
-      .withApi('/accounts/1/roles/admin')
-      .should.return403OnPut();
-
     it('should return a 403 on PUT where user does not have permission to grant the role', () => {
       cloud.put(`/accounts/${accountId}/roles/sys-admin`, null, r => {
         expect(r).to.have.statusCode(403);
       });
     });
 
-    /* 404 on PUT where role does not exist */
+    /* 400 on PUT where role does not exist */
     test
       .withApi('/accounts/1/roles/foo')
       .should.return400OnPut();

--- a/src/test/platform/accounts/accounts.js
+++ b/src/test/platform/accounts/accounts.js
@@ -9,13 +9,6 @@ const chakram = require('chakram');
 const expect = require('chakram').expect;
 const suite = require('core/suite');
 const cloud = require('core/cloud');
-const userPayload = {
-  firstName: 'frank',
-  lastName: 'ricard',
-  email: 'frank@oldschool.com',
-  password: 'password'
-};
-
 
 suite.forPlatform('accounts', { payload: account, schema: accountSchema }, (test) => {
 
@@ -25,11 +18,6 @@ suite.forPlatform('accounts', { payload: account, schema: accountSchema }, (test
   test.should.return404OnDelete(-1);
   test.should.return404OnPatch(-1);
   test.should.return404OnGet(-1);
-
-  let roleKey = 'admin';
-  let payload = {
-    key: roleKey
-  };
 
   describe('account roles', () => {
     let accountId;

--- a/src/test/platform/accounts/accounts.js
+++ b/src/test/platform/accounts/accounts.js
@@ -2,6 +2,8 @@
 
 const account = require('./assets/account');
 const accountSchema = require('./assets/account.schema');
+const roleSchema = require('./assets/role.schema');
+const rolesSchema = require('./assets/roles.schema');
 const accountsSchema = require('./assets/accounts.schema');
 const chakram = require('chakram');
 const expect = require('chakram').expect;
@@ -32,7 +34,51 @@ suite.forPlatform('accounts', { payload: account, schema: accountSchema }, (test
         });
     });
 
-    test.withApi(`/accounts/${accountId}/roles`).should.supportCrd();
+    it('should support CRD of roles for own account', () => {
+      const api = `/accounts/${accountId}/roles`;
+      return cloud.put(`${api}/admin`, null, roleSchema)
+       .then(r => cloud.get(api, rolesSchema))
+       .then(r => expect(r.body.length).to.equal(1) && expect(r.body[0].key).to.equal('admin'))
+       .then(r => cloud.delete(`${api}/admin`));
+    });
+
+    it('should not support CRD of roles for other org\'s account', () => {
+      const api = `/accounts/1/roles`;
+      return cloud.put(`${api}/admin`, null, r => {
+         expect(r).to.have.statusCode(403);
+       })
+      .then(r => cloud.delete(`${api}/admin`, r => {
+         expect(r).to.have.statusCode(403);
+      }));
+    });
+
+    /* 404 on PUT where account does not exist */
+    test
+      .withApi('/accounts/-1/roles/admin')
+      .should.return404OnPut();
+
+    /* 401 on PUT where account does not belong in user's org
+    NOTE: Don't run this test as the system user. */
+    test
+      .withApi('/accounts/1/roles/admin')
+      .should.return403OnPut();
+
+    /* 401 on PUT where user does not have permissions to grant the role.
+    NOTE: Don't run this test as the system user. */
+    test
+      .withApi('/accounts/1/roles/admin')
+      .should.return403OnPut();
+
+    it('should return a 401 on PUT where user does not have permission to grant the role', () => {
+      cloud.put(`/accounts/${accountId}/roles/sys-admin`, null, r => {
+        expect(r).to.have.statusCode(403);
+      });
+    });
+
+    /* 404 on PUT where role does not exist */
+    test
+      .withApi('/accounts/1/roles/foo')
+      .should.return400OnPut();
 
     it.skip('should support granting admin role by admin account', () => {
       return cloud.get('/accounts')
@@ -47,7 +93,6 @@ suite.forPlatform('accounts', { payload: account, schema: accountSchema }, (test
           .then(r => cloud.delete(`/accounts/${accountId}/roles/${roleKey}`)));
     });
   });
-
 
   after(() =>
     chakram.get('/accounts')

--- a/src/test/platform/accounts/accounts.js
+++ b/src/test/platform/accounts/accounts.js
@@ -9,6 +9,7 @@ const suite = require('core/suite');
 const cloud = require('core/cloud');
 
 suite.forPlatform('accounts', { payload: account, schema: accountSchema }, (test) => {
+
   test.should.supportCrud();
   test.withOptions({ schema: accountsSchema }).should.supportS();
   test.should.supportCeqlSearch('name');
@@ -16,28 +17,39 @@ suite.forPlatform('accounts', { payload: account, schema: accountSchema }, (test
   test.should.return404OnPatch(-1);
   test.should.return404OnGet(-1);
 
-  let accountId;
-  let roleKey = 'sub-account-instances';
+  let roleKey = 'admin';
   let payload = {
-    name: 'Sub-account Instances',
-    key: roleKey,
-    description: 'Allow this admin account to view/use sub-account instances'
+    key: roleKey
   };
 
-  it('should support creating sub account instances role by admin account', () => {
-    return cloud.get('/accounts')
-      .then(r => {
-        expect(r.body.length).to.be.at.least(1) &&
-          expect(r.body[0]).to.contain.key('defaultAccount') &&
-          expect(r.body[0].defaultAccount).to.equal(true);
-        accountId = r.body[0].id;
-      })
-      .then(r => cloud.post(`/accounts/${accountId}/roles`, payload)
-        .then(r => expect(r).to.have.statusCode(200))
-        .then(r => cloud.delete(`/accounts/${accountId}/roles/${roleKey}`)));
+  describe('account roles', () => {
+    let accountId;
+    before(() => {
+      return cloud.post(`/accounts/`, account)
+        .then(r => {
+          accountId = r.body.id;
+          console.log(`Account ID: ${accountId}`);
+        });
+    });
+
+    test.withApi(`/accounts/${accountId}/roles`).should.supportCrd();
+
+    it.skip('should support granting admin role by admin account', () => {
+      return cloud.get('/accounts')
+        .then(r => {
+          expect(r.body.length).to.be.at.least(1) &&
+            expect(r.body[0]).to.contain.key('defaultAccount') &&
+            expect(r.body[0].defaultAccount).to.equal(true);
+          accountId = r.body[0].id;
+        })
+        .then(r => cloud.post(`/accounts/${accountId}/roles`, payload)
+          .then(r => expect(r).to.have.statusCode(200))
+          .then(r => cloud.delete(`/accounts/${accountId}/roles/${roleKey}`)));
+    });
   });
 
-  afterEach(() =>
+
+  after(() =>
     chakram.get('/accounts')
     .then(r => Promise.all(r.body.filter(a => !a.defaultAccount).map(a => chakram.delete(`/accounts/${a.id}`))))
   );

--- a/src/test/platform/accounts/assets/role.schema.json
+++ b/src/test/platform/accounts/assets/role.schema.json
@@ -1,0 +1,18 @@
+{
+  "type": "object",
+  "properties": {
+    "description": {
+      "type": "string"
+    },
+    "id": {
+      "type": "number"
+    },
+    "name": {
+      "type": "string"
+    },
+    "key": {
+      "type": "string"
+    }
+  },
+  "required": ["id", "name", "key", "description"]
+}

--- a/src/test/platform/accounts/assets/roles.schema.json
+++ b/src/test/platform/accounts/assets/roles.schema.json
@@ -1,0 +1,21 @@
+{
+  "type": "array",
+  "items": {
+      "type": "object",
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "id": {
+          "type": "number"
+        },
+        "name": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        }
+      },
+      "required": ["id", "name", "key", "description"]
+    }
+}

--- a/test/core/assets/suite-helper.js
+++ b/test/core/assets/suite-helper.js
@@ -152,6 +152,14 @@ exports.mock = (baseUrl, headers, eventHeaders) => {
     .put('/foo/456')
     .reply(404, (uri, requestBody) => {
       return { message: 'No foo found with the given ID' };
+    })
+    .put('/foo/789')
+    .reply(403, (uri, requestBody) => {
+      return { message: 'Forbidden' };
+    })
+    .put('/foo/987')
+    .reply(400, (uri, requestBody) => {
+      return { message: 'Bad request' };
     });
 
   /** MOCKING OUT HTTP ENDPOINTS **/

--- a/test/core/suite.test.js
+++ b/test/core/suite.test.js
@@ -90,6 +90,14 @@ describe('suite', () => {
       .withOptions({ qs: { page: 1, pageSize: 1 } })
       .should.return200OnGet();
 
+    test
+      .withApi('/foo/789')
+      .should.return403OnPut();
+
+    test
+      .withApi('/foo/987')
+      .should.return400OnPut();
+
     /* withApi overrides the default api that was passed in to the `suite.forPlatform` above */
     test
       .withApi(`${test.api}/456`)


### PR DESCRIPTION
## Highlights
* Tests for accounts roles APIs related to the new roles architecture in Soba.

## Screenshot
```
  accounts
    ✓ should allow CRUD for /accounts (2111ms)
    ✓ should allow S for /accounts (477ms)
    ✓ should support searching /accounts by name (1112ms)
    ✓ should throw a 404 when trying to DELETE /accounts with an ID that does not exist (577ms)
    ✓ should throw a 404 when trying to PATCH /accounts with an ID that does not exist (545ms)
    ✓ should throw a 404 when trying to GET /accounts with an ID that does not exist (576ms)
    account roles
      ✓ should support CRD of roles for own account (1479ms)
      ✓ should not support CRD of roles for other org's account (617ms)
      ✓ should throw a 404 when trying to PUT /accounts/-1/roles/admin with an ID that does not exist (224ms)
      ✓ should throw a 403 when trying to PUT /accounts/1/roles/admin with improper permissions (308ms)
      ✓ should throw a 403 when trying to PUT /accounts/1/roles/admin with improper permissions (288ms)
      ✓ should return a 401 on PUT where user does not have permission to grant the role
      ✓ should throw a 400 when trying to PUT /accounts/1/roles/foo with invalid params (505ms)


  13 passing (14s)
```

## Reference
* [SOBA](https://github.com/cloud-elements/soba/pull/7388)
