### PR TITLE
Added Churros for attachment API's of Intacct

### DIFF
--- a/src/test/elements/intacct/assets/attachment.json
+++ b/src/test/elements/intacct/assets/attachment.json
@@ -1,5 +1,5 @@
 {
-  "supdocid":"67",
+  "supdocid":"68",
   "foldername":"madhuri",
-  "discription":"testChurros"
+  "discription":"Test"
 }

--- a/src/test/elements/intacct/assets/attachment.json
+++ b/src/test/elements/intacct/assets/attachment.json
@@ -1,0 +1,5 @@
+{
+  "supdocid":"67",
+  "foldername":"madhuri",
+  "discription":"testChurros"
+}

--- a/src/test/elements/intacct/assets/objects.attachments.json
+++ b/src/test/elements/intacct/assets/objects.attachments.json
@@ -1,0 +1,115 @@
+[
+  {
+    "supdocname": "Unnamed",
+    "creationdate": "11/23/2017",
+    "folder": "madhuri",
+    "createdby": "admin",
+    "description": "test",
+    "id": "27",
+    "recordno": 41
+  },
+  {
+    "supdocname": "Unnamed",
+    "creationdate": "11/23/2017",
+    "folder": "madhuri",
+    "createdby": "admin",
+    "description": "test",
+    "id": "28",
+    "recordno": 42
+  },
+  {
+    "supdocname": "Unnamed",
+    "creationdate": "11/22/2017",
+    "folder": "madhuri",
+    "createdby": "admin",
+    "description": "test",
+    "id": "29",
+    "recordno": 30
+  },
+  {
+    "supdocname": "Unnamed",
+    "creationdate": "11/22/2017",
+    "folder": "madhuri",
+    "createdby": "admin",
+    "id": "30",
+    "recordno": 31
+  },
+  {
+    "supdocname": "Unnamed",
+    "creationdate": "11/23/2017",
+    "folder": "madhuri",
+    "attachments": {
+      "attachment": {
+        "attachmentdata": "test",
+        "attachmenttype": "txt",
+        "attachmentname": "gauri"
+      }
+    },
+    "createdby": "admin",
+    "description": "test2",
+    "id": "34",
+    "recordno": 44
+  },
+  {
+    "supdocname": "Unnamed",
+    "creationdate": "11/22/2017",
+    "folder": "madhuri",
+    "createdby": "admin",
+    "description": "testChurros",
+    "id": "40",
+    "recordno": 33
+  },
+  {
+    "supdocname": "Unnamed",
+    "creationdate": "11/22/2017",
+    "folder": "madhuri",
+    "createdby": "admin",
+    "description": "testChurros",
+    "id": "42",
+    "recordno": 35
+  },
+  {
+    "supdocname": "Unnamed",
+    "creationdate": "11/22/2017",
+    "folder": "madhuri",
+    "createdby": "admin",
+    "description": "testChurros",
+    "id": "44",
+    "recordno": 36
+  },
+  {
+    "supdocname": "Unnamed",
+    "creationdate": "11/22/2017",
+    "folder": "madhuri",
+    "createdby": "admin",
+    "description": "testChurros",
+    "id": "45",
+    "recordno": 38
+  },
+  {
+    "supdocname": "Unnamed",
+    "creationdate": "11/28/2017",
+    "folder": "madhuri",
+    "createdby": "admin",
+    "id": "65",
+    "recordno": 47
+  },
+  {
+    "supdocname": "Unnamed",
+    "creationdate": "11/28/2017",
+    "folder": "madhuri",
+    "createdby": "admin",
+    "description": "testChurros",
+    "id": "67",
+    "recordno": 49
+  },
+  {
+    "supdocname": "Unnamed",
+    "creationdate": "11/28/2017",
+    "folder": "madhuri",
+    "createdby": "admin",
+    "description": "testChurros",
+    "id": "69",
+    "recordno": 51
+  }
+]

--- a/src/test/elements/intacct/assets/transformations.json
+++ b/src/test/elements/intacct/assets/transformations.json
@@ -1,191 +1,200 @@
 {
-  "contacts": {
-    "vendorName": "",
-    "fields": [
-      {
-        "path": "id",
-        "vendorPath": "contactid"
-      }
-    ]
-  },
-  "departments": {
-    "vendorName": "",
-    "fields": [
-      {
-        "path": "id",
-        "vendorPath": "departmentid"
-      }
-    ]
-  },
-  "employees": {
-    "vendorName": "",
-    "fields": [
-      {
-        "path": "id",
-        "vendorPath": "employeeid"
-      }
-    ]
-  },
-  "journals": {
-    "vendorName": "",
-    "fields": [
-      {
-        "path": "id",
-        "vendorPath": "journalid"
-      }
-    ]
-  },
-  "locations": {
-    "vendorName": "",
-    "fields": [
-      {
-        "path": "id",
-        "vendorPath": "locationid"
-      }
-    ]
-  },
-  "classes": {
-    "vendorName": "",
-    "fields": [
-      {
-        "path": "id",
-        "vendorPath": "classid"
-      }
-    ]
-  },
-  "customers": {
-    "vendorName": "",
-    "fields": [
-      {
-        "path": "id",
-        "vendorPath": "customerid"
-      }
-    ]
-  },
-  "bills": {
-    "vendorName": "",
-    "fields": [
-      {
-        "path": "id",
-        "vendorPath": "billid"
-      }
-    ]
-  },
-  "invoices": {
-    "vendorName": "",
-    "fields": [
-      {
-        "path": "id",
-        "vendorPath": "invoiceid"
-      }
-    ]
-  },
-  "payments": {
-    "vendorName": "",
-    "fields": [
-      {
-        "path": "id",
-        "vendorPath": "arpaymentid"
-      }
-    ]
-  },
-  "projects": {
-    "vendorName": "",
-    "fields": [
-      {
-        "path": "id",
-        "vendorPath": "projectid"
-      }
-    ]
-  },
-  "purchase-orders": {
-    "vendorName": "",
-    "fields": [
-      {
-        "path": "id",
-        "vendorPath": "potransactionid"
-      }
-    ]
-  },
-  "sales-orders": {
-    "vendorName": "",
-    "fields": [
-      {
-        "path": "id",
-        "vendorPath": "sotransactionid"
-      }
-    ]
-  },
-  "terms": {
-    "vendorName": "",
-    "fields": [
-      {
-        "path": "id",
-        "vendorPath": "termid"
-      }
-    ]
-  },
-  "vendors": {
-    "vendorName": "",
-    "fields": [
-      {
-        "path": "id",
-        "vendorPath": "vendorid"
-      }
-    ]
-  },
-  "vouchers": {
-    "vendorName": "",
-    "fields": [
-      {
-        "path": "id",
-        "vendorPath": "apadjustmentid"
-      }
-    ]
-  },
-  "warehouses": {
-    "vendorName": "",
-    "fields": [
-      {
-        "path": "id",
-        "vendorPath": "warehouseid"
-      }
-    ]
-  },
-  "ledger-accounts": {
-    "vendorName": "",
-    "fields": [
-      {
-        "path": "id",
-        "vendorPath": "glaccountid"
-      }
-    ]
-  },
-  "terms": {
-    "vendorName": "",
-    "fields": [
-      {
-        "path": "id",
-        "vendorPath": "name"
-      }
-    ]
-  },
-  "transactions": {
-    "vendorName": "",
-    "fields": [
-      {
-        "path": "id",
-        "vendorPath": "gltransactionid"
-      }
-    ]
-  },
-  "items": {
-    "vendorName": "",
-    "fields": [
-      {
-        "path": "id",
-        "vendorPath": "icitemid"
-      }
-    ]
-  }
+"contacts": {
+  "vendorName": "",
+  "fields": [
+    {
+      "path": "id",
+      "vendorPath": "contactid"
+    }
+  ]
+},
+"departments": {
+  "vendorName": "",
+  "fields": [
+    {
+      "path": "id",
+      "vendorPath": "departmentid"
+    }
+  ]
+},
+"employees": {
+  "vendorName": "",
+  "fields": [
+    {
+      "path": "id",
+      "vendorPath": "employeeid"
+    }
+  ]
+},
+"journals": {
+  "vendorName": "",
+  "fields": [
+    {
+      "path": "id",
+      "vendorPath": "journalid"
+    }
+  ]
+},
+"locations": {
+  "vendorName": "",
+  "fields": [
+    {
+      "path": "id",
+      "vendorPath": "locationid"
+    }
+  ]
+},
+"classes": {
+  "vendorName": "",
+  "fields": [
+    {
+      "path": "id",
+      "vendorPath": "classid"
+    }
+  ]
+},
+"customers": {
+  "vendorName": "",
+  "fields": [
+    {
+      "path": "id",
+      "vendorPath": "customerid"
+    }
+  ]
+},
+"bills": {
+  "vendorName": "",
+  "fields": [
+    {
+      "path": "id",
+      "vendorPath": "billid"
+    }
+  ]
+},
+"invoices": {
+  "vendorName": "",
+  "fields": [
+    {
+      "path": "id",
+      "vendorPath": "invoiceid"
+    }
+  ]
+},
+"payments": {
+  "vendorName": "",
+  "fields": [
+    {
+      "path": "id",
+      "vendorPath": "arpaymentid"
+    }
+  ]
+},
+"projects": {
+  "vendorName": "",
+  "fields": [
+    {
+      "path": "id",
+      "vendorPath": "projectid"
+    }
+  ]
+},
+"purchase-orders": {
+  "vendorName": "",
+  "fields": [
+    {
+      "path": "id",
+      "vendorPath": "potransactionid"
+    }
+  ]
+},
+"sales-orders": {
+  "vendorName": "",
+  "fields": [
+    {
+      "path": "id",
+      "vendorPath": "sotransactionid"
+    }
+  ]
+},
+"terms": {
+  "vendorName": "",
+  "fields": [
+    {
+      "path": "id",
+      "vendorPath": "termid"
+    }
+  ]
+},
+"vendors": {
+  "vendorName": "",
+  "fields": [
+    {
+      "path": "id",
+      "vendorPath": "vendorid"
+    }
+  ]
+},
+"vouchers": {
+  "vendorName": "",
+  "fields": [
+    {
+      "path": "id",
+      "vendorPath": "apadjustmentid"
+    }
+  ]
+},
+"warehouses": {
+  "vendorName": "",
+  "fields": [
+    {
+      "path": "id",
+      "vendorPath": "warehouseid"
+    }
+  ]
+},
+"ledger-accounts": {
+  "vendorName": "",
+  "fields": [
+    {
+      "path": "id",
+      "vendorPath": "glaccountid"
+    }
+  ]
+},
+"terms": {
+  "vendorName": "",
+  "fields": [
+    {
+      "path": "id",
+      "vendorPath": "name"
+    }
+  ]
+},
+"transactions": {
+  "vendorName": "",
+  "fields": [
+    {
+      "path": "id",
+      "vendorPath": "gltransactionid"
+    }
+  ]
+},
+"items": {
+  "vendorName": "",
+  "fields": [
+    {
+      "path": "id",
+      "vendorPath": "icitemid"
+    }
+  ]
+},
+"attachments": {
+  "vendorName": "",
+  "fields": [
+   {
+     "path": "id",
+     "vendorPath": "supdocid"
+   }
+  ]
+ }
 }

--- a/src/test/elements/intacct/attachments.js
+++ b/src/test/elements/intacct/attachments.js
@@ -1,12 +1,8 @@
 'use strict';
 
 const suite = require('core/suite');
-const tools = require('core/tools');
 const cloud = require('core/cloud');
 const payload = require('./assets/attachment');
-const updatePayload = {
-    "discription":"testChurrosUpdated"
-};
 
 suite.forElement('finance', 'attachments', { payload: payload }, (test) => {
   it(`should allow CRUDS for ${test.api}`, () => {
@@ -16,7 +12,7 @@ suite.forElement('finance', 'attachments', { payload: payload }, (test) => {
       .then(r => cloud.post(`${test.api}`, payload))
       .then(r => cloud.get(`${test.api}/${docid}`))
       .then(r => cloud.patch(`${test.api}/${docid}`, payload))
-      .then(r => cloud.delete(`${test.api}/${docid}`))
+      .then(r => cloud.delete(`${test.api}/${docid}`));
   });
   test.should.supportPagination();
   test.withName('should support updated > {date} Ceql search').withOptions({ qs: { where: 'creationdate>\'11/21/2017\'' } }).should.return200OnGet();

--- a/src/test/elements/intacct/attachments.js
+++ b/src/test/elements/intacct/attachments.js
@@ -3,6 +3,7 @@
 const suite = require('core/suite');
 const cloud = require('core/cloud');
 const payload = require('./assets/attachment');
+const schema = require('./assets/objects.attachments.json');
 
 suite.forElement('finance', 'attachments', { payload: payload }, (test) => {
   it(`should allow CRUDS for ${test.api}`, () => {
@@ -15,5 +16,5 @@ suite.forElement('finance', 'attachments', { payload: payload }, (test) => {
       .then(r => cloud.delete(`${test.api}/${docid}`));
   });
   test.should.supportPagination();
-  test.withName('should support updated > {date} Ceql search').withOptions({ qs: { where: 'creationdate>\'11/21/2017\'' } }).should.return200OnGet();
+  test.withValidation(schema).withName('should support updated > {date} Ceql search').withOptions({ qs: { where: 'creationdate>\'11/21/2017\'' } }).should.return200OnGet();
 });

--- a/src/test/elements/intacct/attachments.js
+++ b/src/test/elements/intacct/attachments.js
@@ -1,0 +1,23 @@
+'use strict';
+
+const suite = require('core/suite');
+const tools = require('core/tools');
+const cloud = require('core/cloud');
+const payload = require('./assets/attachment');
+const updatePayload = {
+    "discription":"testChurrosUpdated"
+};
+
+suite.forElement('finance', 'attachments', { payload: payload }, (test) => {
+  it(`should allow CRUDS for ${test.api}`, () => {
+    let docid;
+    return cloud.get(test.api)
+      .then(r => docid = r.body[1].id)
+      .then(r => cloud.post(`${test.api}`, payload))
+      .then(r => cloud.get(`${test.api}/${docid}`))
+      .then(r => cloud.patch(`${test.api}/${docid}`, payload))
+      .then(r => cloud.delete(`${test.api}/${docid}`))
+  });
+  test.should.supportPagination();
+  test.withName('should support updated > {date} Ceql search').withOptions({ qs: { where: 'creationdate>\'11/21/2017\'' } }).should.return200OnGet();
+});


### PR DESCRIPTION
## Highlights
* Added Churros for attachment API's of Intacct.

## Screenshot
![attachment](https://user-images.githubusercontent.com/20813984/33321033-0757c0d2-d43c-11e7-9507-94e7ac938372.PNG)


## Reference
* [SOBA](https://github.com/cloud-elements/soba/pull/7708)
* [RALLY-#${US2872}](https://rally1.rallydev.com/#/144349237612d/detail/userstory/170991500320?fdp=true)

## Closes
* Closes #[US2872](https://rally1.rallydev.com/#/144349237612d/detail/userstory/170991500320?fdp=true)
