### PR TITLE
US1595: Updated Ecwid to be Extendable

### DIFF
--- a/src/test/elements/ecwid/assets/newResource.json
+++ b/src/test/elements/ecwid/assets/newResource.json
@@ -1,0 +1,41 @@
+{
+  "method": "GET",
+  "nextResource": "",
+  "description": "GET Orders",
+  "type": "api",
+  "vendorPath": "/api/v1/5628038/orders",
+  "nextPageKey": "",
+  "path": "/extended-resource",
+  "paginationType": "VENDOR_SUPPORTED",
+  "vendorMethod": "GET",
+  "response": {
+    "contentType": "application/json"
+  },
+  "ownerAccountId": 218,
+  "hooks": [],
+  "parameters": [
+    {
+      "vendorType": "query",
+      "dataType": "string",
+      "name": "pageSize",
+      "description": "The number of resources to return in a given page",
+      "vendorDataType": "string",
+      "source": "request",
+      "type": "query",
+      "vendorName": "limit",
+      "required": false
+    },
+    {
+      "vendorType": "query",
+      "dataType": "string",
+      "name": "page",
+      "description": "The page number of resources to retrieve",
+      "vendorDataType": "string",
+      "source": "request",
+      "type": "query",
+      "vendorName": "offset",
+      "required": false
+    }
+  ],
+  "rootKey": "|orders"
+}

--- a/src/test/elements/ecwid/extended-resource.js
+++ b/src/test/elements/ecwid/extended-resource.js
@@ -1,0 +1,24 @@
+'use strict';
+
+const expect = require('chakram').expect;
+const suite = require('core/suite');
+const cloud = require('core/cloud');
+const newResource = require('./assets/newResource.json');
+
+// Test for extending orders and invoking the extended resource
+suite.forElement('ecommerce', 'extended-resource', {}, (test) => {
+  let newResourceId;
+  // Add resource to
+  before(() => cloud.post(`elements/ecwid/resources`, newResource)
+    .then(r => newResourceId = r.body.id));
+
+  //delete new/overide resource should work fine
+  after(() => cloud.delete(`elements/ecwid/resources/${newResourceId}`));
+
+  it('should test newly added resource extended-resource', () => {
+      return cloud.get(`extended-resource`)
+      .then(r => {
+        expect(r.body).to.not.be.empty;
+      });
+  });
+});


### PR DESCRIPTION
## Highlights
 - Added  test cases for Ecwid extended-resource

## PFA the churros result file
[Ecwid- Churros-Results.txt](https://github.com/cloud-elements/churros/files/1382733/Ecwid-.Churros-Results.txt)

## Reference
* [SOBA](https://github.com/cloud-elements/soba/pull/7530)
* [CircleCI](Link to SOBA PR adding Tests to `circle.yml`, when applicable)
* [churros-sauce](Link to Associated Churros-sauce PR, when applicable)
* [RALLY-#${US1595}](https://rally1.rallydev.com/#/144349237612d/detail/userstory/156281696296)

## Closes
* Closes #[US1595](https://rally1.rallydev.com/#/144349237612d/detail/userstory/156281696296)
