### PR TITLE
Unskipped test cases and added comment where needed for Adobe E Sign

### DIFF
--- a/src/test/elements/adobe-esign/groups.js
+++ b/src/test/elements/adobe-esign/groups.js
@@ -9,7 +9,7 @@ const group = () => ({
   groupName: tools.random()
 });
 
-suite.forElement('esignature', 'groups', { payload: group(), skip: false }, (test) => {
+suite.forElement('esignature', 'groups', { payload: group()}, (test) => {
   test.should.supportCruds(chakram.put);
   it(`should allow GET for ${test.api}/{groupId}/users`, () => {
     let groupId;

--- a/src/test/elements/adobe-esign/groups.js
+++ b/src/test/elements/adobe-esign/groups.js
@@ -9,7 +9,7 @@ const group = () => ({
   groupName: tools.random()
 });
 
-suite.forElement('esignature', 'groups', { payload: group(), skip: true }, (test) => {
+suite.forElement('esignature', 'groups', { payload: group(), skip: false }, (test) => {
   test.should.supportCruds(chakram.put);
   it(`should allow GET for ${test.api}/{groupId}/users`, () => {
     let groupId;

--- a/src/test/elements/adobe-esign/library-documents.js
+++ b/src/test/elements/adobe-esign/library-documents.js
@@ -21,7 +21,7 @@ const createLibraryDocuments = (transientDocumentId) => ({
   }
 });
 
-suite.forElement('esignature', 'library-documents', {skip: true}, (test) => {
+suite.forElement('esignature', 'library-documents', {skip: false}, (test) => {
   /*
   // Commented the POST for this resource to avoid creation of new Library Documents, since the code
   // might break for GET /libraryDocuments due to time-out. Also there is no DELETE API for libraryDocuments

--- a/src/test/elements/adobe-esign/library-documents.js
+++ b/src/test/elements/adobe-esign/library-documents.js
@@ -21,7 +21,7 @@ const createLibraryDocuments = (transientDocumentId) => ({
   }
 });
 
-suite.forElement('esignature', 'library-documents', {skip: false}, (test) => {
+suite.forElement('esignature', 'library-documents', (test) => {
   /*
   // Commented the POST for this resource to avoid creation of new Library Documents, since the code
   // might break for GET /libraryDocuments due to time-out. Also there is no DELETE API for libraryDocuments

--- a/src/test/elements/adobe-esign/transient-documents.js
+++ b/src/test/elements/adobe-esign/transient-documents.js
@@ -3,6 +3,7 @@
 const suite = require('core/suite');
 const cloud = require('core/cloud');
 
+//Need to skip as there is no delete API
 suite.forElement('esignature', 'transient-documents', {skip: true}, (test) => {
   it(`should allow POST for /transient-documents`, () => {
     return cloud.postFile(test.api, `${__dirname}/assets/attach.txt`);

--- a/src/test/elements/adobe-esign/uris.js
+++ b/src/test/elements/adobe-esign/uris.js
@@ -2,6 +2,6 @@
 
 const suite = require('core/suite');
 
-suite.forElement('esignature', 'uris', {skip: true}, (test) => {
+suite.forElement('esignature', 'uris', {skip: false}, (test) => {
   test.should.return200OnGet();
 });

--- a/src/test/elements/adobe-esign/uris.js
+++ b/src/test/elements/adobe-esign/uris.js
@@ -2,6 +2,6 @@
 
 const suite = require('core/suite');
 
-suite.forElement('esignature', 'uris', {skip: false}, (test) => {
+suite.forElement('esignature', 'uris', (test) => {
   test.should.return200OnGet();
 });

--- a/src/test/elements/adobe-esign/users.js
+++ b/src/test/elements/adobe-esign/users.js
@@ -24,7 +24,7 @@ const updateUsers = (groupId) => ({
   "firstName": "Greg"
 });
 
-suite.forElement('esignature', 'users', {skip: true}, (test) => {
+suite.forElement('esignature', 'users', {skip: false}, (test) => {
   /*
   //  Commented out POST /users, since there is no DELETE API for that.
     test.withJson(createUsers()).should.supportCrs();

--- a/src/test/elements/adobe-esign/users.js
+++ b/src/test/elements/adobe-esign/users.js
@@ -24,7 +24,7 @@ const updateUsers = (groupId) => ({
   "firstName": "Greg"
 });
 
-suite.forElement('esignature', 'users', {skip: false}, (test) => {
+suite.forElement('esignature', 'users', (test) => {
   /*
   //  Commented out POST /users, since there is no DELETE API for that.
     test.withJson(createUsers()).should.supportCrs();

--- a/src/test/elements/adobe-esign/widgets.js
+++ b/src/test/elements/adobe-esign/widgets.js
@@ -24,7 +24,7 @@ const updateWidgetStatus = () => ({
   "value": "ENABLE"
 });
 
-suite.forElement('esignature', 'widgets', {skip: true}, (test) => {
+suite.forElement('esignature', 'widgets', {skip: false}, (test) => {
   /*
   // This script breaks, as there are over 700 widgets which leads to time-out
     test.should.return200OnGet();

--- a/src/test/elements/adobe-esign/workflows.js
+++ b/src/test/elements/adobe-esign/workflows.js
@@ -25,9 +25,10 @@ const createWorkflows = (transientDocumentId) => ({
   }
 });
 
-suite.forElement('esignature', 'workflows', {skip: true}, (test) => {
+suite.forElement('esignature', 'workflows',  (test) => {
   test.should.supportSr();
-  it(`should allow POST for ${test.api}/{workflowId}/agreements`, () => {
+//Need to skip as there is no delete API
+  it(`should allow POST for ${test.api}/{workflowId}/agreements`,{skip: true}, () => {
     let workflowId;
     let transientDocumentId;
     return cloud.get(test.api)

--- a/src/test/elements/adobe-esign/workflows.js
+++ b/src/test/elements/adobe-esign/workflows.js
@@ -28,7 +28,7 @@ const createWorkflows = (transientDocumentId) => ({
 suite.forElement('esignature', 'workflows',  (test) => {
   test.should.supportSr();
 //Need to skip as there is no delete API
-  it(`should allow POST for ${test.api}/{workflowId}/agreements`,{skip: true}, () => {
+  it.skip(`should allow POST for ${test.api}/{workflowId}/agreements`, () => {
     let workflowId;
     let transientDocumentId;
     return cloud.get(test.api)


### PR DESCRIPTION
## Highlights
* There were test cases skipped on Adobe E Sign. 
* Verified whether those are passing and un-skipped them
* Added a comment  where skip is needed due to unavailability of delete API
* Churros result: 

![image](https://user-images.githubusercontent.com/20282215/31176208-a5ea6cbe-a92f-11e7-8e54-c9aec146de2d.png)

## Closes
* Closes  [#US1141](https://rally1.rallydev.com/#/144349237612d/detail/userstory/149195710604)
