### PR TITLE
Fixed failing custom object test for Marketo element

### DIFF
--- a/src/test/elements/marketo/assets/sampleBulkCustomObject_c.json
+++ b/src/test/elements/marketo/assets/sampleBulkCustomObject_c.json
@@ -1,6 +1,6 @@
 {
-   "myAddress":"210 Main Stret",
-   "myCity":"Addisson",
-   "myExternalId":"20171",
-   "myName":"Test Object"
+   "myAddress":"<<address.streetAddress>>",
+   "myCity":"<<address.city>>",
+   "myExternalId":"<<random.number>>",
+   "myName":"<<name.firstName>> Object"
 }

--- a/src/test/elements/marketo/sampleBulkCustomObject_c.js
+++ b/src/test/elements/marketo/sampleBulkCustomObject_c.js
@@ -1,8 +1,18 @@
 'use strict';
 
 const suite = require('core/suite');
-const payload = require('core/tools').requirePayload(`${__dirname}/assets/sampleBulkCustomObject_c.json`);
+const tools = require('core/tools');
+const payload = tools.requirePayload(`${__dirname}/assets/sampleBulkCustomObject_c.json`);
 
 suite.forElement('marketing', 'sampleBulkCustomObject_c', { payload: payload }, (test) => {
-  test.should.supportCrud();
+  const options = {
+    churros: {
+      updatePayload: {
+        "myAddress": "Paris Belle Epoque, Trou Aux Cerf",
+        "myCity": "Curepipe",
+        "myName": "Zeeshan Gungabasen"
+      }
+    }
+  };
+  test.withOptions(options).should.supportCrud();
 });

--- a/src/test/elements/marketo/tagTypes.js
+++ b/src/test/elements/marketo/tagTypes.js
@@ -3,7 +3,7 @@
 const suite = require('core/suite');
 const cloud = require('core/cloud');
 
-suite.forElement('marketing', 'tagTypes', { skip: true }, (test) => {
+suite.forElement('marketing', 'tagTypes', { skip: false }, (test) => {
   let tagType;
   test.should.supportPagination();
   it('should allow Sr for Tagtypes ', () => {


### PR DESCRIPTION
## Highlights
* Using dynamic data for posting a new record for `sampleBulkCustomObject_c` object.
* Removed `skip` from `tagTypes` resource test.

## Screenshot
![marketo_churros_p1](https://user-images.githubusercontent.com/25840389/30739505-425ed0dc-9fab-11e7-84ac-b2e2d51156ef.png)
![marketo_churros_p2](https://user-images.githubusercontent.com/25840389/30739506-425f624a-9fab-11e7-945f-b234f858626f.png)


## Reference
* [RALLY-#US1312](https://rally1.rallydev.com/#/144349237612ud/detail/userstory/151491240096k)

## Closes
* Closes #US1312
