### PR TITLE
Model autogeneration tests

### DIFF
--- a/src/test/platform/models/assets/payload.json
+++ b/src/test/platform/models/assets/payload.json
@@ -1,0 +1,100 @@
+{
+    "timeTaxCode": {
+      "internalId": "-7",
+      "name": "-Not Taxable-",
+      "externalId": "asdsadas",
+      "type": {
+        "value": "invoice"
+      }
+    },
+    "timeTaxRate2": 3,
+    "toBeEmailed": false,
+    "toBeFaxed": false,
+    "toBePrinted": false,
+    "trackingNumbers": "2324324",
+    "tranDate": "2016-6-30T05:28:05.007Z",
+    "tranId": "2132235324",
+    "tranIsVsoeBundle": false,
+    "vatRegNum": "123112321",
+    "vsoeAutoCalc": false,
+    "taxRate": 2,
+    "taxTotal": 4100,
+    "terms": {
+      "internalId": "2",
+      "name": "Net 30",
+      "externalId": "string",
+      "type": {
+        "value": "account"
+      }
+    },
+    "timeDiscPrint": false,
+    "timeDiscRate": "3%",
+    "timeDiscTax1Amt": 10020,
+    "timeDiscTaxable": false,
+    "shippingCost": 10140,
+    "shippingTax2Rate": "5%",
+    "status": "Open",
+    "syncPartnerTeams": false,
+    "syncSalesTeams": false,
+    "tax2Total": 4200,
+    "taxItem": {
+      "internalId": "-153",
+      "name": "CA-SAN FRANCISCO",
+      "externalId": "string",
+      "type": {
+        "value": "account"
+      }
+    },
+    "shipIsResidential": false,
+    "shipMethod": {
+      "internalId": "3",
+      "name": "Truck",
+      "externalId": "asdasdadasd",
+      "type": {
+        "value": "account"
+      }
+    },
+    "handlingTax2Rate": "3.00%",
+    "isTaxable": false,
+    "itemCostDiscPrint": false,
+    "itemCostDiscRate": "4.00%",
+    "itemCostDiscTax1Amt": 650,
+    "itemCostDiscTaxable": false,
+    "expCostTaxCode": {
+      "internalId": "1",
+      "name": "asdasdasd123",
+      "externalId": "asdasdasd123",
+      "type": {
+        "value": "account"
+      }
+    },
+    "expCostTaxRate1": 1,
+    "expCostTaxRate2": 2,
+    "externalId": "dsfsfdsf",
+    "fax": "(415) 6543-1001",
+    "giftCertApplied": 41,
+    "accountingBookDetailList": {
+      "replaceAll": true,
+      "accountingBookDetail": [
+        {
+          "exchangeRate": 89,
+          "accountingBook": {
+            "internalId": "1",
+            "name": "appconfxwr99usbjxn3wb7hw7b9",
+            "externalId": "appconeoftizzu80ewxlnfdpldi",
+            "type": {
+              "value": "subsidiary"
+            }
+          },
+          "currency": {
+            "internalId": "1",
+            "name": "appconfxwr99usbjxn3wb7hw7b9",
+            "externalId": "appconeoftizzu80ewxlnfdpldi",
+            "type": {
+              "value": "subsidiary"
+            }
+          }
+        }
+      ]
+    }
+  }

--- a/src/test/platform/models/assets/payload.schema.json
+++ b/src/test/platform/models/assets/payload.schema.json
@@ -1,0 +1,1201 @@
+{
+  "type": "object",
+  "properties": {
+    "timeTaxCodetype": {
+      "type": "object",
+      "properties": {
+        "x-has-customfields": {
+          "type": "boolean"
+        },
+        "type": {
+          "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "properties": {
+          "type": "object",
+          "properties": {
+            "value": {
+              "type": "object",
+              "properties": {
+                "x-samplevalue": {
+                  "type": "string"
+                },
+                "type": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "expCostTaxCode": {
+      "type": "object",
+      "properties": {
+        "x-has-customfields": {
+          "type": "boolean"
+        },
+        "type": {
+          "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "properties": {
+          "type": "object",
+          "properties": {
+            "internalId": {
+              "type": "object",
+              "properties": {
+                "x-samplevalue": {
+                  "type": "string"
+                },
+                "type": {
+                  "type": "string"
+                }
+              }
+            },
+            "name": {
+              "type": "object",
+              "properties": {
+                "x-samplevalue": {
+                  "type": "string"
+                },
+                "type": {
+                  "type": "string"
+                }
+              }
+            },
+            "externalId": {
+              "type": "object",
+              "properties": {
+                "x-samplevalue": {
+                  "type": "string"
+                },
+                "type": {
+                  "type": "string"
+                }
+              }
+            },
+            "type": {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "shipMethodtype": {
+      "type": "object",
+      "properties": {
+        "x-has-customfields": {
+          "type": "boolean"
+        },
+        "type": {
+          "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "properties": {
+          "type": "object",
+          "properties": {
+            "value": {
+              "type": "object",
+              "properties": {
+                "x-samplevalue": {
+                  "type": "string"
+                },
+                "type": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "taxItem": {
+      "type": "object",
+      "properties": {
+        "x-has-customfields": {
+          "type": "boolean"
+        },
+        "type": {
+          "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "properties": {
+          "type": "object",
+          "properties": {
+            "internalId": {
+              "type": "object",
+              "properties": {
+                "x-samplevalue": {
+                  "type": "string"
+                },
+                "type": {
+                  "type": "string"
+                }
+              }
+            },
+            "name": {
+              "type": "object",
+              "properties": {
+                "x-samplevalue": {
+                  "type": "string"
+                },
+                "type": {
+                  "type": "string"
+                }
+              }
+            },
+            "externalId": {
+              "type": "object",
+              "properties": {
+                "x-samplevalue": {
+                  "type": "string"
+                },
+                "type": {
+                  "type": "string"
+                }
+              }
+            },
+            "type": {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "termstype": {
+      "type": "object",
+      "properties": {
+        "x-has-customfields": {
+          "type": "boolean"
+        },
+        "type": {
+          "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "properties": {
+          "type": "object",
+          "properties": {
+            "value": {
+              "type": "object",
+              "properties": {
+                "x-samplevalue": {
+                  "type": "string"
+                },
+                "type": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "type": {
+      "type": "object",
+      "properties": {
+        "x-has-customfields": {
+          "type": "boolean"
+        },
+        "type": {
+          "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "properties": {
+          "type": "object",
+          "properties": {
+            "value": {
+              "type": "object",
+              "properties": {
+                "x-samplevalue": {
+                  "type": "string"
+                },
+                "type": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "timeTaxCode": {
+      "type": "object",
+      "properties": {
+        "x-has-customfields": {
+          "type": "boolean"
+        },
+        "type": {
+          "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "properties": {
+          "type": "object",
+          "properties": {
+            "internalId": {
+              "type": "object",
+              "properties": {
+                "x-samplevalue": {
+                  "type": "string"
+                },
+                "type": {
+                  "type": "string"
+                }
+              }
+            },
+            "name": {
+              "type": "object",
+              "properties": {
+                "x-samplevalue": {
+                  "type": "string"
+                },
+                "type": {
+                  "type": "string"
+                }
+              }
+            },
+            "externalId": {
+              "type": "object",
+              "properties": {
+                "x-samplevalue": {
+                  "type": "string"
+                },
+                "type": {
+                  "type": "string"
+                }
+              }
+            },
+            "type": {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "accountingBooktype": {
+      "type": "object",
+      "properties": {
+        "x-has-customfields": {
+          "type": "boolean"
+        },
+        "type": {
+          "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "properties": {
+          "type": "object",
+          "properties": {
+            "value": {
+              "type": "object",
+              "properties": {
+                "x-samplevalue": {
+                  "type": "string"
+                },
+                "type": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "currencytype": {
+      "type": "object",
+      "properties": {
+        "x-has-customfields": {
+          "type": "boolean"
+        },
+        "type": {
+          "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "properties": {
+          "type": "object",
+          "properties": {
+            "value": {
+              "type": "object",
+              "properties": {
+                "x-samplevalue": {
+                  "type": "string"
+                },
+                "type": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "accountingBookDetailList": {
+      "type": "object",
+      "properties": {
+        "x-has-customfields": {
+          "type": "boolean"
+        },
+        "type": {
+          "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "properties": {
+          "type": "object",
+          "properties": {
+            "accountingBookDetail": {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string"
+                },
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "type": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "replaceAll": {
+              "type": "object",
+              "properties": {
+                "x-samplevalue": {
+                  "type": "boolean"
+                },
+                "type": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "channels": {
+      "type": "object",
+      "properties": {
+        "x-has-customfields": {
+          "type": "boolean"
+        },
+        "title": {
+          "type": "string"
+        },
+        "properties": {
+          "type": "object",
+          "properties": {
+            "tranId": {
+              "type": "object",
+              "properties": {
+                "x-samplevalue": {
+                  "type": "string"
+                },
+                "type": {
+                  "type": "string"
+                }
+              }
+            },
+            "vatRegNum": {
+              "type": "object",
+              "properties": {
+                "x-samplevalue": {
+                  "type": "string"
+                },
+                "type": {
+                  "type": "string"
+                }
+              }
+            },
+            "taxTotal": {
+              "type": "object",
+              "properties": {
+                "x-samplevalue": {
+                  "type": "integer"
+                },
+                "format": {
+                  "type": "string"
+                },
+                "type": {
+                  "type": "string"
+                }
+              }
+            },
+            "taxItem": {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string"
+                }
+              }
+            },
+            "expCostTaxRate1": {
+              "type": "object",
+              "properties": {
+                "x-samplevalue": {
+                  "type": "integer"
+                },
+                "format": {
+                  "type": "string"
+                },
+                "type": {
+                  "type": "string"
+                }
+              }
+            },
+            "itemCostDiscTaxable": {
+              "type": "object",
+              "properties": {
+                "x-samplevalue": {
+                  "type": "boolean"
+                },
+                "type": {
+                  "type": "string"
+                }
+              }
+            },
+            "expCostTaxRate2": {
+              "type": "object",
+              "properties": {
+                "x-samplevalue": {
+                  "type": "integer"
+                },
+                "format": {
+                  "type": "string"
+                },
+                "type": {
+                  "type": "string"
+                }
+              }
+            },
+            "syncPartnerTeams": {
+              "type": "object",
+              "properties": {
+                "x-samplevalue": {
+                  "type": "boolean"
+                },
+                "type": {
+                  "type": "string"
+                }
+              }
+            },
+            "itemCostDiscTax1Amt": {
+              "type": "object",
+              "properties": {
+                "x-samplevalue": {
+                  "type": "integer"
+                },
+                "format": {
+                  "type": "string"
+                },
+                "type": {
+                  "type": "string"
+                }
+              }
+            },
+            "giftCertApplied": {
+              "type": "object",
+              "properties": {
+                "x-samplevalue": {
+                  "type": "integer"
+                },
+                "format": {
+                  "type": "string"
+                },
+                "type": {
+                  "type": "string"
+                }
+              }
+            },
+            "accountingBookDetailList": {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string"
+                }
+              }
+            },
+            "terms": {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string"
+                }
+              }
+            },
+            "timeDiscTax1Amt": {
+              "type": "object",
+              "properties": {
+                "x-samplevalue": {
+                  "type": "integer"
+                },
+                "format": {
+                  "type": "string"
+                },
+                "type": {
+                  "type": "string"
+                }
+              }
+            },
+            "timeDiscPrint": {
+              "type": "object",
+              "properties": {
+                "x-samplevalue": {
+                  "type": "boolean"
+                },
+                "type": {
+                  "type": "string"
+                }
+              }
+            },
+            "fax": {
+              "type": "object",
+              "properties": {
+                "x-samplevalue": {
+                  "type": "string"
+                },
+                "type": {
+                  "type": "string"
+                }
+              }
+            },
+            "vsoeAutoCalc": {
+              "type": "object",
+              "properties": {
+                "x-samplevalue": {
+                  "type": "boolean"
+                },
+                "type": {
+                  "type": "string"
+                }
+              }
+            },
+            "toBeFaxed": {
+              "type": "object",
+              "properties": {
+                "x-samplevalue": {
+                  "type": "boolean"
+                },
+                "type": {
+                  "type": "string"
+                }
+              }
+            },
+            "shippingCost": {
+              "type": "object",
+              "properties": {
+                "x-samplevalue": {
+                  "type": "integer"
+                },
+                "format": {
+                  "type": "string"
+                },
+                "type": {
+                  "type": "string"
+                }
+              }
+            },
+            "itemCostDiscPrint": {
+              "type": "object",
+              "properties": {
+                "x-samplevalue": {
+                  "type": "boolean"
+                },
+                "type": {
+                  "type": "string"
+                }
+              }
+            },
+            "toBePrinted": {
+              "type": "object",
+              "properties": {
+                "x-samplevalue": {
+                  "type": "boolean"
+                },
+                "type": {
+                  "type": "string"
+                }
+              }
+            },
+            "tranIsVsoeBundle": {
+              "type": "object",
+              "properties": {
+                "x-samplevalue": {
+                  "type": "boolean"
+                },
+                "type": {
+                  "type": "string"
+                }
+              }
+            },
+            "timeDiscRate": {
+              "type": "object",
+              "properties": {
+                "x-samplevalue": {
+                  "type": "string"
+                },
+                "type": {
+                  "type": "string"
+                }
+              }
+            },
+            "expCostTaxCode": {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string"
+                }
+              }
+            },
+            "shippingTax2Rate": {
+              "type": "object",
+              "properties": {
+                "x-samplevalue": {
+                  "type": "string"
+                },
+                "type": {
+                  "type": "string"
+                }
+              }
+            },
+            "trackingNumbers": {
+              "type": "object",
+              "properties": {
+                "x-samplevalue": {
+                  "type": "string"
+                },
+                "type": {
+                  "type": "string"
+                }
+              }
+            },
+            "isTaxable": {
+              "type": "object",
+              "properties": {
+                "x-samplevalue": {
+                  "type": "boolean"
+                },
+                "type": {
+                  "type": "string"
+                }
+              }
+            },
+            "externalId": {
+              "type": "object",
+              "properties": {
+                "x-samplevalue": {
+                  "type": "string"
+                },
+                "type": {
+                  "type": "string"
+                }
+              }
+            },
+            "timeTaxCode": {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string"
+                }
+              }
+            },
+            "timeDiscTaxable": {
+              "type": "object",
+              "properties": {
+                "x-samplevalue": {
+                  "type": "boolean"
+                },
+                "type": {
+                  "type": "string"
+                }
+              }
+            },
+            "handlingTax2Rate": {
+              "type": "object",
+              "properties": {
+                "x-samplevalue": {
+                  "type": "string"
+                },
+                "type": {
+                  "type": "string"
+                }
+              }
+            },
+            "taxRate": {
+              "type": "object",
+              "properties": {
+                "x-samplevalue": {
+                  "type": "integer"
+                },
+                "format": {
+                  "type": "string"
+                },
+                "type": {
+                  "type": "string"
+                }
+              }
+            },
+            "syncSalesTeams": {
+              "type": "object",
+              "properties": {
+                "x-samplevalue": {
+                  "type": "boolean"
+                },
+                "type": {
+                  "type": "string"
+                }
+              }
+            },
+            "itemCostDiscRate": {
+              "type": "object",
+              "properties": {
+                "x-samplevalue": {
+                  "type": "string"
+                },
+                "type": {
+                  "type": "string"
+                }
+              }
+            },
+            "timeTaxRate2": {
+              "type": "object",
+              "properties": {
+                "x-samplevalue": {
+                  "type": "integer"
+                },
+                "format": {
+                  "type": "string"
+                },
+                "type": {
+                  "type": "string"
+                }
+              }
+            },
+            "toBeEmailed": {
+              "type": "object",
+              "properties": {
+                "x-samplevalue": {
+                  "type": "boolean"
+                },
+                "type": {
+                  "type": "string"
+                }
+              }
+            },
+            "shipMethod": {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string"
+                }
+              }
+            },
+            "tranDate": {
+              "type": "object",
+              "properties": {
+                "x-samplevalue": {
+                  "type": "string"
+                },
+                "x-mask": {
+                  "type": "string"
+                },
+                "format": {
+                  "type": "string"
+                },
+                "type": {
+                  "type": "string"
+                }
+              }
+            },
+            "tax2Total": {
+              "type": "object",
+              "properties": {
+                "x-samplevalue": {
+                  "type": "integer"
+                },
+                "format": {
+                  "type": "string"
+                },
+                "type": {
+                  "type": "string"
+                }
+              }
+            },
+            "shipIsResidential": {
+              "type": "object",
+              "properties": {
+                "x-samplevalue": {
+                  "type": "boolean"
+                },
+                "type": {
+                  "type": "string"
+                }
+              }
+            },
+            "status": {
+              "type": "object",
+              "properties": {
+                "x-samplevalue": {
+                  "type": "string"
+                },
+                "type": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "terms": {
+      "type": "object",
+      "properties": {
+        "x-has-customfields": {
+          "type": "boolean"
+        },
+        "type": {
+          "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "properties": {
+          "type": "object",
+          "properties": {
+            "internalId": {
+              "type": "object",
+              "properties": {
+                "x-samplevalue": {
+                  "type": "string"
+                },
+                "type": {
+                  "type": "string"
+                }
+              }
+            },
+            "name": {
+              "type": "object",
+              "properties": {
+                "x-samplevalue": {
+                  "type": "string"
+                },
+                "type": {
+                  "type": "string"
+                }
+              }
+            },
+            "externalId": {
+              "type": "object",
+              "properties": {
+                "x-samplevalue": {
+                  "type": "string"
+                },
+                "type": {
+                  "type": "string"
+                }
+              }
+            },
+            "type": {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "shipMethod": {
+      "type": "object",
+      "properties": {
+        "x-has-customfields": {
+          "type": "boolean"
+        },
+        "type": {
+          "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "properties": {
+          "type": "object",
+          "properties": {
+            "internalId": {
+              "type": "object",
+              "properties": {
+                "x-samplevalue": {
+                  "type": "string"
+                },
+                "type": {
+                  "type": "string"
+                }
+              }
+            },
+            "name": {
+              "type": "object",
+              "properties": {
+                "x-samplevalue": {
+                  "type": "string"
+                },
+                "type": {
+                  "type": "string"
+                }
+              }
+            },
+            "externalId": {
+              "type": "object",
+              "properties": {
+                "x-samplevalue": {
+                  "type": "string"
+                },
+                "type": {
+                  "type": "string"
+                }
+              }
+            },
+            "type": {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "accountingBookDetail": {
+      "type": "object",
+      "properties": {
+        "x-has-customfields": {
+          "type": "boolean"
+        },
+        "title": {
+          "type": "string"
+        },
+        "properties": {
+          "type": "object",
+          "properties": {
+            "exchangeRate": {
+              "type": "object",
+              "properties": {
+                "x-samplevalue": {
+                  "type": "integer"
+                },
+                "format": {
+                  "type": "string"
+                },
+                "type": {
+                  "type": "string"
+                }
+              }
+            },
+            "currency": {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string"
+                }
+              }
+            },
+            "accountingBook": {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "expCostTaxCodetype": {
+      "type": "object",
+      "properties": {
+        "x-has-customfields": {
+          "type": "boolean"
+        },
+        "type": {
+          "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "properties": {
+          "type": "object",
+          "properties": {
+            "value": {
+              "type": "object",
+              "properties": {
+                "x-samplevalue": {
+                  "type": "string"
+                },
+                "type": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "currency": {
+      "type": "object",
+      "properties": {
+        "x-has-customfields": {
+          "type": "boolean"
+        },
+        "type": {
+          "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "properties": {
+          "type": "object",
+          "properties": {
+            "internalId": {
+              "type": "object",
+              "properties": {
+                "x-samplevalue": {
+                  "type": "string"
+                },
+                "type": {
+                  "type": "string"
+                }
+              }
+            },
+            "name": {
+              "type": "object",
+              "properties": {
+                "x-samplevalue": {
+                  "type": "string"
+                },
+                "type": {
+                  "type": "string"
+                }
+              }
+            },
+            "externalId": {
+              "type": "object",
+              "properties": {
+                "x-samplevalue": {
+                  "type": "string"
+                },
+                "type": {
+                  "type": "string"
+                }
+              }
+            },
+            "type": {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "accountingBook": {
+      "type": "object",
+      "properties": {
+        "x-has-customfields": {
+          "type": "boolean"
+        },
+        "type": {
+          "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "properties": {
+          "type": "object",
+          "properties": {
+            "internalId": {
+              "type": "object",
+              "properties": {
+                "x-samplevalue": {
+                  "type": "string"
+                },
+                "type": {
+                  "type": "string"
+                }
+              }
+            },
+            "name": {
+              "type": "object",
+              "properties": {
+                "x-samplevalue": {
+                  "type": "string"
+                },
+                "type": {
+                  "type": "string"
+                }
+              }
+            },
+            "externalId": {
+              "type": "object",
+              "properties": {
+                "x-samplevalue": {
+                  "type": "string"
+                },
+                "type": {
+                  "type": "string"
+                }
+              }
+            },
+            "type": {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/test/platform/models/models.js
+++ b/src/test/platform/models/models.js
@@ -1,0 +1,12 @@
+'use strict';
+
+const suite = require('core/suite');
+const cloud = require('core/cloud');
+const payload = require('./assets/payload.json');
+const schema = require('./assets/payload.schema.json');
+
+suite.forPlatform('models', {}, (test) => {
+  it('should generate model schema from payload', () => {
+        return cloud.post('/models/invoices/schema', payload, schema);
+  });
+});


### PR DESCRIPTION
## Highlights
* Model auto generation tests for `POST /models/{objectName}/schema`

## Screenshot
```
asura:churros ramana$ churros test platform/models
sleep: using busy loop fallback


  models
    ✓ should generate model schema from payload (1718ms)


  1 passing (3s)


```

## Reference
* [7775](https://github.com/cloud-elements/soba/pull/7775)
* [US3470](https://rally1.rallydev.com/#/153723136912ud/detail/userstory/178585626984)
