### PR TITLE
Added test cases for preference endpoints of QuickBooks Online element

### DIFF
--- a/src/test/elements/quickbooks/preferences.js
+++ b/src/test/elements/quickbooks/preferences.js
@@ -1,0 +1,14 @@
+'use strict';
+
+const suite = require('core/suite');
+const cloud = require('core/cloud');
+
+suite.forElement('finance', 'preferences', (test) => {
+
+  test.should.supportPagination();
+  it('should allow Patch for preferences', () => {
+    return cloud.get(test.api)
+      .then(r => cloud.patch(`${test.api}/${r.body[0].Id}`, { "SyncToken": r.body[0].SyncToken, "sparse":false })); 
+  });
+});
+

--- a/src/test/elements/quickbooks/preferences.js
+++ b/src/test/elements/quickbooks/preferences.js
@@ -7,8 +7,18 @@ suite.forElement('finance', 'preferences', (test) => {
 
   test.should.supportPagination();
   it('should allow Patch for preferences', () => {
+    let id,syncToken; 
     return cloud.get(test.api)
-      .then(r => cloud.patch(`${test.api}/${r.body[0].Id}`, { "SyncToken": r.body[0].SyncToken, "sparse":false })); 
+      .then(r =>{
+	   if(r.body && r.body.length>0){
+            id=r.body[0].Id;
+	    syncToken=r.body[0].SyncToken;
+	   }
+      })
+      .then(r => {
+	   if(id && syncToken)
+	   return  cloud.patch(`${test.api}/${id}`, { "SyncToken": syncToken, "sparse":false }); 
+     });
   });
 });
 


### PR DESCRIPTION
## Highlights
* Added test cases for preference endpoints of QuickBooks Online element

## Screenshot
![qbochurros](https://user-images.githubusercontent.com/22440666/32549629-33fe9b9c-c4b0-11e7-9eac-b044bdd54445.PNG)


## Reference
* [SOBA](https://github.com/cloud-elements/soba/pull/7633)
* [RALLY-#[US2485](https://rally1.rallydev.com/#/144349237612d/detail/userstory/163971164532)

## Closes
* Closes #$US2485
