### PR TITLE
Added Churros for extended resource for MailJet Marketing

### DIFF
--- a/src/test/elements/mailjetmarketing/assets/newResource.json
+++ b/src/test/elements/mailjetmarketing/assets/newResource.json
@@ -1,0 +1,52 @@
+{
+  "method": "GET",
+  "nextResource": "",
+  "description": "GET Campaigns.",
+  "type": "api",
+  "vendorPath": "contact",
+  "nextPageKey": "",
+  "path": "/extended-resource",
+  "paginationType": "VENDOR_SUPPORTED",
+  "vendorMethod": "GET",
+  "response": {
+    "contentType": "application/json"
+  },
+  "ownerAccountId": 218,
+  "hooks": [],
+  "parameters": [{
+      "vendorType": "query",
+      "converter": "toQueryParameters",
+      "dataType": "string",
+      "name": "where",
+      "description": "The CEQL search expression.",
+      "vendorDataType": "string",
+      "source": "request",
+      "type": "query",
+      "vendorName": "converter:toQueryParameters",
+      "required": false
+    },
+    {
+      "vendorType": "query",
+      "dataType": "string",
+      "name": "pageSize",
+      "description": "The number of resources to return in a given page",
+      "vendorDataType": "string",
+      "source": "request",
+      "type": "query",
+      "vendorName": "pageSize",
+      "required": false
+    },
+    {
+      "vendorType": "query",
+      "dataType": "string",
+      "name": "page",
+      "description": "The page number of resources to retrieve",
+      "vendorDataType": "string",
+      "source": "request",
+      "type": "query",
+      "vendorName": "page",
+      "required": false
+    }
+  ],
+  "rootKey": "|Data"
+}

--- a/src/test/elements/mailjetmarketing/assets/newResource.json
+++ b/src/test/elements/mailjetmarketing/assets/newResource.json
@@ -1,7 +1,7 @@
 {
   "method": "GET",
   "nextResource": "",
-  "description": "GET Campaigns.",
+  "description": "GET Contacts.",
   "type": "api",
   "vendorPath": "contact",
   "nextPageKey": "",

--- a/src/test/elements/mailjetmarketing/extended-resource.js
+++ b/src/test/elements/mailjetmarketing/extended-resource.js
@@ -1,0 +1,24 @@
+'use strict';
+
+const expect = require('chakram').expect;
+const suite = require('core/suite');
+const cloud = require('core/cloud');
+const newResource = require('./assets/newResource.json');
+
+// Test for extending marketing and invoking the extended resource
+suite.forElement('marketing', 'extended-resource', {}, (test) => {
+  let newResourceId;
+  // Add resource to
+  before(() => cloud.post(`elements/mailjetmarketing/resources`, newResource)
+    .then(r => newResourceId = r.body.id));
+
+  //delete new/overide resource should work fine
+  after(() => cloud.delete(`elements/mailjetmarketing/resources/${newResourceId}`));
+
+  it('should test newly added resource extended-resource', () => {
+      return cloud.get(`extended-resource`)
+      .then(r => {
+        expect(r.body).to.not.be.empty;
+      });
+  });
+});


### PR DESCRIPTION
## Highlights
* Added Churros for extended resources of MailJet Marketing.

## Screenshot
![image](https://user-images.githubusercontent.com/22442264/31270823-8bc37d24-aaa3-11e7-91bb-3e1b68ce44a7.png)

## Reference
* [SOBA](https://github.com/cloud-elements/soba/pull/7490)
* [CircleCI](Link to SOBA PR adding Tests to `circle.yml`, when applicable)
* [churros-sauce](Link to Associated Churros-sauce PR, when applicable)
* [RALLY-#$US1494](https://rally1.rallydev.com/#/144349237612d/detail/userstory/155195549172)

## Closes
* Closes #$US1494
