### PR TITLE
Tests for user roles

### DIFF
--- a/src/test/platform/users/assets/role.schema.json
+++ b/src/test/platform/users/assets/role.schema.json
@@ -1,0 +1,18 @@
+{
+  "type": "object",
+  "properties": {
+    "description": {
+      "type": "string"
+    },
+    "id": {
+      "type": "number"
+    },
+    "name": {
+      "type": "string"
+    },
+    "key": {
+      "type": "string"
+    }
+  },
+  "required": ["id", "name", "key", "description"]
+}

--- a/src/test/platform/users/assets/roles.schema.json
+++ b/src/test/platform/users/assets/roles.schema.json
@@ -1,0 +1,21 @@
+{
+  "type": "array",
+  "items": {
+      "type": "object",
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "id": {
+          "type": "number"
+        },
+        "name": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        }
+      },
+      "required": ["id", "name", "key", "description"]
+    }
+}

--- a/src/test/platform/users/users.js
+++ b/src/test/platform/users/users.js
@@ -3,7 +3,9 @@
 const cloud = require('core/cloud');
 const suite = require('core/suite');
 const schema = require('./assets/users.schema');
-const expect = require('chai').expect;
+const roleSchema = require('./assets/role.schema');
+const rolesSchema = require('./assets/roles.schema');
+const expect = require('chakram').expect;
 const payload = {
   firstName: 'frank',
   lastName: 'ricard',
@@ -35,7 +37,7 @@ suite.forPlatform('users', { schema: schema, payload: payload }, (test) => {
       .then(r => userId = r.body.id);
   });
 
-  after(() => cleanup());
+  after(() => { console.log('Cleaning Up'); cleanup(); });
 
   it('should support CRUDS for users', () => {
     const validate = (r, amount, firstName, lastName) => {
@@ -58,5 +60,63 @@ suite.forPlatform('users', { schema: schema, payload: payload }, (test) => {
       .then(r => cloud.delete(`/users/${userId}`))
       .then(r => cloud.get(`/users`))
       .then(r => validate(r, 0, updatePayload.firstName, updatePayload.lastName));
+  });
+
+  describe('user roles', () => {
+    before(() => {
+      return cleanup()
+        .then(r => cloud.get(`/accounts`))
+        .then(r => accountId = r.body.filter(account => account.defaultAccount)[0].id)
+        .then(r => cloud.post(`/accounts/${accountId}/users`, payload, schema))
+        .then(r => userId = r.body.id);
+    });
+
+    it('should support CRD of admin role for user in own account', () => {
+      const api = `/users/${userId}/roles`;
+      const isAdmin = r => r.key === 'admin';
+      return cloud.put(`${api}/admin`, null, roleSchema)
+        .then(r => cloud.get(api, rolesSchema))
+        .then(r => expect(r.body.filter(isAdmin).length).to.equal(1))
+        .then(r => cloud.delete(`${api}/admin`))
+        .then(r => cloud.get(api))
+        .then(r => expect(r.body.filter(isAdmin).length).to.equal(0));
+    });
+
+    it('should not support CRD of roles for user in other account', () => {
+      const api = `/users/1/roles`;
+      return cloud.put(`${api}/admin`, null, r => expect(r).to.have.statusCode(403))
+      .then(() => cloud.get(`${api}`, r => expect(r).to.have.statusCode(403)))
+      .then(() => cloud.delete(`${api}/admin`, r => expect(r).to.have.statusCode(403)));
+    });
+
+    test
+      .withApi('/users/-1/roles/admin')
+      .should.return404OnPut();
+
+    it('should return a 403 on PUT where user does not have permission to grant the role', () => {
+      cloud.put(`/users/${userId}/roles/sys-admin`, null, r => {
+        expect(r).to.have.statusCode(403);
+      });
+    });
+
+    it('should return a 403 on PUT where user does not have permission to grant the role', () => {
+      cloud.put(`/users/1/roles/admin`, null, r => {
+        expect(r).to.have.statusCode(403);
+      });
+    });
+
+    it('should return a 400 on PUT with an invalid role', () => {
+      cloud.put(`/users/1/roles/foo`, null, r => {
+        expect(r).to.have.statusCode(400);
+      });
+    });
+
+    it('should return a 409 on two PUTs with the same user and role', () => {
+      cloud.put(`/users/${userId}/roles/admin`, null, roleSchema)
+        .then(r => cloud.put(`/users/${userId}/roles/admin`, null, r => {
+          expect(r).to.have.statusCode(409);
+        }))
+        .then(r => cloud.delete(`/users/${userId}/roles/admin`));
+    });
   });
 });

--- a/src/test/platform/users/users.js
+++ b/src/test/platform/users/users.js
@@ -37,7 +37,7 @@ suite.forPlatform('users', { schema: schema, payload: payload }, (test) => {
       .then(r => userId = r.body.id);
   });
 
-  after(() => { console.log('Cleaning Up'); cleanup(); });
+  after(() => cleanup());
 
   it('should support CRUDS for users', () => {
     const validate = (r, amount, firstName, lastName) => {


### PR DESCRIPTION
## Highlights
* Tests for the new user roles APIs:
  * `GET /users/:id/roles`
  * `PUT /users/:id/roles/:roleKey`
  * `DELETE /users/:id/roles/:roleKey`

## Examples
If applicable, please include any images, GIFs, etc. showing up these changes

## Screenshot
```
$ churros test platform/users

  users
    ✓ should support CRUDS for users (402ms)
    user roles
      ✓ should support CRD of admin role for user in own account (509ms)
      ✓ should not support CRD of roles for user in other account (318ms)
      ✓ should throw a 404 when trying to PUT /users/-1/roles/admin with an ID that does not exist (109ms)
      ✓ should return a 403 on PUT where user does not have permission to grant the role
      ✓ should return a 403 on PUT where user does not have permission to grant the role
      ✓ should return a 400 on PUT with an invalid role
      ✓ should return a 409 on two PUTs with the same user and role


  8 passing (5s)
```

## Reference
* cloud-elements/soba#7440
