### PR TITLE
Added churros for extended-resource for Onenote

### DIFF
--- a/src/core/oauth.js
+++ b/src/core/oauth.js
@@ -363,6 +363,7 @@ const manipulateDom = (element, browser, r, username, password, config) => {
       return browser.getCurrentUrl();
     case 'onedrivev2':
     case 'onedrive':
+    case 'onenote':
       browser.get(r.body.oauthUrl);
       waitForElement(webdriver.By.id('i0116'));
       browser.findElement(webdriver.By.id('i0116')).sendKeys(username);
@@ -370,8 +371,8 @@ const manipulateDom = (element, browser, r, username, password, config) => {
       browser.findElement(webdriver.By.id('idSIButton9')).click();
       waitForElement(webdriver.By.id('i0118'));
       browser.findElement(webdriver.By.id('i0118')).sendKeys(password);
-      waitForElement(webdriver.By.id('idSIButton9'));
-      browser.findElement(webdriver.By.id('idSIButton9')).click();
+      waitForElement(webdriver.By.xpath('.//*[@value= "Sign in" and @type= "submit"]'));
+      browser.findElement(webdriver.By.xpath('.//*[@value= "Sign in" and @type= "submit"]')).click();
       waitForElement(webdriver.By.id('idBtn_Accept')).thenCatch(r => true); // ignore
       browser.findElement(webdriver.By.id('idBtn_Accept'))
         .then((element) => element.click(), (err) => {}); // ignore this

--- a/src/test/elements/onenote/assets/newResource.json
+++ b/src/test/elements/onenote/assets/newResource.json
@@ -1,0 +1,30 @@
+{
+  "method": "GET",
+  "nextResource": "",
+  "description": "Retrive the noteBooks",
+  "type": "api",
+  "vendorPath": "/me/notes/notebooks",
+  "nextPageKey": "",
+  "path": "/extended-resource",
+  "paginationType": "VENDOR_NOT_SUPPORTED",
+  "vendorMethod": "GET",
+  "response": {
+    "contentType": "application/json"
+  },
+  "ownerAccountId": 218,
+  "hooks": [],
+  "parameters": [{
+      "vendorType": "query",
+      "converter": "toQueryParameters",
+      "dataType": "string",
+      "name": "where",
+      "description": "The CEQL search expression.",
+      "vendorDataType": "string",
+      "source": "request",
+      "type": "query",
+      "vendorName": "converter:toQueryParameters",
+      "required": false
+    }
+  ],
+  "rootKey": "|value"
+}

--- a/src/test/elements/onenote/extended-resource.js
+++ b/src/test/elements/onenote/extended-resource.js
@@ -1,0 +1,24 @@
+'use strict';
+
+const expect = require('chakram').expect;
+const suite = require('core/suite');
+const cloud = require('core/cloud');
+const newResource = require('./assets/newResource.json');
+
+// Test for extending eloqua and invoking the extended resource
+suite.forElement('documents', 'extended-resource', {}, (test) => {
+  let newResourceId;
+  // Add resource to
+  before(() => cloud.post(`elements/onenote/resources`, newResource)
+    .then(r => newResourceId = r.body.id));
+
+  //delete new/overide resource should work fine
+  after(() => cloud.delete(`elements/onenote/resources/${newResourceId}`));
+
+  it('should test newly added account resource extended-resource', () => {
+      return cloud.get(`extended-resource`)
+      .then(r => {
+        expect(r.body).to.not.be.empty;
+      });
+  });
+});


### PR DESCRIPTION
## Highlights
* Added churros for extended-resource for Onenote.
## Screenshot
Churros for this element is missing created the User story for the same.
![onenote](https://user-images.githubusercontent.com/22440353/31986721-237ccc6e-b987-11e7-942e-b678568e167d.JPG)
 


## Reference
* [[SOBA]](https://github.com/cloud-elements/soba/pull/7570)
* [CircleCI](Link to SOBA PR adding Tests to `circle.yml`, when applicable)
* [[churros-sauce]](https://github.com/cloud-elements/churros-sauce/pull/111)
* [RALLY-#${US1599}][https://rally1.rallydev.com/#/144349237612d/detail/task/162178648660](https://rally1.rallydev.com/#/144349237612d/detail/task/162178648660)

## Closes
* Closes #${issueNumber}
