### PR TITLE
add formula execution tests for amqp and notification steps and notify.email

### DIFF
--- a/src/test/platform/formulas/assets/formulas/amqp-step.json
+++ b/src/test/platform/formulas/assets/formulas/amqp-step.json
@@ -1,0 +1,24 @@
+{
+  "name": "amqp-step",
+  "triggers": [{
+    "type": "manual",
+    "onSuccess": ["start"]
+  }],
+  "steps": [{
+    "name": "start",
+    "type": "script",
+    "onSuccess": ["end"],
+    "properties": {
+      "body": "done({message: 'this is a test message'})"
+    }
+  },{
+    "name": "end",
+    "type": "amqpRequest",
+    "properties": {
+      "exchange": "amq.topic",
+      "body": "${steps.start}",
+      "queue": "queue",
+      "url": "amqp://tqsyfgzq:kjXt3iBfPfegpRREvMhUPdYiXOHpcpg1@donkey.rmq.cloudamqp.com/tqsyfgzq"
+    }
+  }]
+}

--- a/src/test/platform/formulas/assets/formulas/notification-step.json
+++ b/src/test/platform/formulas/assets/formulas/notification-step.json
@@ -1,0 +1,14 @@
+{
+  "name": "notification-step",
+  "triggers": [{
+    "type": "manual",
+    "onSuccess": ["end"]
+  }],
+  "steps": [{
+    "name": "end",
+    "type": "notification",
+    "properties": {
+      "body": "done(true);"
+    }
+  }]
+}

--- a/src/test/platform/formulas/assets/formulas/notify-email.json
+++ b/src/test/platform/formulas/assets/formulas/notify-email.json
@@ -8,7 +8,7 @@
     "name": "end",
     "type": "script",
     "properties": {
-      "body": "notify.email('laura+tester@cloud-elements.com', 'test subject', 'test message'); done(trigger.args);"
+      "body": "notify.email('tester@cloud-elements.com', 'test subject', 'test message'); done(trigger.args);"
     }
   }]
 }

--- a/src/test/platform/formulas/assets/formulas/notify-email.json
+++ b/src/test/platform/formulas/assets/formulas/notify-email.json
@@ -1,0 +1,14 @@
+{
+  "name": "notify-email",
+  "triggers": [{
+    "type": "manual",
+    "onSuccess": ["end"]
+  }],
+  "steps": [{
+    "name": "end",
+    "type": "script",
+    "properties": {
+      "body": "notify.email('laura+tester@cloud-elements.com', 'test subject', 'test message'); done(trigger.args);"
+    }
+  }]
+}

--- a/src/test/platform/formulas/executions.js
+++ b/src/test/platform/formulas/executions.js
@@ -377,9 +377,6 @@ suite.forPlatform('formulas', { name: 'formula executions' }, (test) => {
 
         const ses = e.stepExecutions;
         ses.filter(se => se.stepName !== 'end').map(validateSuccessfulStepExecution);
-
-        const consolidated = consolidateStepExecutionValues(ses);
-        // expect(JSON.parse(consolidated['end.request']).body).to.contain('this is a test message');
       });
     };
     return manualTriggerTest('amqp-step', null, { foo: 'bar' }, 3, validator);

--- a/src/test/platform/formulas/executions.js
+++ b/src/test/platform/formulas/executions.js
@@ -185,7 +185,7 @@ suite.forPlatform('formulas', { name: 'formula executions' }, (test) => {
   /**
    * Handles the basic formula execution test for a formula that has a manual trigger type
    */
-  const manualTriggerTest = (fName, configuration, trigger, numSevs, validator, executionStatus, optionalNumSes) => {
+  const manualTriggerTest = (fName, configuration, trigger, numSevs, validator, executionStatus, optionalNumSes, settings) => {
     const f = require(`./assets/formulas/${fName}`);
     let fi = { name: 'churros-manual-formula-instance' };
 
@@ -193,6 +193,10 @@ suite.forPlatform('formulas', { name: 'formula executions' }, (test) => {
 
     if (configuration) {
       fi.configuration = configuration;
+    }
+
+    if (settings) {
+      fi.settings = settings;
     }
 
     const validatorWrapper = (executions) => {
@@ -331,6 +335,54 @@ suite.forPlatform('formulas', { name: 'formula executions' }, (test) => {
       });
     };
     return eventTriggerTest('simple-no-return-console-formula', 1, 2, validator);
+  });
+
+  it('should properly handle a formula with a step that uses notify.email', () => {
+    const validator = (executions) => {
+      executions.map(e => {
+        expect(e.status).to.equal('success');
+
+        const ses = e.stepExecutions;
+        ses.filter(se => se.stepName !== 'end').map(validateSuccessfulStepExecution);
+
+        const consolidated = consolidateStepExecutionValues(ses);
+
+        expect(JSON.parse(consolidated['end.notify'])).to.have.length(1);
+        expect(JSON.parse(consolidated['end.notify'])[0].subject).to.equal('test subject');
+      });
+    };
+    return manualTriggerTest('notify-email', null, { foo: 'bar' }, 2, validator);
+  });
+
+  it('should properly handle a formula with a notification step', () => {
+    const validator = (executions) => {
+      executions.map(e => {
+        expect(e.status).to.equal('success');
+
+        const ses = e.stepExecutions;
+        ses.filter(se => se.stepName !== 'end').map(validateSuccessfulStepExecution);
+
+        const consolidated = consolidateStepExecutionValues(ses);
+        expect(consolidated['end.continue']).to.equal(true);
+      });
+    };
+    return manualTriggerTest('notification-step', null, { foo: 'bar' }, 2, validator, null, null, {'notification.email': 'laura+tester@cloud-elements.com'});
+  });
+
+
+  it('should properly handle a formula with an amqp step', () => {
+    const validator = (executions) => {
+      executions.map(e => {
+        expect(e.status).to.equal('success');
+
+        const ses = e.stepExecutions;
+        ses.filter(se => se.stepName !== 'end').map(validateSuccessfulStepExecution);
+
+        const consolidated = consolidateStepExecutionValues(ses);
+        // expect(JSON.parse(consolidated['end.request']).body).to.contain('this is a test message');
+      });
+    };
+    return manualTriggerTest('amqp-step', null, { foo: 'bar' }, 3, validator);
   });
 
   it('should properly handle a formula with a v1 step that contains invalid json', () => {

--- a/src/test/platform/formulas/executions.js
+++ b/src/test/platform/formulas/executions.js
@@ -366,7 +366,7 @@ suite.forPlatform('formulas', { name: 'formula executions' }, (test) => {
         expect(consolidated['end.continue']).to.equal(true);
       });
     };
-    return manualTriggerTest('notification-step', null, { foo: 'bar' }, 2, validator, null, null, {'notification.email': 'laura+tester@cloud-elements.com'});
+    return manualTriggerTest('notification-step', null, { foo: 'bar' }, 2, validator, null, null, {'notification.email': 'tester@cloud-elements.com'});
   });
 
 


### PR DESCRIPTION
## Highlights
* formula amqp step test
* formula notification step and notify.email tests

## Reference
* [SOBA](Link to SOBA or Other PR for which tests were written, when applicable)
* [CircleCI](Link to SOBA PR adding Tests to `circle.yml`, when applicable)
* [churros-sauce](Link to Associated Churros-sauce PR, when applicable)
* [RALLY-#${US4266}](https://rally1.rallydev.com/#/144349238268d/detail/userstory/179993177580)
