### PR TITLE
Quickbooks estimate object tests

### DIFF
--- a/src/test/elements/quickbooks/assets/estimates.json
+++ b/src/test/elements/quickbooks/assets/estimates.json
@@ -1,0 +1,55 @@
+{
+  "line": [
+    {
+      "detailType": "SALES_ITEM_LINE_DETAIL",
+      "amount": 200,
+      "salesItemLineDetail": {
+        "unitPrice": 200,
+        "itemRef": {
+          "name": "Toy:flour sack",
+          "value": "465"
+        },
+        "serviceDate": 1480550400000,
+        "taxCodeRef": {
+          "value": "TAX"
+        },
+        "qty": 1
+      },
+      "lineNum": 1,
+      "description": "one of my favorites",
+      "id": "1"
+    },
+    {
+      "amount": 35,
+      "detailType": "SUB_TOTAL_LINE_DETAIL",
+      "subTotalLineDetail": {}
+    },
+    {
+      "detailType": "DISCOUNT_LINE_DETAIL",
+      "discountLineDetail": {
+        "percentBased": true,
+        "discountPercent": 10,
+        "discountAccountRef": {
+          "value": "86",
+          "name": "Discounts given"
+        }
+      }
+    }
+  ],
+  "txnTaxDetail": {
+    "totalTax": 0
+  },
+    "customerRef": {
+      "name": "Stout Man",
+      "value": "1905"
+    },
+  "customerMemo": {
+    "value": "Thank you for your business and have a great day!"
+  },
+  "totalAmt": 31.5,
+  "applyTaxAfterDiscount": false,
+  "printStatus": "NEED_TO_PRINT",
+  "billEmail": {
+    "address": "Cool_Cars@intuit.com"
+  }
+}

--- a/src/test/elements/quickbooks/estimates.js
+++ b/src/test/elements/quickbooks/estimates.js
@@ -1,0 +1,10 @@
+'use strict';
+
+const suite = require('core/suite');
+const payload = require('./assets/estimates');
+
+suite.forElement('finance', 'estimate', { payload: payload }, (test) => {
+  test.should.supportCrds();
+  test.withOptions({ qs: { page: 1, pageSize: 5 } }).should.return200OnGet();
+  test.withOptions({ qs: { where: 'totalAmt = \'1\'', page: 1, pageSize: 1 } }).should.return200OnGet();
+});


### PR DESCRIPTION
## Highlights
* Quickbooks estimate object tests

## Screenshot

```
asura:churros ramana$ churros test elements/quickbooks
sleep: using busy loop fallback


info: Using url: http://localhost:5050
info: Using user: churros@ce.com
info: Using oauth username: quickbooks@cloud-elements.com
info: Using api key: qyprdxLrqNbUbzaIRo3AsvwE9bPwHO
info: Running tests for element: quickbooks
info: Provisioned with instance id of 6283
  Basic tests
    ✓ should provision
    ✓ should GET /objects (152ms)
    - docs
    ✓ metadata (110ms)
error: Failed to delete /instances/6283/transformations
error: Failed to delete /instances/6283/transformations
    ✓ transformations (401ms)
    - should not allow provisioning with bad credentials

  bill-payments
    ✓ should allow CRDS for /hubs/finance/bill-payments (6132ms)
    ✓ should allow GET for /hubs/finance/bill-payments (688ms)
    ✓ should allow GET for /hubs/finance/bill-payments (1683ms)

  bills
    ✓ should allow CRUDS for /hubs/finance/bills (5628ms)
    ✓ should allow GET for /hubs/finance/bills (656ms)
    ✓ should allow GET for /hubs/finance/bills (606ms)

  classes
    ✓ should allow SR for /hubs/finance/classes (1188ms)

  credit-memos
    ✓ should allow CRUDS for /hubs/finance/credit-memos (7655ms)
    ✓ should allow GET for /hubs/finance/credit-memos (657ms)
    ✓ should allow GET for /hubs/finance/credit-memos (586ms)

  credit-terms
    ✓ should allow CRS for /hubs/finance/credit-terms (2403ms)
    ✓ should allow GET for /hubs/finance/credit-terms (631ms)

  customers-search
    ✓ should test newly added account resource customers-search (1284ms)

  customers
    ✓ should allow CRUDS for /hubs/finance/customers (5912ms)
    ✓ should allow GET for /hubs/finance/customers (598ms)
    ✓ should support searching /hubs/finance/customers by familyName (1944ms)

  departments
    ✓ should allow CRUDS for /hubs/finance/departments (6320ms)
    ✓ should allow GET for /hubs/finance/departments (614ms)
    ✓ should support searching /hubs/finance/departments by name (3146ms)

  employees
    ✓ should allow CRUDS for /hubs/finance/employees (5456ms)
    ✓ should allow GET for /hubs/finance/employees (777ms)
    ✓ should support searching /hubs/finance/employees by displayName (2628ms)

  estimate
    ✓ should allow CRDS for /hubs/finance/estimate (7070ms)
    ✓ should allow GET for /hubs/finance/estimate (1100ms)
    ✓ should allow GET for /hubs/finance/estimate (682ms)

  invoices
    ✓ should allow CRUDS for /hubs/finance/invoices (11486ms)
    ✓ should allow GET for /hubs/finance/invoices (646ms)
    ✓ should allow GET for /hubs/finance/invoices (611ms)

  journal-entries
    ✓ should allow CRUDS for /hubs/finance/journal-entries (5891ms)
    ✓ should allow GET for /hubs/finance/journal-entries (1009ms)

  ledger-accounts
    ✓ should allow CRS for /hubs/finance/ledger-accounts (2492ms)
    ✓ should allow GET for /hubs/finance/ledger-accounts (586ms)

  payment-methods
    ✓ should allow CRS for /hubs/finance/payment-methods (3235ms)
    ✓ should allow GET for /hubs/finance/payment-methods (1346ms)

  payments
    ✓ should allow CRUS for /hubs/finance/payments (4006ms)
    ✓ should allow GET for /hubs/finance/payments (799ms)

  ping
    ✓ should allow GET for /hubs/finance/ping (98ms)

  polling
    - polling /hubs/finance/bill-payments
    - polling /hubs/finance/bills
    - polling /hubs/finance/credit-memos
    - polling /hubs/finance/credit-terms
    - polling /hubs/finance/customers
    - polling /hubs/finance/employees
    - polling /hubs/finance/invoices
    - polling /hubs/finance/journal-entries
    - polling /hubs/finance/ledger-accounts
    - polling /hubs/finance/payment-methods
    - polling /hubs/finance/payments
    - polling /hubs/finance/products
    - polling /hubs/finance/purchase-orders
    - polling /hubs/finance/sales-receipts
    - polling /hubs/finance/time-activities
    - polling /hubs/finance/vendor-credits
    - polling /hubs/finance/vendor

  products
    ✓ should allow CRUDS for /hubs/finance/products (4748ms)
    ✓ should allow GET for /hubs/finance/products (670ms)
    ✓ should allow GET for /hubs/finance/products (561ms)

  purchase-orders
    ✓ should allow CRUDS for /hubs/finance/purchase-orders (7251ms)
    ✓ should allow GET for /hubs/finance/purchase-orders (687ms)
    ✓ should allow GET for /hubs/finance/purchase-orders (669ms)

  purchases
    ✓ should allow CRUDS for /hubs/finance/purchases (9865ms)
    ✓ should allow GET for /hubs/finance/purchases (844ms)
    ✓ should support searching /hubs/finance/purchases by docNumber (3364ms)

  reports
    ✓ should shupport GET /reports/meatadata and GET /reoprts/:id (973ms)

  sales-receipts
    ✓ should allow CRUDS for /hubs/finance/sales-receipts (9474ms)
    ✓ should allow GET for /hubs/finance/sales-receipts (718ms)

  tax-agencies
    - should allow CRS for /hubs/finance/tax-agencies

  tax-codes
    ✓ should allow paginating with page and pageSize for /hubs/finance/tax-codes (3009ms)
    ✓ should allow S for /hubs/finance/tax-codes (729ms)

  tax-rates
    ✓ should allow SR for /hubs/finance/tax-rates (1651ms)

  tax-service
    - should support create tax-service

  time-activities
    ✓ should allow CRUDS for /hubs/finance/time-activities (6411ms)
    ✓ should allow GET for /hubs/finance/time-activities (586ms)

  vendor-credits
    ✓ should allow CRUDS for /hubs/finance/vendor-credits (9283ms)
    ✓ should allow GET for /hubs/finance/vendor-credits (695ms)
    ✓ should allow GET for /hubs/finance/vendor-credits (2248ms)

  vendor
    ✓ should allow CRUDS for /hubs/finance/vendor (5426ms)
    ✓ should allow GET for /hubs/finance/vendor (605ms)


  63 passing (3m)
  21 pending
```

## Reference
* [SOBA](Link to SOBA or Other PR for which tests were written, when applicable)
* [RALLY-DE394](https://rally1.rallydev.com/#/144349237612d/detail/defect/170626056772)
