### PR TITLE
Enhanced/ Added New Test for SAPBusinessOne

### DIFF
--- a/src/test/elements/assets/object.definitions.json
+++ b/src/test/elements/assets/object.definitions.json
@@ -1694,6 +1694,15 @@
      "type": "string"
    }]
  },
+ "equipment-cards": {
+   "fields": [{
+     "path": "idTransformed",
+     "type": "string"
+    },{
+     "path": "id",
+     "type": "string"
+   }]
+ },
  "bill-payment-cards": {
    "fields": [{
      "path": "idTransformed",

--- a/src/test/elements/sapbusinessone/assets/equipment-cards.json
+++ b/src/test/elements/sapbusinessone/assets/equipment-cards.json
@@ -1,0 +1,17 @@
+{
+    "ItemCode": "A00003",
+    "InternalSerialNum": "888855",
+    "ItemDescription": "Sample Postman Created",
+    "ServiceBPType": "srvcSales",
+    "StatusOfSerialNumber": "sns_Active",
+    "DefaultTechnician": 8,
+    "Street": "Plynarenska",
+    "CustomerName": "Star Company",
+    "CustomerCode": "C25000",
+    "InvoiceNumber": 0,
+    "CountryCode": "US",
+    "ContactEmployeeCode": 31,
+    "ManufacturerSerialNum": "78999",
+    "DeliveryNumber": 0,
+    "InstallLocation": "Sample Locations Info"
+}

--- a/src/test/elements/sapbusinessone/assets/transformations.json
+++ b/src/test/elements/sapbusinessone/assets/transformations.json
@@ -20,6 +20,13 @@
       "vendorPath": "Code"
     }]
   },
+  "equipment-cards": {
+    "vendorName": "equipmentcards",
+    "fields": [{
+      "path": "id",
+      "vendorPath": "EquipmentCardNum"
+    }]
+  },
   "products": {
     "vendorName": "items",
     "fields": [{

--- a/src/test/elements/sapbusinessone/customers.js
+++ b/src/test/elements/sapbusinessone/customers.js
@@ -8,4 +8,5 @@ suite.forElement('erp', 'customers', { payload: payload}, (test) => {
   test.should.supportCruds();
   test.should.supportPagination();
   test.should.supportCeqlSearch('CardName');
+  test.withOptions({ qs: { where: `lastModifiedDate >= '2010-10-26'`}}).should.supportPagination();
 });

--- a/src/test/elements/sapbusinessone/equipment-cards.js
+++ b/src/test/elements/sapbusinessone/equipment-cards.js
@@ -1,0 +1,11 @@
+'use strict';
+
+const suite = require('core/suite');
+const tools = require('core/tools');
+const payload = tools.requirePayload(`${__dirname}/assets/equipment-cards.json`);
+
+suite.forElement('erp', 'equipment-cards', { payload: payload}, (test) => {
+  test.should.supportCruds();
+  test.should.supportPagination();
+  test.should.supportCeqlSearch('ItemCode');
+});


### PR DESCRIPTION
elements-mac67->/Users/atul (master-US2498): churros test elements/sapbusinessone
sleep: using busy loop fallback


info: Using url: http://localhost:8080
info: Using user: demandbase@cloud-elements.com
info: Using oauth username: manager
info: Running tests for element: sapbusinessone
info: Provisioned with instance id of 289
  Basic tests
    ✓ should provision
    ✓ should GET /objects (158ms)
    - docs
    ✓ metadata (181ms)
    ✓ transformations (7398ms)
    - should not allow provisioning with bad credentials

  customers
    ✓ should allow CRUDS for /hubs/erp/customers (3884ms)
    ✓ should allow paginating with page and pageSize for /hubs/erp/customers (1929ms)
    ✓ should support searching /hubs/erp/customers by CardName (1465ms)

  drafts
    ✓ should allow CRDS for /hubs/erp/drafts (3071ms)
    ✓ should allow paginating with page and pageSize for /hubs/erp/drafts (2521ms)
    ✓ should support searching /hubs/erp/drafts by Project (2183ms)

  equipment-cards
    ✓ should allow CRUDS for /hubs/erp/equipment-cards (3481ms)
    ✓ should allow paginating with page and pageSize for /hubs/erp/equipment-cards (1810ms)
    ✓ should support searching /hubs/erp/equipment-cards by ItemCode (1852ms)

  ledger-accounts
    ✓ should allow paginating with page and pageSize for /hubs/erp/ledger-accounts (1871ms)
    ✓ should allow GET for /hubs/erp/ledger-accounts (449ms)
    ✓ should allow SR for /hubs/erp/ledger-accounts (1452ms)

  products
    ✓ should allow CRUDS for /hubs/erp/products (5238ms)
    ✓ should allow paginating with page and pageSize for /hubs/erp/products (2724ms)
    ✓ should support searching /hubs/erp/products by ItemName (1869ms)


  19 passing (48s)
  2 pending
