### PR TITLE
Added churros for extended resource for MailJet

### DIFF
--- a/src/test/elements/mailjet/assets/newResource.json
+++ b/src/test/elements/mailjet/assets/newResource.json
@@ -1,0 +1,52 @@
+{
+  "method": "GET",
+  "nextResource": "",
+  "description": "GET messages state.",
+  "type": "api",
+  "vendorPath": "/REST/messagestate",
+  "nextPageKey": "",
+  "path": "/extended-resource",
+  "paginationType": "VENDOR_SUPPORTED",
+  "vendorMethod": "GET",
+  "response": {
+    "contentType": "application/json"
+  },
+  "ownerAccountId": 218,
+  "hooks": [],
+  "parameters": [{
+      "vendorType": "query",
+      "converter": "toQueryParameters",
+      "dataType": "string",
+      "name": "where",
+      "description": "The CEQL search expression.",
+      "vendorDataType": "string",
+      "source": "request",
+      "type": "query",
+      "vendorName": "converter:toQueryParameters",
+      "required": false
+    },
+    {
+      "vendorType": "query",
+      "dataType": "string",
+      "name": "pageSize",
+      "description": "The number of resources to return in a given page",
+      "vendorDataType": "string",
+      "source": "request",
+      "type": "query",
+      "vendorName": "pageSize",
+      "required": false
+    },
+    {
+      "vendorType": "query",
+      "dataType": "string",
+      "name": "page",
+      "description": "The page number of resources to retrieve",
+      "vendorDataType": "string",
+      "source": "request",
+      "type": "query",
+      "vendorName": "page",
+      "required": false
+    }
+  ],
+  "rootKey": "|Data"
+}

--- a/src/test/elements/mailjet/extended-resource.js
+++ b/src/test/elements/mailjet/extended-resource.js
@@ -1,0 +1,24 @@
+'use strict';
+
+const expect = require('chakram').expect;
+const suite = require('core/suite');
+const cloud = require('core/cloud');
+const newResource = require('./assets/newResource.json');
+
+// Test for extending messaging and invoking the extended resource
+suite.forElement('messaging', 'extended-resource', {}, (test) => {
+  let newResourceId;
+  // Add resource to
+  before(() => cloud.post(`elements/mailjet/resources`, newResource)
+    .then(r => newResourceId = r.body.id));
+
+  //delete new/overide resource should work fine
+  after(() => cloud.delete(`elements/mailjet/resources/${newResourceId}`));
+
+  it('should test newly added resource extended-resource', () => {
+      return cloud.get(`extended-resource`)
+      .then(r => {
+        expect(r.body).to.not.be.empty;
+      });
+  });
+});


### PR DESCRIPTION
## Highlights
* Added Churros for extended resources of  MailJet.

## Non-Customer Highlights
* All churros tests are passing, including testing for addition of new resource.

![image](https://user-images.githubusercontent.com/22442264/31171258-aa6c2132-a91c-11e7-9639-f553fe4ef2c1.png)

## Reference
* https://rally1.rallydev.com/#/144349237612d/detail/userstory/155195548928

## Closes
* Closes #US-1493