### PR TITLE
BigCommerce : Updated customers and orders churros tests

### DIFF
--- a/src/test/elements/bigcommerce/customers.js
+++ b/src/test/elements/bigcommerce/customers.js
@@ -11,7 +11,11 @@ const groupPayload = tools.requirePayload(`${__dirname}/assets/group.json`);
 suite.forElement('ecommerce', 'customers', { payload: payload }, (test) => {
   test.should.supportCruds();
   test.withApi(`${test.api}/count`).should.return200OnGet();
-  test.withOptions({ qs: { where: 'fetchShippingAddresses=\'true\'' } }).should.return200OnGet();
+  /* updated the where query from  'fetchShippingAddresses=\'true\'' to
+    where: 'email=\'jamesbrown@theking.com\'' as fetchShippingAddresses field not present in
+    response and vendor response is failing with 504 Gateway Time-out error
+  */
+  test.withOptions({ qs: { where: 'email=\'jamesbrown@theking.com\'' } }).should.return200OnGet();
   test.should.supportPagination();
   test.should.supportCeqlSearch('email');
   it('should allow CRUDS for customer/addresses', () => {

--- a/src/test/elements/bigcommerce/orders.js
+++ b/src/test/elements/bigcommerce/orders.js
@@ -28,10 +28,16 @@ const shipmentsCreate = (addressId, productId) => ({
 const shipmentsUpdate = () => ({
   "comments": "UpdateThis"
 });
-
+/*  orders with Sales Tax Calculation set to 'automatic' in Vendor account are not allowed to be deleted
+    hence all the tests are skipped.
+*/
 suite.forElement('ecommerce', 'orders', { payload: payload, skip: true }, (test) => {
   test.withOptions(options).should.supportCruds();
-  test.withOptions({ qs: { where: 'fetchShippingAddresses=\'true\'' } }).should.return200OnGet();
+  /* updated the where query from  'fetchShippingAddresses=\'true\'' to
+     'email=\'jamesjiffer@jiffylube.org\'' as fetchShippingAddresses field not present in
+    response and vendor response is failing with 504 Gateway Time-out error
+  */
+  test.withOptions({ qs: { where: 'email=\'jamesjiffer@jiffylube.org\'' } }).should.return200OnGet();
   test.withApi(`${test.api}/count`).should.return200OnGet();
   test.withApi(`${test.api}/products/count`).should.return200OnGet();
   test.withApi(`${test.api}/shipments/count`).should.return200OnGet();
@@ -80,6 +86,7 @@ suite.forElement('ecommerce', 'orders', { payload: payload, skip: true }, (test)
       .then(r => cloud.get(`${test.api}/${orderId}/shipments/${shipmentId}`))
       .then(r => cloud.patch(`${test.api}/${orderId}/shipments/${shipmentId}`, shipmentsUpdate()))
       .then(r => cloud.get(`${test.api}/${orderId}/shipments/count`))
+      //For delete orders to be success ,Sales Tax Calculation should be set to 'manual' in the vendor account
       .then(r => cloud.delete(`${test.api}/${orderId}/shipments/${shipmentId}`));
   });
   after(() => cloud.delete(`${test.api}/${orderId}`));

--- a/src/test/elements/bigcommerce/orders.js
+++ b/src/test/elements/bigcommerce/orders.js
@@ -31,7 +31,7 @@ const shipmentsUpdate = () => ({
 /*  orders with Sales Tax Calculation set to 'automatic' in Vendor account are not allowed to be deleted
     hence all the tests are skipped.
 */
-suite.forElement('ecommerce', 'orders', { payload: payload, skip: true }, (test) => {
+suite.forElement('ecommerce', 'orders', { payload: payload}, (test) => {
   test.withOptions(options).should.supportCruds();
   /* updated the where query from  'fetchShippingAddresses=\'true\'' to
      'email=\'jamesjiffer@jiffylube.org\'' as fetchShippingAddresses field not present in

--- a/src/test/elements/bigcommerce/orders.js
+++ b/src/test/elements/bigcommerce/orders.js
@@ -29,7 +29,7 @@ const shipmentsUpdate = () => ({
   "comments": "UpdateThis"
 });
 /*  orders with Sales Tax Calculation set to 'automatic' in Vendor account are not allowed to be deleted
-    hence all the tests are skipped.
+    Hence skip the tests if Tax calculation = 'automatic' 
 */
 suite.forElement('ecommerce', 'orders', { payload: payload}, (test) => {
   test.withOptions(options).should.supportCruds();


### PR DESCRIPTION
- Added  appropriate comments in orders.js for skip test and updated where query in orders and customers.js

## Screenshot

- Please  find attached the results of the tests running successfully
[bigcommerce-polling-churros.txt](https://github.com/cloud-elements/churros/files/1344261/bigcommerce-polling-churros-stag.txt)

- PFA the test results after tax-calculations is set to Manual and order tests are unskipped
  
[bigcommerce-churros-orders-unskipped.txt](https://github.com/cloud-elements/churros/files/1389975/bigcommerce-churros-orders-unskipped.txt)



## Reference
* [SOBA](Link to SOBA or Other PR for which tests were written, when applicable)
* [CircleCI](Link to SOBA PR adding Tests to `circle.yml`, when applicable)
* [RALLY-#${US1485}](https://rally1.rallydev.com/#/144349237612d/detail/userstory/155192973820)

## Closes
[US1485](https://rally1.rallydev.com/#/144349237612d/detail/userstory/155192973820)