### PR TITLE
Added churros tests for new resources for Bullhorn

### DIFF
--- a/src/test/elements/bullhorn/assets/company.json
+++ b/src/test/elements/bullhorn/assets/company.json
@@ -1,3 +1,3 @@
 {
-		  "name": "Test company"
+		  "name": "<<random.word>>"
 }

--- a/src/test/elements/bullhorn/assets/company.json
+++ b/src/test/elements/bullhorn/assets/company.json
@@ -1,0 +1,3 @@
+{
+		  "name": "Test company"
+}

--- a/src/test/elements/bullhorn/assets/placments.json
+++ b/src/test/elements/bullhorn/assets/placments.json
@@ -1,11 +1,11 @@
 {
 "candidate": {
           "id": 204,
-           "name": "TestFirstt TestLastt"
+           "name": "<<random.word>>"
                     },
  "employmentType":"Permanent",
 "jobOrder": {
       "id": 50,
-      "title": "AA"
+    "title": "<<random.word>>"
     }
 }

--- a/src/test/elements/bullhorn/assets/placments.json
+++ b/src/test/elements/bullhorn/assets/placments.json
@@ -1,0 +1,11 @@
+{
+"candidate": {
+          "id": 204,
+           "name": "TestFirstt TestLastt"
+                    },
+ "employmentType":"Permanent",
+"jobOrder": {
+      "id": 50,
+      "title": "AA"
+    }
+}

--- a/src/test/elements/bullhorn/candidates.js
+++ b/src/test/elements/bullhorn/candidates.js
@@ -16,6 +16,6 @@ suite.forElement('crm', 'candidates', { payload: payload }, (test) => {
       .then(r => cloud.get(test.api))
       .then(r => cloud.get(`${test.api}/${candidateId}`))
       .then(r => cloud.patch(`${test.api}/${candidateId}`, updatePayload))
-      .then(r => cloud.delete(`${test.api}/${candidateId}`, r => expect(r).to.have.statusCode(403)));
+      .then(r => cloud.delete(`${test.api}/${candidateId}`));
   });
 });

--- a/src/test/elements/bullhorn/candidates.js
+++ b/src/test/elements/bullhorn/candidates.js
@@ -1,5 +1,4 @@
 'use strict';
-const expect = require('chakram').expect;
 const suite = require('core/suite');
 const cloud = require('core/cloud');
 const payload = require('./assets/candidates');

--- a/src/test/elements/bullhorn/company.js
+++ b/src/test/elements/bullhorn/company.js
@@ -2,7 +2,9 @@
 
 const suite = require('core/suite');
 const cloud = require('core/cloud');
-const payload = require('./assets/company');
+const tools = require('core/tools');
+const payload = tools.requirePayload(`${__dirname}/assets/company.json`);
+
 const updatePayload = {};
 //Skipping the test since Delete is not supported for this Company resource.
 suite.forElement('crm', 'company', { payload: payload }, (test) => {

--- a/src/test/elements/bullhorn/company.js
+++ b/src/test/elements/bullhorn/company.js
@@ -1,0 +1,20 @@
+'use strict';
+
+const suite = require('core/suite');
+const cloud = require('core/cloud');
+const payload = require('./assets/company');
+const updatePayload = {};
+//Skipping the test since Delete is not supported for this Company resource.
+suite.forElement('crm', 'company', { payload: payload }, (test) => {
+  it.skip('should support CRUDS for company', () => {
+    let companyId;
+    return cloud.post(test.api, payload)
+      .then(r => companyId = r.body.changedEntityId)
+      .then(r => cloud.get(test.api))
+      .then(r => cloud.get(`${test.api}/${companyId}`))
+      .then(r => cloud.patch(`${test.api}/${companyId}`, updatePayload));
+
+
+  });
+  test.should.supportPagination();
+});

--- a/src/test/elements/bullhorn/contacts.js
+++ b/src/test/elements/bullhorn/contacts.js
@@ -1,5 +1,4 @@
 'use strict';
-const expect = require('chakram').expect;
 const suite = require('core/suite');
 const cloud = require('core/cloud');
 const payload = require('./assets/contacts');

--- a/src/test/elements/bullhorn/contacts.js
+++ b/src/test/elements/bullhorn/contacts.js
@@ -18,6 +18,6 @@ suite.forElement('crm', 'contacts', { payload: payload }, (test) => {
       .then(r => cloud.get(test.api))
       .then(r => cloud.get(`${test.api}/${contactId}`))
       .then(r => cloud.patch(`${test.api}/${contactId}`, updatePayload))
-      .then(r => cloud.delete(`${test.api}/${contactId}`, r => expect(r).to.have.statusCode(403)));
+      .then(r => cloud.delete(`${test.api}/${contactId}`));
   });
 });

--- a/src/test/elements/bullhorn/notes.js
+++ b/src/test/elements/bullhorn/notes.js
@@ -19,6 +19,6 @@ suite.forElement('crm', 'notes', { payload: notesPayload }, (test) => {
       .then(r => noteId = r.body.changedEntityId)
       .then(r => cloud.get(`${test.api}/${noteId}`))
       .then(r => cloud.patch(`${test.api}/${noteId}`, updatePayload))
-      .then(r => cloud.delete(`${test.api}/${noteId}`, r => expect(r).to.have.statusCode(403)));
+      .then(r => cloud.delete(`${test.api}/${noteId}`));
   });
 });

--- a/src/test/elements/bullhorn/notes.js
+++ b/src/test/elements/bullhorn/notes.js
@@ -2,7 +2,6 @@
 
 const suite = require('core/suite');
 const tools = require('core/tools');
-const expect = require('chakram').expect;
 const cloud = require('core/cloud');
 const notesPayload = require('./assets/notes');
 

--- a/src/test/elements/bullhorn/placements.js
+++ b/src/test/elements/bullhorn/placements.js
@@ -1,7 +1,5 @@
 'use strict';
 
-const suite = require('core/suite');
-const cloud = require('core/cloud');
 const tools = require('core/tools');
 const payload = tools.requirePayload(`${__dirname}/assets/placments.json`);
 const updatePayload = {};

--- a/src/test/elements/bullhorn/placements.js
+++ b/src/test/elements/bullhorn/placements.js
@@ -2,20 +2,12 @@
 
 const suite = require('core/suite');
 const cloud = require('core/cloud');
-const payload = require('./assets/placments');
+const tools = require('core/tools');
+const payload = tools.requirePayload(`${__dirname}/assets/placments.json`);
 const updatePayload = {};
 
-suite.forElement('crm', 'placements', { payload: payload }, (test) => {
-  it('should support CRUDS for placements', () => {
-    let placementId;
-    return cloud.post(test.api, payload)
-      .then(r => placementId = r.body.changedEntityId)
-      .then(r => cloud.get(test.api))
-      .then(r => cloud.get(`${test.api}/${placementId}`))
-      .then(r => cloud.patch(`${test.api}/${placementId}`, updatePayload))
-      .then(r => cloud.delete(`${test.api}/${placementId}`));
 
-  });
+suite.forElement('crm', 'placements', { payload: payload }, (test) => {
+  test.should.supportCruds();
   test.should.supportPagination();
 });
-

--- a/src/test/elements/bullhorn/placements.js
+++ b/src/test/elements/bullhorn/placements.js
@@ -1,0 +1,21 @@
+'use strict';
+
+const suite = require('core/suite');
+const cloud = require('core/cloud');
+const payload = require('./assets/placments');
+const updatePayload = {};
+
+suite.forElement('crm', 'placements', { payload: payload }, (test) => {
+  it('should support CRUDS for placements', () => {
+    let placementId;
+    return cloud.post(test.api, payload)
+      .then(r => placementId = r.body.changedEntityId)
+      .then(r => cloud.get(test.api))
+      .then(r => cloud.get(`${test.api}/${placementId}`))
+      .then(r => cloud.patch(`${test.api}/${placementId}`, updatePayload))
+      .then(r => cloud.delete(`${test.api}/${placementId}`));
+
+  });
+  test.should.supportPagination();
+});
+

--- a/src/test/elements/bullhorn/placements.js
+++ b/src/test/elements/bullhorn/placements.js
@@ -1,8 +1,8 @@
 'use strict';
 
+const suite = require('core/suite');
 const tools = require('core/tools');
 const payload = tools.requirePayload(`${__dirname}/assets/placments.json`);
-const updatePayload = {};
 
 
 suite.forElement('crm', 'placements', { payload: payload }, (test) => {


### PR DESCRIPTION
## Highlights
* Added tests for new endpoints  - `placements ,  company`
* Company currently does not support Delete operation, so the test for company CRUS are skipped.

## Screenshot
![image](https://user-images.githubusercontent.com/29943090/33071673-7ab118ee-cee2-11e7-86f7-f51d0a0a0aa0.png)


## Reference
* SOBA PR - #[7680](https://github.com/cloud-elements/soba/pull/7680)
* RALLY #[US2295](https://rally1.rallydev.com/#/144349237612/detail/userstory/172897030496), #[US2996](https://rally1.rallydev.com/#/144349237612/detail/userstory/172897686352)

## Closes
* Closes  #[US2295](https://rally1.rallydev.com/#/144349237612/detail/userstory/172897030496), #[US2996](https://rally1.rallydev.com/#/144349237612/detail/userstory/172897686352)

