### PR TITLE
Shopify : Fixed the failing churros test 

### DIFF
--- a/src/core/oauth.js
+++ b/src/core/oauth.js
@@ -135,10 +135,10 @@ const manipulateDom = (element, browser, r, username, password, config) => {
       browser.findElement(webdriver.By.name('password')).sendKeys(password);
       browser.findElement(webdriver.By.name('commit')).click();
 
-      browser.wait(() => browser.isElementPresent(webdriver.By.xpath('//div[@id="app-install"]/form/input[@type="submit"]')), 5000)
+      browser.wait(() => browser.isElementPresent(webdriver.By.name('commit')), 5000)
         .thenCatch(r => true); // ignore
 
-      browser.findElement(webdriver.By.xpath('//div[@id="app-install"]/form/input[@type="submit"]'))
+      browser.findElement(webdriver.By.name('commit'))
         .then((element) => element.click(), (err) => {}); // ignore this
 
       return browser.getCurrentUrl();

--- a/src/test/elements/shopify/addresses.js
+++ b/src/test/elements/shopify/addresses.js
@@ -17,7 +17,7 @@ const updateAddress = (addressId) => ({
   "zip": tools.random()
 });
 
-suite.forElement('ecommerce', 'addresses', {skip: true}, (test) => {
+suite.forElement('ecommerce', 'addresses', (test) => {
   let customerId;
   before(() => cloud.post(`/hubs/ecommerce/customers`,customer())
     .then(r => customerId = r.body.id)

--- a/src/test/elements/shopify/fulfillment-events.js
+++ b/src/test/elements/shopify/fulfillment-events.js
@@ -18,7 +18,7 @@ const createFulfillment = (lineId) => ({
   }]
 });
 
-suite.forElement('ecommerce', 'fulfillment-events', { payload: payload, skip: true}, (test) => {
+suite.forElement('ecommerce', 'fulfillment-events', { payload: payload}, (test) => {
   let orderId, lineId, fulfillmentId, eventId;
   before(() => cloud.post(`/hubs/ecommerce/orders`, order())
     .then(r => orderId = r.body.id)

--- a/src/test/elements/shopify/fulfillment-events.js
+++ b/src/test/elements/shopify/fulfillment-events.js
@@ -18,7 +18,7 @@ const createFulfillment = (lineId) => ({
   }]
 });
 
-suite.forElement('ecommerce', 'fulfillment-events', { payload: payload}, (test) => {
+suite.forElement('ecommerce', 'fulfillment-events', { payload: payload }, (test) => {
   let orderId, lineId, fulfillmentId, eventId;
   before(() => cloud.post(`/hubs/ecommerce/orders`, order())
     .then(r => orderId = r.body.id)
@@ -38,4 +38,6 @@ suite.forElement('ecommerce', 'fulfillment-events', { payload: payload}, (test) 
   it(`should allow DELETE for /hubs/ecommerce/orders/{orderId}/fulfillments/{fulfillmentId}/fulfillment-events/{eventId}`, () => {
     return cloud.delete(`/hubs/ecommerce/orders/${orderId}/fulfillments/${fulfillmentId}/fulfillment-events/${eventId}`);
   });
+  after(() => cloud.delete(`/hubs/ecommerce/orders/${orderId}`));
+
 });

--- a/src/test/elements/shopify/fulfillments.js
+++ b/src/test/elements/shopify/fulfillments.js
@@ -11,12 +11,12 @@ const order = () => ({
   }]
 });
 const createFulfillment = (lineId) => ({
-  "fulfillment": {
+  
     "tracking_number": tools.random(),
     "line_items": [{
       "id": lineId
     }]
-  }
+  
 });
 const updateFulfillment = (fulfillmentId) => ({
   "fulfillment": {
@@ -24,7 +24,7 @@ const updateFulfillment = (fulfillmentId) => ({
     "id": fulfillmentId
   }
 });
-suite.forElement('ecommerce', 'fulfillments', { payload: createFulfillment({}), skip: true }, (test) => {
+suite.forElement('ecommerce', 'fulfillments', { payload: createFulfillment({}) }, (test) => {
   let orderId, lineId, fulfillmentId;
   before(() => cloud.post(`/hubs/ecommerce/orders`, order())
     .then(r => orderId = r.body.id)


### PR DESCRIPTION
## Highlights
* Removed skip from` /fulfillments, /fulfillment-events and /addresses `churros test  
* Fixed the instance creation flow 
* Fixed the /fulfillments and /fulfillment-events churros test 
* Not removed skip from discounts APIs it is deprecated  and they are not visible in the swagger doc 
## Screenshot
![shopfiy](https://user-images.githubusercontent.com/22440353/30686298-7a2e0e46-9ed5-11e7-8dea-5d86a94b0ebe.JPG)

## Reference
* [SOBA](Link to SOBA or Other PR for which tests were written, when applicable)
* [CircleCI](Link to SOBA PR adding Tests to `circle.yml`, when applicable)
* [churros-sauce](Link to Associated Churros-sauce PR, when applicable)
* [RALLY-#${https://rally1.rallydev.com/#/144349237612d/detail/userstory/151491239588}](Link to Rally User Story or Task)

## Closes
* Closes #${https://rally1.rallydev.com/#/144349237612d/detail/userstory/151491239588}
