### PR TITLE
Implemented churros  for extended resources of Marketo

### DIFF
--- a/src/test/elements/marketo/assets/newResource.json
+++ b/src/test/elements/marketo/assets/newResource.json
@@ -1,0 +1,52 @@
+{
+  "method": "GET",
+  "nextResource": "",
+  "description": "GET files.",
+  "type": "api",
+  "vendorPath": "/asset/v1/files.json",
+  "nextPageKey": "",
+  "path": "/extended-resource",
+  "paginationType": "VENDOR_SUPPORTED",
+  "vendorMethod": "GET",
+  "response": {
+    "contentType": "application/json"
+  },
+  "ownerAccountId": 218,
+  "hooks": [],
+  "parameters": [{
+      "vendorType": "query",
+      "converter": "toQueryParameters",
+      "dataType": "string",
+      "name": "where",
+      "description": "The CEQL search expression.",
+      "vendorDataType": "string",
+      "source": "request",
+      "type": "query",
+      "vendorName": "converter:toQueryParameters",
+      "required": false
+    },
+    {
+      "vendorType": "query",
+      "dataType": "string",
+      "name": "pageSize",
+      "description": "The number of resources to return in a given page",
+      "vendorDataType": "string",
+      "source": "request",
+      "type": "query",
+      "vendorName": "maxReturn",
+      "required": false
+    },
+    {
+      "vendorType": "query",
+      "dataType": "string",
+      "name": "page",
+      "description": "The page number of resources to retrieve",
+      "vendorDataType": "string",
+      "source": "request",
+      "type": "query",
+      "vendorName": "offset",
+      "required": false
+    }
+  ],
+  "rootKey": "|result"
+}

--- a/src/test/elements/marketo/extended-resource.js
+++ b/src/test/elements/marketo/extended-resource.js
@@ -1,0 +1,24 @@
+'use strict';
+
+const expect = require('chakram').expect;
+const suite = require('core/suite');
+const cloud = require('core/cloud');
+const newResource = require('./assets/newResource.json');
+
+// Test for extending hubspot crm and invoking the extended resource
+suite.forElement('marketing', 'extended-resource', {}, (test) => {
+  let newResourceId;
+  // Add resource to
+  before(() => cloud.post(`elements/marketo/resources`, newResource)
+    .then(r => newResourceId = r.body.id));
+
+  //delete new/overide resource should work fine
+  after(() => cloud.delete(`elements/marketo/resources/${newResourceId}`));
+
+  it('should test newly added account resource extended-resource', () => {
+      return cloud.get(`extended-resource`)
+      .then(r => {
+        expect(r.body).to.not.be.empty;
+      });
+  });
+});


### PR DESCRIPTION
## Highlights
* Implemented churros te test extended resources for Marketo. 

## Reference
* [SOBA](https://github.com/cloud-elements/soba/pull/7382)
* [RALLY-#${ticketNumber}(https://rally1.rallydev.com/#/144349237612d/detail/userstory/153626883688)

## Closes
* Closes #US1362 : https://rally1.rallydev.com/#/144349237612d/detail/userstory/153626883688
