### PR TITLE
ZuoraV2 : Added test for Suspend and Resume API

### DIFF
--- a/src/test/elements/zuorav2/assets/subscriptions.json
+++ b/src/test/elements/zuorav2/assets/subscriptions.json
@@ -3,8 +3,7 @@
   "invoice": false,
   "autoRenew": true,
   "contractEffectiveDate": "2016-02-01",
-  "initialTerm": "12",
-  "initialTermPeriodType": "Week",
+  "initialTermPeriodType": "Month",
   "notes": "Test POST subscription from z-ruby-sdk",
   "renewalTerm": "3",
   "renewalTermPeriodType": "Week",
@@ -14,5 +13,5 @@
     }],
     "productRatePlanId": "aeecd727df9818433f0c9cb643e2b642"
   }],
-  "termType": "TERMED"
+  "termType": "EVERGREEN"
 }

--- a/src/test/elements/zuorav2/subscriptions.js
+++ b/src/test/elements/zuorav2/subscriptions.js
@@ -40,9 +40,9 @@ const ceqlOptions = {
       .then(r => payload.accountKey = customerId);
   });
 
-  test.withName(ceqlOptions.name).withOptions(ceqlOptions).should.return200OnGet();
-  test.should.supportNextPagePagination(2);
-  test.withOptions(options).should.supportCruds(chakram.put);
+  //test.withName(ceqlOptions.name).withOptions(ceqlOptions).should.return200OnGet();
+  //test.should.supportNextPagePagination(2);
+  //test.withOptions(options).should.supportCruds(chakram.put);
 
 
 
@@ -98,6 +98,24 @@ const ceqlOptions = {
      return cloud.post(`${test.api}`, payload)
              .then(r => id = r.body.id)
              .then(r => cloud.put(`${test.api}/${id}/cancel`, cancleUpdatePayload));
+
+});
+it.skip(`should allow PUT ${test.api}/{id}/suspend and ${test.api}/{id}/resume `, () => {
+
+   let id;
+   let idNew;
+     const suspendUpdatePayload = {
+     "suspendPolicy": "Today"
+   };
+   const resumeUpdatePayload = {
+   "resumePolicy": "SpecificDate",
+   "resumeSpecificDate": "2018-11-23"
+ };
+    return cloud.post(`${test.api}`, payload)
+            .then(r => id = r.body.id)
+            .then(r => cloud.put(`${test.api}/${id}/suspend`, suspendUpdatePayload))
+            .then(r => idNew = r.body.subscriptionId)
+            .then(r => cloud.put(`${test.api}/${idNew}/resume`, resumeUpdatePayload));
 
 });
 

--- a/src/test/elements/zuorav2/subscriptions.js
+++ b/src/test/elements/zuorav2/subscriptions.js
@@ -40,9 +40,9 @@ const ceqlOptions = {
       .then(r => payload.accountKey = customerId);
   });
 
-  //test.withName(ceqlOptions.name).withOptions(ceqlOptions).should.return200OnGet();
-  //test.should.supportNextPagePagination(2);
-  //test.withOptions(options).should.supportCruds(chakram.put);
+  test.withName(ceqlOptions.name).withOptions(ceqlOptions).should.return200OnGet();
+  test.should.supportNextPagePagination(2);
+  test.withOptions(options).should.supportCruds(chakram.put);
 
 
 


### PR DESCRIPTION
## Non-Customer Highlights
1. Added tests for Suspend and Resume APIs.
2. Please note that sauce credentials do not work for these APIs as they do not have permission to suspend a subscription.
3. Credentials to test are:
kelly@cloud-elements.com
Z3brasrideoncl0uds!

## Screenshot
Please include a screenshot of the tests running successfully
![image](https://user-images.githubusercontent.com/22442264/33124638-ae18ccd8-cfa3-11e7-9f59-b27f60f2b777.png)


## Reference
* [SOBA](https://github.com/cloud-elements/soba/pull/7693)
* [CircleCI](Link to SOBA PR adding Tests to `circle.yml`, when applicable)
* [churros-sauce](Link to Associated Churros-sauce PR, when applicable)
* [RALLY-#${US2757}](https://rally1.rallydev.com/#/144349237612d/detail/userstory/168528669852)
* [RALLY-#${US2758}](https://rally1.rallydev.com/#/144349237612d/detail/userstory/168528670264)

## Closes
* Closes 
#$[{US2757}](https://rally1.rallydev.com/#/144349237612d/detail/userstory/168528669852)
#$[{US2758}](https://rally1.rallydev.com/#/144349237612d/detail/userstory/168528670264)
