### PR TITLE
Added churros for reporting periods API for Intacct

### DIFF
--- a/src/test/elements/intacct/assets/schema.json
+++ b/src/test/elements/intacct/assets/schema.json
@@ -1,0 +1,16 @@
+[
+  {
+    "RECORDNO": 111,
+    "STATUS": "active",
+    "WHENCREATED": "01/01/1970 00:00:00",
+    "HEADER1": "Year Ended",
+    "BUDGETING": false,
+    "DATETYPE": 99,
+    "HEADER2": "December ",
+    "RECORD": 111,
+    "END_DATE": "12/31/2011",
+    "START_DATE": "01/01/2011",
+    "NAME": "Calendar Year Ended December 2011",
+    "WHENMODIFIED": "01/01/1970 00:00:00"
+  }
+]

--- a/src/test/elements/intacct/reporting-periods.js
+++ b/src/test/elements/intacct/reporting-periods.js
@@ -1,9 +1,10 @@
 'use strict';
 
 const suite = require('core/suite');
+const schema = require('./assets/schema.json');
 
 suite.forElement('finance', 'reporting-periods', null , (test) => {
   test.should.return200OnGet();
   test.should.supportPagination();
-  test.withName('should support updated > {date} Ceql search').withOptions({ qs: { where: 'WHENCREATED>\'08/13/2016 05:26:37\'' } }).should.return200OnGet();
+  test.withValidation(schema).withName('should support updated > {date} Ceql search').withOptions({ qs: { where: 'RECORDNO=\'111\'' } }).should.return200OnGet();
 });

--- a/src/test/elements/intacct/reporting-periods.js
+++ b/src/test/elements/intacct/reporting-periods.js
@@ -1,0 +1,9 @@
+'use strict';
+
+const suite = require('core/suite');
+
+suite.forElement('finance', 'reporting-periods', null , (test) => {
+  test.should.return200OnGet();
+  test.should.supportPagination();
+  test.withName('should support updated > {date} Ceql search').withOptions({ qs: { where: 'WHENCREATED>\'08/13/2016 05:26:37\'' } }).should.return200OnGet();
+});


### PR DESCRIPTION
## Highlights
* Added churros for reporting periods API for Intacct.

## Screenshot
![rp](https://user-images.githubusercontent.com/20813984/33426703-a3d2676c-d5ba-11e7-8617-7b6445533ceb.PNG)


## Reference
* [SOBA](https://github.com/cloud-elements/soba/pull/7718)
* [RALLY-#${#2999}](https://rally1.rallydev.com/#/144349237612d/detail/userstory/172898191972?fdp=true)

## Closes
* Closes #$[2999](https://rally1.rallydev.com/#/144349237612d/detail/userstory/172898191972?fdp=true)
