### PR TITLE
BigCommerce : Fixed payload for SKU POST

### DIFF
--- a/src/test/elements/bigcommerce/assets/skus.json
+++ b/src/test/elements/bigcommerce/assets/skus.json
@@ -1,8 +1,8 @@
 {
   "sku": "see loud elephants",
   "options": [    {
-      "product_option_id": 1,
-      "option_value_id": 1
+      "product_option_id": 87,
+      "option_value_id": 7
     }
   ]
 }


### PR DESCRIPTION
## Non-Customer Highlights
* Fixed payload for SKU POST API as teh values were invalid for `options` field.

## Screenshot
![image](https://user-images.githubusercontent.com/22442264/31341275-a4667b12-ad26-11e7-818c-7e184d1aa1ed.png)

## Reference
* [SOBA](https://github.com/cloud-elements/soba/pull/7503)
* [CircleCI](Link to SOBA PR adding Tests to `circle.yml`, when applicable)
* [churros-sauce](Link to Associated Churros-sauce PR, when applicable)
* [RALLY-#$DE87](https://rally1.rallydev.com/#/144349237612d/detail/defect/157345230140)

## Closes
* Closes #$DE87
