### PR TITLE
Testing presence of elements-element-instance-id header on elements responses

### DIFF
--- a/src/test/platform/elements/instances.js
+++ b/src/test/platform/elements/instances.js
@@ -301,6 +301,14 @@ suite.forPlatform('elements/instances', opts, (test) => {
       .then(r => expect(r.body).to.deep.equal(withCorrectHub));
   });
 
+  it('should return element-instance-id on headers', () => {
+    let instanceId;
+    return provisioner.create('jira')
+      .then(r => instanceId = r.body.id)
+      .then(() => cloud.get(`/incidents`))
+      .then(r => expect(parseInt(r.response.headers['elements-element-instance-id'])).to.equal(instanceId));
+  });
+
   it('should allow disabling and enabling  an instance', () => {
     let instanceId;
     defaults.token(closeioInstance.token);


### PR DESCRIPTION
## Highlights
* Checking for elements-element-instance-id header on responses from elements

## Reference
* [SOBA](https://github.com/cloud-elements/soba/pull/7572)

