### PR TITLE
Added Churros for extended resource for SendGrid (Messaging)

### DIFF
--- a/src/test/elements/sendgrid/assets/newResource.json
+++ b/src/test/elements/sendgrid/assets/newResource.json
@@ -1,0 +1,40 @@
+{
+  "method": "GET",
+  "nextResource": "",
+  "description": "GET Usage Stats",
+  "type": "api",
+  "vendorPath": "/stats.get.json",
+  "nextPageKey": "",
+  "path": "/extended-resource",
+  "paginationType": "VENDOR_SUPPORTED",
+  "vendorMethod": "GET",
+  "response": {
+    "contentType": "application/json"
+  },
+  "ownerAccountId": 218,
+  "hooks": [],
+  "parameters": [
+    {
+      "vendorType": "query",
+      "dataType": "string",
+      "name": "pageSize",
+      "description": "The number of resources to return in a given page",
+      "vendorDataType": "string",
+      "source": "request",
+      "type": "query",
+      "vendorName": "limit",
+      "required": false
+    },
+    {
+      "vendorType": "query",
+      "dataType": "string",
+      "name": "page",
+      "description": "The page number of resources to retrieve",
+      "vendorDataType": "string",
+      "source": "request",
+      "type": "query",
+      "vendorName": "offset",
+      "required": false
+    }
+  ]
+}

--- a/src/test/elements/sendgrid/extended-resource.js
+++ b/src/test/elements/sendgrid/extended-resource.js
@@ -1,0 +1,24 @@
+'use strict';
+
+const expect = require('chakram').expect;
+const suite = require('core/suite');
+const cloud = require('core/cloud');
+const newResource = require('./assets/newResource.json');
+
+// Test for extending messaging and invoking the extended resource
+suite.forElement('messaging', 'extended-resource', {}, (test) => {
+  let newResourceId;
+  // Add resource to
+  before(() => cloud.post(`elements/sendgrid/resources`, newResource)
+    .then(r => newResourceId = r.body.id));
+
+  //delete new/overide resource should work fine
+  after(() => cloud.delete(`elements/sendgrid/resources/${newResourceId}`));
+
+  it('should test newly added resource extended-resource', () => {
+      return cloud.get(`extended-resource`)
+      .then(r => {
+        expect(r.body).to.not.be.empty;
+      });
+  });
+});


### PR DESCRIPTION
## Highlights
* Added Churros for extended resources of SendGrid.

## Screenshot
![image](https://user-images.githubusercontent.com/22442264/31493023-0437ebfc-af6b-11e7-901c-d110fbd67394.png)

## Reference
* [SOBA](https://github.com/cloud-elements/soba/pull/7519)
* [CircleCI](Link to SOBA PR adding Tests to `circle.yml`, when applicable)
* [churros-sauce](Link to Associated Churros-sauce PR, when applicable)
* [RALLY-#$US1499](https://rally1.rallydev.com/#/144349237612d/detail/userstory/155195550592)

## Closes
* Closes #$[US1499](https://rally1.rallydev.com/#/144349237612d/detail/userstory/155195550592)
