### PR TITLE
Added Churros for extended resource for Twilio SMS (Messaging)

### DIFF
--- a/src/test/elements/twilio/assets/newResource.json
+++ b/src/test/elements/twilio/assets/newResource.json
@@ -1,0 +1,51 @@
+{
+  "method": "GET",
+  "nextResource": "",
+  "description": "GET messages",
+  "type": "api",
+  "vendorPath": "/{AccountSid}/Messages.json",
+  "nextPageKey": "",
+  "path": "/extended-resource",
+  "paginationType": "VENDOR_SUPPORTED",
+  "vendorMethod": "GET",
+  "response": {
+    "contentType": "application/json"
+  },
+  "ownerAccountId": 218,
+  "hooks": [],
+  "parameters": [{
+      "vendorType": "path",
+      "dataType": "string",
+      "name": "messaging.sms.twilio.account",
+      "description": "Account SID",
+      "vendorDataType": "string",
+      "source": "request",
+      "type": "configuration",
+      "vendorName": "AccountSid",
+      "required": false
+    },
+    {
+      "vendorType": "query",
+      "dataType": "string",
+      "name": "pageSize",
+      "description": "The number of resources to return in a given page",
+      "vendorDataType": "string",
+      "source": "request",
+      "type": "query",
+      "vendorName": "pageSize",
+      "required": false
+    },
+    {
+      "vendorType": "query",
+      "dataType": "string",
+      "name": "page",
+      "description": "The page number of resources to retrieve",
+      "vendorDataType": "string",
+      "source": "request",
+      "type": "query",
+      "vendorName": "page",
+      "required": false
+    }
+  ],
+  "rootKey": "|messages"
+}

--- a/src/test/elements/twilio/extended-resource.js
+++ b/src/test/elements/twilio/extended-resource.js
@@ -1,0 +1,24 @@
+'use strict';
+
+const expect = require('chakram').expect;
+const suite = require('core/suite');
+const cloud = require('core/cloud');
+const newResource = require('./assets/newResource.json');
+
+// Test for extending messaging and invoking the extended resource
+suite.forElement('messaging', 'extended-resource', {}, (test) => {
+  let newResourceId;
+  // Add resource to
+  before(() => cloud.post(`elements/twilio/resources`, newResource)
+    .then(r => newResourceId = r.body.id));
+
+  //delete new/overide resource should work fine
+  after(() => cloud.delete(`elements/twilio/resources/${newResourceId}`));
+
+  it('should test newly added resource extended-resource', () => {
+      return cloud.get(`extended-resource`)
+      .then(r => {
+        expect(r.body).to.not.be.empty;
+      });
+  });
+});


### PR DESCRIPTION
## Highlights
* Added Churros for extended resources of Twilio SMS (Messaging).

## Non-Customer Highlights
* No churros test present currently for Twilio SMS element.
* Basic Tests are failing as Twilio does not contain any `objects` and `definitions`.
* Churros passing for extended-resource.
* Churros Sauce file update pending, as Kelly needs to confirm which credentials needs to be added.

## Screenshot
![image](https://user-images.githubusercontent.com/22442264/31487656-ece2b0e8-af58-11e7-8a9d-d2fc795f7c54.png)


## Reference
* [SOBA](https://github.com/cloud-elements/soba/pull/7517)
* [CircleCI](Link to SOBA PR adding Tests to `circle.yml`, when applicable)
* [churros-sauce](Link to Associated Churros-sauce PR, when applicable)
* [RALLY-#$US1592](https://rally1.rallydev.com/#/144349237612d/detail/userstory/156281695228)

## Closes
* Closes #$[US1592](https://rally1.rallydev.com/#/144349237612d/detail/userstory/156281695228)
