### PR TITLE
Removed 'skip' from 'users' APIs

### DIFF
--- a/src/test/elements/ciscospark/users.js
+++ b/src/test/elements/ciscospark/users.js
@@ -6,7 +6,7 @@ const payload = require('./assets/users');
 const tools = require('core/tools');
 const build = (overrides) => Object.assign({}, payload, overrides);
 let email = tools.randomEmail();
-const userPayload = build({ displayName: tools.random(), lastName: tools.random(), emails: [ email ] });
+const userPayload = build({ displayName: tools.random(), lastName: tools.random(), emails: [email] });
 
 suite.forElement('collaboration', 'users', null, (test) => {
   it(`should allow SR for ${test.api} and GET account`, () => {
@@ -17,8 +17,8 @@ suite.forElement('collaboration', 'users', null, (test) => {
       .then(r => userEmail = r.body.emails[0])
       .then(r => cloud.withOptions({ qs: { where: `email='${userEmail}'` } }).get(test.api));
   });
-  //Skipping as there is a Cisco Spark bug with DELETE /users
-  it.skip(`should allow CUD for ${test.api} with admin privileges`, () => {
+
+  it(`should allow CUD for ${test.api} with admin privileges`, () => {
     let updatePayload = (org) => ({
       "displayName": `${tools.random()}-update`,
       "emails": [
@@ -33,5 +33,5 @@ suite.forElement('collaboration', 'users', null, (test) => {
       .then(r => body = r.body)
       .then(r => cloud.put(`${test.api}/${body.id}`, updatePayload(body.orgId)))
       .then(r => cloud.delete(`${test.api}/${body.id}`));
-    });
+  });
 });


### PR DESCRIPTION
## Highlights
* Removed `skip` from `users` CRUD APIs as `DELETE /users` API is working now.
## Screenshot
![ciscospark-1](https://user-images.githubusercontent.com/25840389/32887990-d042a854-caeb-11e7-81c1-fbd61eafc782.png)

![ciscospark-2](https://user-images.githubusercontent.com/25840389/32887989-cfe2a6de-caeb-11e7-8de5-03a70337b5df.png)


## Reference
* [RALLY-#US3108](https://rally1.rallydev.com/#/144349237612ud/detail/userstory/174410551440)
