### PR TITLE
Churros for CustomRecords and ExpenseReports

### DIFF
--- a/src/test/elements/netsuitefinancev2/assets/customrecords.json
+++ b/src/test/elements/netsuitefinancev2/assets/customrecords.json
@@ -1,0 +1,12 @@
+{
+  "recType": {
+    "internalId": "478",
+    "name": "churros"
+  },
+  "owner": {
+    "internalId": "44604",
+    "name": "Ramana Lashkar"
+  },
+
+  "name": "churros11form"
+}

--- a/src/test/elements/netsuitefinancev2/assets/expense-reports.json
+++ b/src/test/elements/netsuitefinancev2/assets/expense-reports.json
@@ -1,0 +1,43 @@
+{
+	"entity" : {
+		"type": "employee",
+		"internalId": "866783"
+	},
+    "complete":true,
+    "expenseList":{
+        "expense": [
+            {
+                "amount": 6,
+                "line": 2,
+                "expenseDate": "2017-10-06T02:00:00-05:00",
+                "foreignAmount": 6,
+                "isBillable": false,
+                "exchangeRate": 1,
+                "refNumber": 1,
+                "isNonReimbursable": false,
+                "currency": {
+                    "internalId": "1",
+                    "name": "USA"
+                },
+                "location": {
+                    "internalId": "6",
+                    "name": "Texas"
+                },
+                "receipt": false,
+                "_class": {
+                    "internalId": "120",
+                    "name": "Churros"
+                },
+                "category": {
+                    "internalId": "3",
+                    "name": "Mileage"
+                },
+                "department": {
+                    "internalId": "11",
+                    "name": "Engineering"
+                }
+            }
+        ],
+        "replaceAll": false
+    }
+}

--- a/src/test/elements/netsuitefinancev2/customrecords.js
+++ b/src/test/elements/netsuitefinancev2/customrecords.js
@@ -1,0 +1,22 @@
+'use strict';
+
+const suite = require('core/suite');
+const cloud = require('core/cloud');
+const tools = require('core/tools');
+const customRecordsPayload = require('./assets/customrecords');
+
+
+suite.forElement('finance', 'custom-record-types', (test) => {
+
+    it('should allow CRUDS /hubs/finance/customrecords', () => {
+      let customRecordTypeId = 478;
+      let customRecordId;
+      return cloud.post(`${test.api}/${customRecordTypeId}/custom-records`, customRecordsPayload)
+      .then(r => customRecordId = r.body.internalId)
+      .then(r => cloud.get(`${test.api}/${customRecordTypeId}/custom-records`))
+      .then(r => cloud.get(`${test.api}/${customRecordTypeId}/custom-records/${customRecordId}`))
+      .then(r => cloud.patch(`${test.api}/${customRecordTypeId}/custom-records/${customRecordId}`,customRecordsPayload))
+      .then(r => cloud.delete(`${test.api}/${customRecordTypeId}/custom-records/${customRecordId}`));
+
+    });
+});

--- a/src/test/elements/netsuitefinancev2/customrecords.js
+++ b/src/test/elements/netsuitefinancev2/customrecords.js
@@ -6,7 +6,7 @@ const customRecordsPayload = require('./assets/customrecords');
 
 
 suite.forElement('finance', 'custom-record-types', (test) => {
-
+    test.withOptions({ qs: { page: 1, pageSize: 5 } }).should.supportPagination();
     it('should allow CRUDS /hubs/finance/customrecords', () => {
       let customRecordTypeId = 478;
       let customRecordId;

--- a/src/test/elements/netsuitefinancev2/customrecords.js
+++ b/src/test/elements/netsuitefinancev2/customrecords.js
@@ -2,7 +2,6 @@
 
 const suite = require('core/suite');
 const cloud = require('core/cloud');
-const tools = require('core/tools');
 const customRecordsPayload = require('./assets/customrecords');
 
 

--- a/src/test/elements/netsuitefinancev2/expense-reports.js
+++ b/src/test/elements/netsuitefinancev2/expense-reports.js
@@ -6,14 +6,14 @@ const expenseReportsPayload = require('./assets/expense-reports');
 
 
 suite.forElement('finance', 'expense-reports', (test) => {
-
-    it('should allow CRUDS /hubs/finance/expense-reports', () => {
-      let internalId;
-      return cloud.get(test.api)
-      .then(r => cloud.post(test.api, expenseReportsPayload))
+  test.withOptions({ qs: { page: 1, pageSize: 5 } }).should.supportPagination();
+  it('should allow CRUDS /hubs/finance/expense-reports', () => {
+    let internalId;
+    return cloud.post(test.api, expenseReportsPayload)
       .then(r => internalId = r.body.internalId)
-       .then(r => cloud.get(`${test.api}/${internalId}`))
-       .then(r => cloud.patch(`${test.api}/${internalId}`, {}))
-       .then(r => cloud.delete(`${test.api}/${internalId}`));
-    });
+      .then(r => cloud.get(test.api))
+      .then(r => cloud.get(`${test.api}/${internalId}`))
+      .then(r => cloud.patch(`${test.api}/${internalId}`, {}))
+      .then(r => cloud.delete(`${test.api}/${internalId}`));
+  });
 });

--- a/src/test/elements/netsuitefinancev2/expense-reports.js
+++ b/src/test/elements/netsuitefinancev2/expense-reports.js
@@ -2,12 +2,11 @@
 
 const suite = require('core/suite');
 const cloud = require('core/cloud');
-const tools = require('core/tools');
 const expenseReportsPayload = require('./assets/expense-reports');
 
 
 suite.forElement('finance', 'expense-reports', (test) => {
-  	
+
     it('should allow CRUDS /hubs/finance/expense-reports', () => {
       let internalId;
       return cloud.get(test.api)

--- a/src/test/elements/netsuitefinancev2/expense-reports.js
+++ b/src/test/elements/netsuitefinancev2/expense-reports.js
@@ -1,0 +1,20 @@
+'use strict';
+
+const suite = require('core/suite');
+const cloud = require('core/cloud');
+const tools = require('core/tools');
+const expenseReportsPayload = require('./assets/expense-reports');
+
+
+suite.forElement('finance', 'expense-reports', (test) => {
+  	
+    it('should allow CRUDS /hubs/finance/expense-reports', () => {
+      let internalId;
+      return cloud.get(test.api)
+      .then(r => cloud.post(test.api, expenseReportsPayload))
+      .then(r => internalId = r.body.internalId)
+       .then(r => cloud.get(`${test.api}/${internalId}`))
+       .then(r => cloud.patch(`${test.api}/${internalId}`, {}))
+       .then(r => cloud.delete(`${test.api}/${internalId}`));
+    });
+});


### PR DESCRIPTION
## Highlights
* Churros for CustomRecords and ExpenseReports

## Screenshot
seshus-MacBook-Pro:~ seshuede$ churros test elements/netsuitefinancev2 --file customrecords --instance 276
info: Running tests for element: netsuitefinancev2
info: Provisioned with instance id of 276
error: Failed to create or validate: /instances/276/objects/accounts/definitions
error: Failed to create or validate: /instances/276/objects/accounts/definitions
error: Failed to create or validate: /instances/276/transformations/accounts
error: Failed to create or validate: /instances/276/transformations/accounts
  - should not allow provisioning with bad credentials
  custom-record-types
    ✓ should allow CRUDS /hubs/finance/customrecords (17213ms)

  1 passing (21s)
  1 pending

seshus-MacBook-Pro:~ seshuede$ churros test elements/netsuitefinancev2 --file expense-reports --instance 276
info: Running tests for element: netsuitefinancev2
info: Provisioned with instance id of 276
error: Failed to create or validate: /instances/276/objects/accounts/definitions
error: Failed to create or validate: /instances/276/objects/accounts/definitions
error: Failed to create or validate: /instances/276/transformations/accounts
error: Failed to create or validate: /instances/276/transformations/accounts
  - should not allow provisioning with bad credentials
  expense-reports
    ✓ should allow CRUDS /hubs/finance/expense-reports (16260ms)


  1 passing (19s)
  1 pending



## Reference
* [SOBA](Link to SOBA or Other PR for which tests were written, when applicable)
* [CircleCI](Link to SOBA PR adding Tests to `circle.yml`, when applicable)
* [churros-sauce](Link to Associated Churros-sauce PR, when applicable)
* [RALLY-#${ticketNumber}](Link to Rally User Story or Task)

## Closes
* #US1646
* #US1467