### PR TITLE
Added ability to use a back up instance

### DIFF
--- a/src/cli/churros-test.js
+++ b/src/cli/churros-test.js
@@ -31,6 +31,7 @@ const fromOptions = (url, options) => {
       params: options.params,
       save: options.save === undefined ? false : true,
       polling: options.polling,
+      backup: options.backup === undefined ? 'use backup' : options.backup //defaults to use back up instance
     });
   });
 };
@@ -102,6 +103,7 @@ const run = (suite, options, cliArgs) => {
   if (cliArgs.polling) args += ` --polling ${cliArgs.polling}`;
   if (cliArgs.params) args += ` --params '${cliArgs.params}'`;
   if (cliArgs.save) args += ` --save '${cliArgs.save}'`;
+  if (cliArgs.backup) args += ` --backup '${cliArgs.backup}'`;
   // loop over each element, constructing the proper paths to pass to mocha
   let cmd = "";
   if (resources.includes('.DS_Store')) resources.splice(resources.indexOf('.DS_Store'), 1);
@@ -167,6 +169,7 @@ commander
   .option('--polling', 'runs the polling tests')
   .option('-P, --params <json>', 'add additional parameters for provisioning')
   .option('--save', 'don\'t run the clean up process before')
+  .option('--backup <arg>', 'options to use backup instance. options: ["use backup", "no backup", "only backup"]. Defaults to "use backup"')
   .on('--help', () => {
     console.log('  Examples:');
     console.log('');
@@ -177,6 +180,7 @@ commander
     console.log('    $ churros test elements/sfdc --polling');
     console.log('    $ churros test elements/zuorav2 --params \'{"zuorav2.sandbox": true}\'');
     console.log('    $ churros test elements/zuorav2 --save');
+    console.log('    $ churros test elements/hubspot --backup "no backup"');
     console.log('    $ churros test elements');
     console.log('    $ churros test elements --exclude autopilot --exclude bigcommerce');
     console.log('    $ churros test elements --start freshbooks');

--- a/src/core/provisioner.js
+++ b/src/core/provisioner.js
@@ -306,7 +306,7 @@ exports.delete = (id, baseApi) => {
 };
 
 exports.getBackup = (element) => {
-  logger.info('Attempting to use backup')
+  logger.info('Attempting to use backup');
   return cloud.get('/instances?tags%5B%5D=churros-backup&hydrate=false')
   .then(r => {
     if (!_.isEmpty(r.body) || !_.isArray(r.body)) {
@@ -315,13 +315,13 @@ exports.getBackup = (element) => {
         props.setForKey(element, 'elementId', instance.element.id);
         defaults.token(instance.token);
         expect(instance.element.key).to.equal(tools.getBaseElement(element));
-        r.body = instance
-        return r
+        r.body = instance;
+        return r;
       } else {
         logger.error('No "churros-backup" instance available');
       }
     } else {
       logger.error('Invalid response: ', JSON.stringify(r.body));
     }
-  })
-}
+  });
+};

--- a/src/core/provisioner.js
+++ b/src/core/provisioner.js
@@ -12,7 +12,7 @@ const r = require('request');
 const defaults = require('core/defaults');
 const cloud = require('core/cloud');
 const argv = require('optimist').argv;
-const _ = require('lodash');
+const _ = require('ramda');
 
 var exports = module.exports = {};
 
@@ -309,7 +309,7 @@ exports.getBackup = (element) => {
   logger.info('Attempting to use backup');
   return cloud.get('/instances?tags%5B%5D=churros-backup&hydrate=false')
   .then(r => {
-    if (!_.isEmpty(r.body) || !_.isArray(r.body)) {
+    if (!_.isEmpty(r.body) && _.type(r.body) === 'Array') {
       var instance = r.body.reduce((acc, cur) => acc = acc === null && cur.element.key === element ? cur : null, null);
       if (instance !== null) {
         props.setForKey(element, 'elementId', instance.element.id);

--- a/src/core/provisioner.js
+++ b/src/core/provisioner.js
@@ -306,6 +306,7 @@ exports.delete = (id, baseApi) => {
 };
 
 exports.getBackup = (element) => {
+  logger.info('Attempting to use backup')
   return cloud.get('/instances?tags%5B%5D=churros-backup&hydrate=false')
   .then(r => {
     if (!_.isEmpty(r.body) || !_.isArray(r.body)) {
@@ -317,10 +318,10 @@ exports.getBackup = (element) => {
         r.body = instance
         return r
       } else {
-        console.warn('No "churros-backup" instance available');
+        logger.error('No "churros-backup" instance available');
       }
     } else {
-      console.warn('Invalid response: ', JSON.stringify(r.body));
+      logger.error('Invalid response: ', JSON.stringify(r.body));
     }
   })
 }

--- a/src/test/elements/lifecycle.js
+++ b/src/test/elements/lifecycle.js
@@ -49,20 +49,20 @@ before(() => {
         expect(r.body.element.key).to.equal(tools.getBaseElement(element));
         deleteInstance = false;
         return r;
-      })
+      });
     } else if (argv.backup === 'only backup') {
       deleteInstance = false;
-      getInstance = provisioner.getBackup(element)
+      getInstance = provisioner.getBackup(element);
     } else {
       getInstance = provisioner.create(element)
       .catch(e => {
         if (argv.backup === 'use backup') { //if default flag
-          deleteInstance = false
-          return provisioner.getBackup(element)
+          deleteInstance = false;
+          return provisioner.getBackup(element);
         } else {
-          throw Error(e)
+          throw Error(e);
         }
-      })
+      });
     }
 
     return getInstance

--- a/src/test/elements/lifecycle.js
+++ b/src/test/elements/lifecycle.js
@@ -27,6 +27,7 @@ const terminate = error => {
 
 let element = argv.element;
 let instanceId;
+let deleteInstance = !argv.save; //we don't always want to delete. Defaults to true
 // Setting which element we are currently running on
 props.set('element', element);
 before(() => {
@@ -39,14 +40,30 @@ before(() => {
   return tools.runFile(element, `${__dirname}/${element}/assets/scripts.js`, 'before')
   .then(() => !argv.save ? cleaner.cleanElementsBefore() : null)
   .then(() => {
-    const getInstance = argv.instance ? cloud.get(`/instances/${argv.instance}`)
+    let getInstance;
+    if (argv.instance) {
+      getInstance = cloud.get(`/instances/${argv.instance}`)
       .then(r => {
         props.setForKey(element, 'elementId', r.body.element.id);
         defaults.token(r.body.token);
         expect(r.body.element.key).to.equal(tools.getBaseElement(element));
+        deleteInstance = false;
         return r;
-      }) : provisioner
-        .create(element);
+      })
+    } else if (argv.backup === 'only backup') {
+      deleteInstance = false;
+      getInstance = provisioner.getBackup(element)
+    } else {
+      getInstance = provisioner.create(element)
+      .catch(e => {
+        if (argv.backup === 'use backup') { //if default flag
+          deleteInstance = false
+          return provisioner.getBackup(element)
+        } else {
+          throw Error(e)
+        }
+      })
+    }
 
     return getInstance
       .then(r => {
@@ -136,7 +153,7 @@ it.skip('should not allow provisioning with bad credentials', () => {
 });
 after(done => {
   tools.resetCleanup();
-  instanceId && !(argv.instance || argv.save) ? provisioner
+  instanceId && deleteInstance ? provisioner
         .delete(instanceId)
         .then(() => done())
         .catch(r => logger.error('Failed to delete element instance: %s', r))


### PR DESCRIPTION
## Highlights
* Will use back up instance if provisioning fails
* Added flag with 3 options `--backup ['use backup', 'no backup', 'only backup']`
* Defaults to use backup

## Examples
`churros test elements/box --backup 'no backup'`

## Screenshot
Without back up it won't provision
https://cl.ly/1b0W2l1l2l0B

Skips provisioning process `--backup 'only backup'`
https://cl.ly/0S2g1C2y3g3S

Fails then uses backup
https://cl.ly/1h420X2z2A1d

## Reference
* [RALLY-#US1464]https://rally1.rallydev.com/#/144349237612d/detail/userstory/155170826608?fdp=true

