### PR TITLE
Formula upgrade and revert API test

### DIFF
--- a/src/test/platform/formulas/assets/formulas/complex-to-upgrade.json
+++ b/src/test/platform/formulas/assets/formulas/complex-to-upgrade.json
@@ -1,0 +1,142 @@
+{
+    "name": "complex_successful",
+    "triggers": [{
+      "type": "event",
+      "onSuccess": [
+        "return_true"
+      ],
+      "onFailure": [],
+      "properties": {
+        "elementInstanceId": "${trigger_instance}"
+      }
+    }],
+    "configuration": [{
+      "key": "trigger_instance",
+      "name": "Trigger Instance",
+      "type": "elementInstance",
+      "description": "The element instance that triggers the formula"
+    }],
+    "steps": [{
+        "onSuccess": [],
+        "onFailure": [],
+        "name": "end",
+        "type": "filter",
+        "properties": {
+          "body": "done(true);"
+        }
+      },
+      {
+        "onSuccess": [
+          "filter_me_always"
+        ],
+        "onFailure": [],
+        "name": "get_instances",
+        "type": "request",
+        "properties": {
+          "api": "/instances",
+          "retry": "false",
+          "method": "GET"
+        }
+      },
+      {
+        "onSuccess": [
+          "retrieve_contact"
+        ],
+        "onFailure": [
+          "end"
+        ],
+        "name": "looper",
+        "type": "loop",
+        "properties": {
+          "list": "ten_ids_please.ids"
+        }
+      },
+      {
+        "onSuccess": ["looper"],
+        "onFailure": [],
+        "name": "invalid_request_step",
+        "type": "request",
+        "properties": {
+          "api": "/nosuchresource/${get_contacts.response[0].id}",
+          "retry": "false",
+          "method": "GET",
+          "acceptableStatusCodes": "401"
+        }
+      },
+      {
+        "onSuccess": [
+          "get_contacts"
+        ],
+        "onFailure": [],
+        "name": "setup_page_parameters",
+        "type": "script",
+        "properties": {
+          "body": "done({page: 1, pageSize: 200});"
+        }
+      },
+      {
+        "onSuccess": [
+          "ten_ids_please"
+        ],
+        "onFailure": [],
+        "name": "get_contacts",
+        "type": "elementRequest",
+        "properties": {
+          "api": "/hubs/crm/contacts",
+          "retry": "false",
+          "elementInstanceId": "${trigger_instance}",
+          "method": "GET",
+          "query": "${steps.setup_page_parameters}"
+        }
+      },
+      {
+        "onSuccess": [
+          "setup_page_parameters"
+        ],
+        "onFailure": [],
+        "name": "return_true",
+        "type": "filter",
+        "properties": {
+          "body": "done(true);"
+        }
+      },
+      {
+        "onSuccess": [
+          "invalid_request_step"
+        ],
+        "onFailure": [],
+        "name": "filter_me_always",
+        "type": "filter",
+        "properties": {
+          "body": "done(true);"
+        }
+      },
+      {
+        "onSuccess": [
+          "looper"
+        ],
+        "onFailure": [],
+        "name": "retrieve_contact",
+        "type": "elementRequest",
+        "properties": {
+          "api": "/hubs/crm/contacts/{entry}",
+          "path": "${looper}",
+          "retry": "false",
+          "elementInstanceId": "${config.trigger_instance}",
+          "method": "GET"
+        }
+      },
+      {
+        "onSuccess": [
+          "get_instances"
+        ],
+        "onFailure": [],
+        "name": "ten_ids_please",
+        "type": "script",
+        "properties": {
+          "body": "var contacts = steps['get_contacts'].response.body;\nvar response = {ids:[]};\n\n// only care about 10 of these bad boyz...\nfor (var i = 0; i < 10; i ++) {\n  var c = contacts[i];\n  if(c.id == null){response.ids.push(c.Id);}else{response.ids.push(c.id);}\n}\n\ndone(response);"
+        }
+      }
+    ]
+  }
+  

--- a/src/test/platform/formulas/formulas.js
+++ b/src/test/platform/formulas/formulas.js
@@ -223,7 +223,7 @@ suite.forPlatform('formulas', opts, (test) => {
     };
 
     const backupValidator = (formulas) => {
-      const backup = formulas.filter(formula => formula.name == `${f.name}-v1-engine-backup`)
+      const backup = formulas.filter(formula => formula.name === `${f.name}-v1-engine-backup`);
       expect(backup).to.have.length(1);
       expect(backup[0].engine).to.equal('v1');
     };

--- a/src/test/platform/formulas/formulas.js
+++ b/src/test/platform/formulas/formulas.js
@@ -222,8 +222,8 @@ suite.forPlatform('formulas', opts, (test) => {
       expect(formula.engine).to.equal('v3');
     };
 
-    const upgradeValidator = (formulas) => {
-      const backup = formulas.filter(formula => formula.name == `${f.name}-v1-backup`)
+    const backupValidator = (formulas) => {
+      const backup = formulas.filter(formula => formula.name == `${f.name}-v1-engine-backup`)
       expect(backup).to.have.length(1);
       expect(backup[0].engine).to.equal('v1');
     };
@@ -231,7 +231,7 @@ suite.forPlatform('formulas', opts, (test) => {
     let formulaId;
     return cloud.post(test.api, f, schema)
       .then(r => formulaId = r.body.id)
-      .then(r => cloud.put(`${test.api}/${formulaId}/upgrad e/v3`))
+      .then(r => cloud.put(`${test.api}/${formulaId}/upgrade/v3`))
       .then(r => upgradeValidator(r.body))
       .then(() => cloud.get(test.api))
       .then(r => backupValidator(r.body))


### PR DESCRIPTION
## Highlights
* Tests for the formula APIs to upgrade a formula to v3 and revert back to v1

## Reference
* [SOBA](https://github.com/cloud-elements/soba/pull/7759)
* [CircleCI](Link to SOBA PR adding Tests to `circle.yml`, when applicable)
* [churros-sauce](Link to Associated Churros-sauce PR, when applicable)
* [RALLY-#${ticketNumber}](Link to Rally User Story or Task)
