### PR TITLE
RBAC tests round 2

### DIFF
--- a/src/test/platform/organizations/rbac.js
+++ b/src/test/platform/organizations/rbac.js
@@ -102,11 +102,42 @@ suite.forPlatform('Tests privileges restrict API access as expected', test => {
       name: `rbac-formula-instance${tools.random()}`,
     };
 
+    const DEFAULT_STEP = {
+      name: 'step1',
+      type: 'filter',
+      properties: {
+        body: 'done(true);'
+      }
+    };
+
+    const DEFAULT_CONFIG = {
+      name: 'myConfig',
+      key: 'myConfig',
+      type: 'value'
+    };
+
+    const DEFAULT_TRIGGER = {
+      type: 'manual',
+      onSuccess: ['done']
+    };
+
     it('should restrict access to viewing formulas without the viewFormulas privilege', () => {
+      let formula;
       return removePrivilegeIfNecessary('viewFormulas')
         .then(() => cloudWithUser().get(`/formulas`, insufficientPrivilegesValidator))
+        .then(() => cloudWithUser().get(`/formulas/12`, insufficientPrivilegesValidator))
+        .then(() => cloudWithUser().get(`/formulas/12/export`, insufficientPrivilegesValidator))
+        .then(() => cloudWithUser().get(`/formulas/12/triggers/12`, insufficientPrivilegesValidator))
+        .then(() => cloudWithUser().get(`/formulas/12/steps`, insufficientPrivilegesValidator))
+        .then(() => cloudWithUser().get(`/formulas/12/steps/12`, insufficientPrivilegesValidator))
         .then(() => addPrivilegeIfNecessary('viewFormulas'))
-        .then(() => cloudWithUser().get(`/formulas`));
+        .then(() => cloudWithUser().get(`/formulas`))
+        .then(fs => formula = fs.body[0])
+        .then(() => cloudWithUser().get(`/formulas/${formula.id}`))
+        .then(() => cloudWithUser().get(`/formulas/${formula.id}/export`))
+        .then(() => cloudWithUser().get(`/formulas/${formula.id}/triggers/${formula.triggers[0].id}`))
+        .then(() => cloudWithUser().get(`/formulas/${formula.id}/steps`))
+        .then(() => cloudWithUser().get(`/formulas/${formula.id}/steps/${formula.steps[0].id}`));
     });
 
     it('should restrict access to creating, editing, and deleting formulas without the necessary privilege', () => {
@@ -128,13 +159,44 @@ suite.forPlatform('Tests privileges restrict API access as expected', test => {
         .then(() => removePrivilegeIfNecessary('editFormulas'))
         .then(() => cloudWithUser().put(`/formulas/${formulaId}`, DEFAULT_FORMULA, insufficientPrivilegesValidator))
         .then(() => cloudWithUser().patch(`/formulas/${formulaId}`, DEFAULT_FORMULA, insufficientPrivilegesValidator))
+        .then(() => cloudWithUser().put(`/formulas/${formulaId}/upgrade/v3`, null, insufficientPrivilegesValidator))
+        .then(() => cloudWithUser().delete(`/formulas/${formulaId}/upgrade/v3`, insufficientPrivilegesValidator))
+        .then(() => cloudWithUser().post(`/formulas/${formulaId}/triggers`, DEFAULT_TRIGGER, insufficientPrivilegesValidator))
+        .then(() => cloudWithUser().put(`/formulas/${formulaId}/triggers/1`, DEFAULT_TRIGGER, insufficientPrivilegesValidator))
+        .then(() => cloudWithUser().delete(`/formulas/${formulaId}/triggers/1`, insufficientPrivilegesValidator))
+        .then(() => cloudWithUser().post(`/formulas/${formulaId}/steps`, DEFAULT_STEP, insufficientPrivilegesValidator))
+        .then(() => cloudWithUser().put(`/formulas/${formulaId}/steps/1`, DEFAULT_STEP, insufficientPrivilegesValidator))
+        .then(() => cloudWithUser().delete(`/formulas/${formulaId}/steps/1`, insufficientPrivilegesValidator))
+        .then(() => cloudWithUser().post(`/formulas/${formulaId}/configuration`, DEFAULT_CONFIG, insufficientPrivilegesValidator))
+        .then(() => cloudWithUser().put(`/formulas/${formulaId}/configuration/1`, DEFAULT_CONFIG, insufficientPrivilegesValidator))
+        .then(() => cloudWithUser().delete(`/formulas/${formulaId}/configuration/1`, insufficientPrivilegesValidator))
         .then(() => addPrivilegeIfNecessary('editFormulas'))
         .then(() => cloudWithUser().put(`/formulas/${formulaId}`, DEFAULT_FORMULA))
         .then(() => cloudWithUser().patch(`/formulas/${formulaId}`, DEFAULT_FORMULA))
+        .then(() => cloudWithUser().put(`/formulas/${formulaId}/upgrade/v3`, DEFAULT_FORMULA))
+        .then(() => cloudWithUser().delete(`/formulas/${formulaId}/upgrade/v3`, DEFAULT_FORMULA))
+        .then(() => cloudWithUser().post(`/formulas/${formulaId}/triggers`, DEFAULT_TRIGGER))
+        .then(t => cloudWithUser().put(`/formulas/${formulaId}/triggers/${t.body.id}`, DEFAULT_TRIGGER))
+        .then(t => cloudWithUser().delete(`/formulas/${formulaId}/triggers/${t.body.id}`))
+        .then(() => cloudWithUser().post(`/formulas/${formulaId}/steps`, DEFAULT_STEP))
+        .then(s => cloudWithUser().put(`/formulas/${formulaId}/steps/${s.body.id}`, DEFAULT_STEP))
+        .then(s => cloudWithUser().delete(`/formulas/${formulaId}/steps/${s.body.id}`))
+        .then(() => cloudWithUser().post(`/formulas/${formulaId}/configuration`, DEFAULT_CONFIG))
+        .then(c => cloudWithUser().put(`/formulas/${formulaId}/configuration/${c.body.id}`, DEFAULT_CONFIG))
+        .then(c => cloudWithUser().delete(`/formulas/${formulaId}/configuration/${c.body.id}`))
         .then(() => removePrivilegeIfNecessary('createFormulaInstances'))
         .then(() => cloudWithUser().post(`/formulas/${formulaId}/instances`, DEFAULT_FORMULA_INSTANCE, insufficientPrivilegesValidator))
+        .then(fi => cloudWithUser().put(`/formulas/${formulaId}/instances/1`, DEFAULT_FORMULA_INSTANCE, insufficientPrivilegesValidator))
+        .then(fi => cloudWithUser().delete(`/formulas/${formulaId}/instances/1/active`, insufficientPrivilegesValidator))
+        .then(fi => cloudWithUser().put(`/formulas/${formulaId}/instances/1/active`, null, insufficientPrivilegesValidator))
         .then(() => addPrivilegeIfNecessary('createFormulaInstances'))
         .then(() => cloudWithUser().post(`/formulas/${formulaId}/instances`, DEFAULT_FORMULA_INSTANCE))
+        .then(fi => formulaInstanceId = fi.body.id)
+
+        .then(() => cloudWithUser().put(`/formulas/${formulaId}/instances/${formulaInstanceId}`, DEFAULT_FORMULA_INSTANCE))
+        .then(() => cloudWithUser().delete(`/formulas/${formulaId}/instances/${formulaInstanceId}/active`))
+        .then(() => cloudWithUser().put(`/formulas/${formulaId}/instances/${formulaInstanceId}/active`, null))
+        
         .then(() => removePrivilegeIfNecessary('deleteFormulas'))
         .then(() => cloudWithUser().delete(`/formulas/${formulaId}`, insufficientPrivilegesValidator))
         .then(() => addPrivilegeIfNecessary('deleteFormulas'))
@@ -237,7 +299,7 @@ suite.forPlatform('Tests privileges restrict API access as expected', test => {
         //TODO - this fails bc I dont own this element - fix bug
         // .then(() => cloudWithUser().withOptions(opts).get(`/elements/${elementKeyOrId}/parameters`));
         ;
-    }
+    };
 
     const runCUDElementTests = keyOrId => {
       let elementKeyOrId, elementInstanceId, cloneId, resourceId;

--- a/src/test/platform/organizations/rbac.js
+++ b/src/test/platform/organizations/rbac.js
@@ -126,8 +126,10 @@ suite.forPlatform('Tests privileges restrict API access as expected', test => {
         .then(r => formulaId = r.body.id)
         .then(() => removePrivilegeIfNecessary('editFormulas'))
         .then(() => cloudWithUser().put(`/formulas/${formulaId}`, DEFAULT_FORMULA, insufficientPrivilegesValidator))
+        .then(() => cloudWithUser().patch(`/formulas/${formulaId}`, DEFAULT_FORMULA, insufficientPrivilegesValidator))
         .then(() => addPrivilegeIfNecessary('editFormulas'))
         .then(() => cloudWithUser().put(`/formulas/${formulaId}`, DEFAULT_FORMULA))
+        .then(() => cloudWithUser().patch(`/formulas/${formulaId}`, DEFAULT_FORMULA))
         .then(() => removePrivilegeIfNecessary('createFormulaInstances'))
         .then(() => cloudWithUser().post(`/formulas/${formulaId}/instances`, DEFAULT_FORMULA_INSTANCE, insufficientPrivilegesValidator))
         .then(() => addPrivilegeIfNecessary('createFormulaInstances'))
@@ -204,8 +206,10 @@ suite.forPlatform('Tests privileges restrict API access as expected', test => {
     it('should restrict access to viewing common objects without the viewCommonObjects privilege', () => {
       return removePrivilegeIfNecessary('viewCommonObjects')
         .then(() => cloudWithUser().get(`/organizations/objects/definitions`, insufficientPrivilegesValidator))
+        .then(() => cloudWithUser().get(`/accounts/objects/definitions`, insufficientPrivilegesValidator))
         .then(() => addPrivilegeIfNecessary('viewCommonObjects'))
-        .then(() => cloudWithUser().get(`/organizations/objects/definitions`));
+        .then(() => cloudWithUser().get(`/organizations/objects/definitions`))
+        .then(() => cloudWithUser().get(`/accounts/objects/definitions`));
     });
 
     it('should restrict access to creating, editing, and deleting common objects without the proper privileges', () => {
@@ -343,10 +347,16 @@ suite.forPlatform('Tests privileges restrict API access as expected', test => {
 
   context('roles', () => {
     it('should restrict viewing roles if the user does not have the proper privilege for configuring organization roles', () => {
+      let roles;
       return removePrivilegeIfNecessary('configureRoles')
         .then(() => cloudWithUser().get(`/organizations/roles`, insufficientPrivilegesValidator))
+        .then(rs => roles = rs)
+        .then(() => cloudWithUser().put(`/organizations/roles`, {}, insufficientPrivilegesValidator))
+        .then(() => cloudWithUser().put(`/organizations/roles/reset`, null, insufficientPrivilegesValidator))        
         .then(() => addPrivilegeIfNecessary('configureRoles'))
-        .then(() => cloudWithUser().get(`/organizations/roles`));
+        .then(() => cloudWithUser().get(`/organizations/roles`))
+        .then(() => cloudWithUser().put(`/organizations/roles`, roles))
+        .then(() => cloudWithUser().put(`/organizations/roles/reset`));
     });
   });
 });

--- a/src/test/platform/organizations/rbac.js
+++ b/src/test/platform/organizations/rbac.js
@@ -192,11 +192,9 @@ suite.forPlatform('Tests privileges restrict API access as expected', test => {
         .then(() => addPrivilegeIfNecessary('createFormulaInstances'))
         .then(() => cloudWithUser().post(`/formulas/${formulaId}/instances`, DEFAULT_FORMULA_INSTANCE))
         .then(fi => formulaInstanceId = fi.body.id)
-
         .then(() => cloudWithUser().put(`/formulas/${formulaId}/instances/${formulaInstanceId}`, DEFAULT_FORMULA_INSTANCE))
         .then(() => cloudWithUser().delete(`/formulas/${formulaId}/instances/${formulaInstanceId}/active`))
         .then(() => cloudWithUser().put(`/formulas/${formulaId}/instances/${formulaInstanceId}/active`, null))
-        
         .then(() => removePrivilegeIfNecessary('deleteFormulas'))
         .then(() => cloudWithUser().delete(`/formulas/${formulaId}`, insufficientPrivilegesValidator))
         .then(() => addPrivilegeIfNecessary('deleteFormulas'))
@@ -296,7 +294,7 @@ suite.forPlatform('Tests privileges restrict API access as expected', test => {
         .then(() => cloudWithUser().withOptions(opts).get(`/elements/${elementKeyOrId}/resources/${resourceId}/models`))
         .then(() => cloudWithUser().withOptions(opts).get(`/elements/${elementKeyOrId}/hooks`))
         .then(hs => cloudWithUser().withOptions(opts).get(`/elements/${elementKeyOrId}/hooks/123`, sufficientPrivilegesValidator))
-        //TODO - this fails bc I dont own this element - fix bug
+        //TODO - this fails bc I dont own this element - this may or may not be a bug
         // .then(() => cloudWithUser().withOptions(opts).get(`/elements/${elementKeyOrId}/parameters`));
         ;
     };

--- a/src/test/platform/organizations/rbac.js
+++ b/src/test/platform/organizations/rbac.js
@@ -200,52 +200,54 @@ suite.forPlatform('Tests privileges restrict API access as expected', test => {
       swagger: {}
     });
 
-    it('should restrict access to viewing elements without the viewElements privilege', () => {
-      let elementId, resourceId;
+    const runReadElementTests = keyOrId => {
+      let elementKeyOrId, resourceId;
       const opts = { qs: { page: 1, pageSize: 1 } };
+      const fakeIdOrKey = keyOrId === 'key' ? 'key' : 23;
+
       return removePrivilegeIfNecessary('viewElements')
         .then(() => cloudWithUser().withOptions(opts).get(`/elements`, insufficientPrivilegesValidator))
-        .then(() => cloudWithUser().withOptions(opts).get(`/elements/23`, insufficientPrivilegesValidator))
-        .then(() => cloudWithUser().withOptions(opts).get(`/elements/23/export`, insufficientPrivilegesValidator))
-        .then(() => cloudWithUser().withOptions(opts).get(`/elements/23/configuration`, insufficientPrivilegesValidator))
-        .then(() => cloudWithUser().withOptions(opts).get(`/elements/23/resources`, insufficientPrivilegesValidator))
-        .then(() => cloudWithUser().withOptions(opts).get(`/elements/23/resources/123`, insufficientPrivilegesValidator))
-        .then(() => cloudWithUser().withOptions(opts).get(`/elements/23/resources/123/hooks`, insufficientPrivilegesValidator))
-        .then(() => cloudWithUser().withOptions(opts).get(`/elements/23/resources/123/hooks/123`, insufficientPrivilegesValidator))
-        .then(() => cloudWithUser().withOptions(opts).get(`/elements/23/resources/123/parameters`, insufficientPrivilegesValidator))
-        .then(() => cloudWithUser().withOptions(opts).get(`/elements/23/resources/123/models`, insufficientPrivilegesValidator))
-        .then(() => cloudWithUser().withOptions(opts).get(`/elements/23/hooks`, insufficientPrivilegesValidator))
-        .then(() => cloudWithUser().withOptions(opts).get(`/elements/23/hooks/123`, insufficientPrivilegesValidator))
-        .then(() => cloudWithUser().withOptions(opts).get(`/elements/23/parameters`, insufficientPrivilegesValidator))
+        .then(() => cloudWithUser().withOptions(opts).get(`/elements/${fakeIdOrKey}`, insufficientPrivilegesValidator))
+        .then(() => cloudWithUser().withOptions(opts).get(`/elements/${fakeIdOrKey}/export`, insufficientPrivilegesValidator))
+        .then(() => cloudWithUser().withOptions(opts).get(`/elements/${fakeIdOrKey}/configuration`, insufficientPrivilegesValidator))
+        .then(() => cloudWithUser().withOptions(opts).get(`/elements/${fakeIdOrKey}/resources`, insufficientPrivilegesValidator))
+        .then(() => cloudWithUser().withOptions(opts).get(`/elements/${fakeIdOrKey}/resources/123`, insufficientPrivilegesValidator))
+        .then(() => cloudWithUser().withOptions(opts).get(`/elements/${fakeIdOrKey}/resources/123/hooks`, insufficientPrivilegesValidator))
+        .then(() => cloudWithUser().withOptions(opts).get(`/elements/${fakeIdOrKey}/resources/123/hooks/123`, insufficientPrivilegesValidator))
+        .then(() => cloudWithUser().withOptions(opts).get(`/elements/${fakeIdOrKey}/resources/123/parameters`, insufficientPrivilegesValidator))
+        .then(() => cloudWithUser().withOptions(opts).get(`/elements/${fakeIdOrKey}/resources/123/models`, insufficientPrivilegesValidator))
+        .then(() => cloudWithUser().withOptions(opts).get(`/elements/${fakeIdOrKey}/hooks`, insufficientPrivilegesValidator))
+        .then(() => cloudWithUser().withOptions(opts).get(`/elements/${fakeIdOrKey}/hooks/123`, insufficientPrivilegesValidator))
+        .then(() => cloudWithUser().withOptions(opts).get(`/elements/${fakeIdOrKey}/parameters`, insufficientPrivilegesValidator))
         .then(() => addPrivilegeIfNecessary('viewElements'))
         .then(() => cloudWithUser().withOptions(opts).get(`/elements`))
-        .then(elements => elementId = elements.body[0].id)
-        .then(() => cloudWithUser().withOptions(opts).get(`/elements/${elementId}`))
-        .then(() => cloudWithUser().withOptions(opts).get(`/elements/${elementId}/export`))
-        .then(() => cloudWithUser().withOptions(opts).get(`/elements/${elementId}/configuration`))
-        .then(() => cloudWithUser().withOptions(opts).get(`/elements/${elementId}/resources`))
+        .then(elements => elementKeyOrId = elements.body[0][keyOrId])
+        .then(() => cloudWithUser().withOptions(opts).get(`/elements/${elementKeyOrId}`))
+        .then(() => cloudWithUser().withOptions(opts).get(`/elements/${elementKeyOrId}/export`))
+        .then(() => cloudWithUser().withOptions(opts).get(`/elements/${elementKeyOrId}/configuration`))
+        .then(() => cloudWithUser().withOptions(opts).get(`/elements/${elementKeyOrId}/resources`))
         .then(resources => resourceId = resources.body[0].id)
-        .then(() => cloudWithUser().withOptions(opts).get(`/elements/${elementId}/resources/${resourceId}`))
-        .then(() => cloudWithUser().withOptions(opts).get(`/elements/${elementId}/resources/${resourceId}/hooks`))
-        .then(() => cloudWithUser().withOptions(opts).get(`/elements/${elementId}/resources/${resourceId}/hooks/123`, sufficientPrivilegesValidator))
-        .then(() => cloudWithUser().withOptions(opts).get(`/elements/${elementId}/resources/${resourceId}/parameters`))
-        .then(() => cloudWithUser().withOptions(opts).get(`/elements/${elementId}/resources/${resourceId}/models`))
-        .then(() => cloudWithUser().withOptions(opts).get(`/elements/${elementId}/hooks`))
-        .then(hs => cloudWithUser().withOptions(opts).get(`/elements/${elementId}/hooks/123`, sufficientPrivilegesValidator))
+        .then(() => cloudWithUser().withOptions(opts).get(`/elements/${elementKeyOrId}/resources/${resourceId}`))
+        .then(() => cloudWithUser().withOptions(opts).get(`/elements/${elementKeyOrId}/resources/${resourceId}/hooks`))
+        .then(() => cloudWithUser().withOptions(opts).get(`/elements/${elementKeyOrId}/resources/${resourceId}/hooks/123`, sufficientPrivilegesValidator))
+        .then(() => cloudWithUser().withOptions(opts).get(`/elements/${elementKeyOrId}/resources/${resourceId}/parameters`))
+        .then(() => cloudWithUser().withOptions(opts).get(`/elements/${elementKeyOrId}/resources/${resourceId}/models`))
+        .then(() => cloudWithUser().withOptions(opts).get(`/elements/${elementKeyOrId}/hooks`))
+        .then(hs => cloudWithUser().withOptions(opts).get(`/elements/${elementKeyOrId}/hooks/123`, sufficientPrivilegesValidator))
         //TODO - this fails bc I dont own this element - fix bug
-        // .then(() => cloudWithUser().withOptions(opts).get(`/elements/${elementId}/parameters`));
+        // .then(() => cloudWithUser().withOptions(opts).get(`/elements/${elementKeyOrId}/parameters`));
         ;
-    });
+    }
 
-    it('should restrict access to creating, editing, and deleting an element without the editElements privilege', () => {
-      let elementId, elementInstanceId, cloneId, resourceId;
+    const runCUDElementTests = keyOrId => {
+      let elementKeyOrId, elementInstanceId, cloneId, resourceId;
       const cleanup = () => {
         if (!R.isNil(elementInstanceId)) {
           cloudWithUser().delete(`/instances/${elementInstanceId}`, R.always(true));
         }
 
-        if (!R.isNil(elementId)) {
-          cloudWithUser().delete(`/elements/${elementId}`, R.always(true));
+        if (!R.isNil(elementKeyOrId)) {
+          cloudWithUser().delete(`/elements/${elementKeyOrId}`, R.always(true));
         }
 
         if (!R.isNil(cloneId)) {
@@ -253,83 +255,102 @@ suite.forPlatform('Tests privileges restrict API access as expected', test => {
         }
       };
 
+      const fakeIdOrKey = keyOrId === 'key' ? 'key' : 23;
+
       // create without priv
       return removePrivilegeIfNecessary('createElements')
         .then(() => cloudWithUser().post(`/elements`, DEFAULT_ELEMENT(), insufficientPrivilegesValidator))
-        .then(() => cloudWithUser().post(`/elements/23/clone`, null, insufficientPrivilegesValidator))
+        .then(() => cloudWithUser().post(`/elements/${fakeIdOrKey}/clone`, null, insufficientPrivilegesValidator))
         // create with priv      
         .then(() => addPrivilegeIfNecessary('createElements'), {}, insufficientPrivilegesValidator)
         .then(() => cloudWithUser().post(`/elements`, DEFAULT_ELEMENT()))
-        .then(r => elementId = r.body.id)        
-        .then(() => cloudWithUser().post(`/elements/${elementId}/clone`, null, sufficientPrivilegesValidator))
-        .then(r => cloneId = r.body.id)
+        .then(r => elementKeyOrId = r.body[keyOrId])      
+        .then(() => console.log('element key or id: ' + elementKeyOrId))  
+        .then(() => cloudWithUser().post(`/elements/${elementKeyOrId}/clone`, null, sufficientPrivilegesValidator))
+        .then(r => cloneId = r.body[keyOrId])
         // edits without priv
         .then(() => removePrivilegeIfNecessary('editElements'))
-        .then(() => cloudWithUser().put(`/elements/${elementId}`, DEFAULT_ELEMENT(), insufficientPrivilegesValidator))
-        .then(() => cloudWithUser().post(`/elements/${elementId}/configuration`, DEFAULT_ELEMENT_CONFIG(), insufficientPrivilegesValidator))
-        .then(() => cloudWithUser().put(`/elements/${elementId}/configuration/1`, DEFAULT_ELEMENT_CONFIG(), insufficientPrivilegesValidator))
-        .then(() => cloudWithUser().delete(`/elements/${elementId}/configuration/1`, insufficientPrivilegesValidator))
-        .then(() => cloudWithUser().post(`/elements/${elementId}/resources`, DEFAULT_ELEMENT_RESOURCE(), insufficientPrivilegesValidator))
-        .then(() => cloudWithUser().put(`/elements/${elementId}/resources/1`, DEFAULT_ELEMENT_RESOURCE(), insufficientPrivilegesValidator))
-        .then(() => cloudWithUser().delete(`/elements/${elementId}/resources/1`, insufficientPrivilegesValidator))  
-        .then(() => cloudWithUser().post(`/elements/${elementId}/resources/1/hooks`, DEFAULT_ELEMENT_HOOK(), insufficientPrivilegesValidator))
-        .then(() => cloudWithUser().put(`/elements/${elementId}/resources/1/hooks/1`, DEFAULT_ELEMENT_HOOK(), insufficientPrivilegesValidator))
-        .then(() => cloudWithUser().delete(`/elements/${elementId}/resources/1/hooks/1`, insufficientPrivilegesValidator))  
-        .then(() => cloudWithUser().post(`/elements/${elementId}/resources/1/parameters`, DEFAULT_ELEMENT_PARAMETER(), insufficientPrivilegesValidator))
-        .then(() => cloudWithUser().put(`/elements/${elementId}/resources/1/parameters/1`, DEFAULT_ELEMENT_PARAMETER(), insufficientPrivilegesValidator))
-        .then(() => cloudWithUser().delete(`/elements/${elementId}/resources/1/parameters/1`, insufficientPrivilegesValidator)) 
-        .then(() => cloudWithUser().post(`/elements/${elementId}/resources/1/models`, DEFAULT_ELEMENT_MODELS(), insufficientPrivilegesValidator))
-        .then(() => cloudWithUser().put(`/elements/${elementId}/resources/1/models`, DEFAULT_ELEMENT_MODELS(), insufficientPrivilegesValidator))
-        .then(() => cloudWithUser().delete(`/elements/${elementId}/resources/1/models`, insufficientPrivilegesValidator)) 
-        .then(() => cloudWithUser().post(`/elements/${elementId}/hooks`, DEFAULT_ELEMENT_HOOK(), insufficientPrivilegesValidator))
-        .then(() => cloudWithUser().put(`/elements/${elementId}/hooks/1`, DEFAULT_ELEMENT_HOOK(), insufficientPrivilegesValidator))
-        .then(() => cloudWithUser().delete(`/elements/${elementId}/hooks/1`, insufficientPrivilegesValidator))  
-        .then(() => cloudWithUser().post(`/elements/${elementId}/parameters`, DEFAULT_ELEMENT_PARAMETER(), insufficientPrivilegesValidator))
-        .then(() => cloudWithUser().put(`/elements/${elementId}/parameters/1`, DEFAULT_ELEMENT_PARAMETER(), insufficientPrivilegesValidator))
-        .then(() => cloudWithUser().delete(`/elements/${elementId}/parameters/1`, insufficientPrivilegesValidator))
-        .then(() => cloudWithUser().delete(`/elements/${elementId}/active`, insufficientPrivilegesValidator))
-        .then(() => cloudWithUser().put(`/elements/${elementId}/active`, null, insufficientPrivilegesValidator))
+        .then(() => cloudWithUser().put(`/elements/${elementKeyOrId}`, DEFAULT_ELEMENT(), insufficientPrivilegesValidator))
+        .then(() => cloudWithUser().post(`/elements/${elementKeyOrId}/configuration`, DEFAULT_ELEMENT_CONFIG(), insufficientPrivilegesValidator))
+        .then(() => cloudWithUser().put(`/elements/${elementKeyOrId}/configuration/key`, DEFAULT_ELEMENT_CONFIG(), insufficientPrivilegesValidator))
+        .then(() => cloudWithUser().delete(`/elements/${elementKeyOrId}/configuration/key`, insufficientPrivilegesValidator))
+        .then(() => cloudWithUser().post(`/elements/${elementKeyOrId}/resources`, DEFAULT_ELEMENT_RESOURCE(), insufficientPrivilegesValidator))
+        .then(() => cloudWithUser().put(`/elements/${elementKeyOrId}/resources/1`, DEFAULT_ELEMENT_RESOURCE(), insufficientPrivilegesValidator))
+        .then(() => cloudWithUser().delete(`/elements/${elementKeyOrId}/resources/1`, insufficientPrivilegesValidator))  
+        .then(() => cloudWithUser().post(`/elements/${elementKeyOrId}/resources/1/hooks`, DEFAULT_ELEMENT_HOOK(), insufficientPrivilegesValidator))
+        .then(() => cloudWithUser().put(`/elements/${elementKeyOrId}/resources/1/hooks/1`, DEFAULT_ELEMENT_HOOK(), insufficientPrivilegesValidator))
+        .then(() => cloudWithUser().delete(`/elements/${elementKeyOrId}/resources/1/hooks/1`, insufficientPrivilegesValidator))  
+        .then(() => cloudWithUser().post(`/elements/${elementKeyOrId}/resources/1/parameters`, DEFAULT_ELEMENT_PARAMETER(), insufficientPrivilegesValidator))
+        .then(() => cloudWithUser().put(`/elements/${elementKeyOrId}/resources/1/parameters/1`, DEFAULT_ELEMENT_PARAMETER(), insufficientPrivilegesValidator))
+        .then(() => cloudWithUser().delete(`/elements/${elementKeyOrId}/resources/1/parameters/1`, insufficientPrivilegesValidator)) 
+        .then(() => cloudWithUser().post(`/elements/${elementKeyOrId}/resources/1/models`, DEFAULT_ELEMENT_MODELS(), insufficientPrivilegesValidator))
+        .then(() => cloudWithUser().put(`/elements/${elementKeyOrId}/resources/1/models`, DEFAULT_ELEMENT_MODELS(), insufficientPrivilegesValidator))
+        .then(() => cloudWithUser().delete(`/elements/${elementKeyOrId}/resources/1/models`, insufficientPrivilegesValidator)) 
+        .then(() => cloudWithUser().post(`/elements/${elementKeyOrId}/hooks`, DEFAULT_ELEMENT_HOOK(), insufficientPrivilegesValidator))
+        .then(() => cloudWithUser().put(`/elements/${elementKeyOrId}/hooks/1`, DEFAULT_ELEMENT_HOOK(), insufficientPrivilegesValidator))
+        .then(() => cloudWithUser().delete(`/elements/${elementKeyOrId}/hooks/1`, insufficientPrivilegesValidator))  
+        .then(() => cloudWithUser().post(`/elements/${elementKeyOrId}/parameters`, DEFAULT_ELEMENT_PARAMETER(), insufficientPrivilegesValidator))
+        .then(() => cloudWithUser().put(`/elements/${elementKeyOrId}/parameters/1`, DEFAULT_ELEMENT_PARAMETER(), insufficientPrivilegesValidator))
+        .then(() => cloudWithUser().delete(`/elements/${elementKeyOrId}/parameters/1`, insufficientPrivilegesValidator))
+        .then(() => cloudWithUser().delete(`/elements/${elementKeyOrId}/active`, insufficientPrivilegesValidator))
+        .then(() => cloudWithUser().put(`/elements/${elementKeyOrId}/active`, null, insufficientPrivilegesValidator))
         // edits w priv     
         .then(() => addPrivilegeIfNecessary('editElements'))
-        .then(() => cloudWithUser().put(`/elements/${elementId}`, DEFAULT_ELEMENT()))
-        .then(() => cloudWithUser().post(`/elements/${elementId}/configuration`, DEFAULT_ELEMENT_CONFIG()))
-        .then(c => cloudWithUser().put(`/elements/${elementId}/configuration/${c.body.key}`, DEFAULT_ELEMENT_CONFIG()))
-        .then(c => cloudWithUser().delete(`/elements/${elementId}/configuration/${c.body.key}`))  
-        .then(() => cloudWithUser().post(`/elements/${elementId}/resources`, DEFAULT_ELEMENT_RESOURCE()))
+        .then(() => cloudWithUser().put(`/elements/${elementKeyOrId}`, DEFAULT_ELEMENT()))
+        .then(() => cloudWithUser().post(`/elements/${elementKeyOrId}/configuration`, DEFAULT_ELEMENT_CONFIG()))
+        .then(c => cloudWithUser().put(`/elements/${elementKeyOrId}/configuration/${c.body.key}`, DEFAULT_ELEMENT_CONFIG()))
+        .then(c => cloudWithUser().delete(`/elements/${elementKeyOrId}/configuration/${c.body.key}`))  
+        .then(() => cloudWithUser().post(`/elements/${elementKeyOrId}/resources`, DEFAULT_ELEMENT_RESOURCE()))
         .then(r => resourceId = r.body.id)
-        .then(() => cloudWithUser().put(`/elements/${elementId}/resources/${resourceId}`, DEFAULT_ELEMENT_RESOURCE()))
-        .then(() => cloudWithUser().post(`/elements/${elementId}/resources/${resourceId}/hooks`, DEFAULT_ELEMENT_HOOK()))
-        .then(h => cloudWithUser().put(`/elements/${elementId}/resources/${resourceId}/hooks/${h.body.id}`, DEFAULT_ELEMENT_HOOK()))
-        .then(h => cloudWithUser().delete(`/elements/${elementId}/resources/${resourceId}/hooks/${h.body.id}`))  
-        .then(() => cloudWithUser().post(`/elements/${elementId}/resources/${resourceId}/parameters`, DEFAULT_ELEMENT_PARAMETER()))
-        .then(p => cloudWithUser().put(`/elements/${elementId}/resources/${resourceId}/parameters/${p.body.id}`, DEFAULT_ELEMENT_PARAMETER()))
-        .then(p => cloudWithUser().delete(`/elements/${elementId}/resources/${resourceId}/parameters/${p.body.id}`)) 
-        .then(() => cloudWithUser().post(`/elements/${elementId}/resources/${resourceId}/models`, DEFAULT_ELEMENT_MODELS()))
-        .then(() => cloudWithUser().put(`/elements/${elementId}/resources/${resourceId}/models`, DEFAULT_ELEMENT_MODELS()))
-        .then(() => cloudWithUser().delete(`/elements/${elementId}/resources/${resourceId}/models`)) 
-        .then(() => cloudWithUser().delete(`/elements/${elementId}/resources/${resourceId}`))
-        .then(() => cloudWithUser().post(`/elements/${elementId}/hooks`, DEFAULT_ELEMENT_HOOK()))
-        .then(h => cloudWithUser().put(`/elements/${elementId}/hooks/${h.body.id}`, DEFAULT_ELEMENT_HOOK()))
-        .then(h => cloudWithUser().delete(`/elements/${elementId}/hooks/${h.body.id}`))
-        .then(() => cloudWithUser().post(`/elements/${elementId}/parameters`, DEFAULT_ELEMENT_PARAMETER()))
-        .then(p => cloudWithUser().put(`/elements/${elementId}/parameters/${p.body.id}`, DEFAULT_ELEMENT_PARAMETER()))
-        .then(p => cloudWithUser().delete(`/elements/${elementId}/parameters/${p.body.id}`))
-        .then(p => cloudWithUser().delete(`/elements/${elementId}/active`))
-        .then(p => cloudWithUser().put(`/elements/${elementId}/active`, null, sufficientPrivilegesValidator))
+        .then(() => cloudWithUser().put(`/elements/${elementKeyOrId}/resources/${resourceId}`, DEFAULT_ELEMENT_RESOURCE()))
+        .then(() => cloudWithUser().post(`/elements/${elementKeyOrId}/resources/${resourceId}/hooks`, DEFAULT_ELEMENT_HOOK()))
+        .then(h => cloudWithUser().put(`/elements/${elementKeyOrId}/resources/${resourceId}/hooks/${h.body.id}`, DEFAULT_ELEMENT_HOOK()))
+        .then(h => cloudWithUser().delete(`/elements/${elementKeyOrId}/resources/${resourceId}/hooks/${h.body.id}`))  
+        .then(() => cloudWithUser().post(`/elements/${elementKeyOrId}/resources/${resourceId}/parameters`, DEFAULT_ELEMENT_PARAMETER()))
+        .then(p => cloudWithUser().put(`/elements/${elementKeyOrId}/resources/${resourceId}/parameters/${p.body.id}`, DEFAULT_ELEMENT_PARAMETER()))
+        .then(p => cloudWithUser().delete(`/elements/${elementKeyOrId}/resources/${resourceId}/parameters/${p.body.id}`)) 
+        .then(() => cloudWithUser().post(`/elements/${elementKeyOrId}/resources/${resourceId}/models`, DEFAULT_ELEMENT_MODELS()))
+        .then(() => cloudWithUser().put(`/elements/${elementKeyOrId}/resources/${resourceId}/models`, DEFAULT_ELEMENT_MODELS()))
+        .then(() => cloudWithUser().delete(`/elements/${elementKeyOrId}/resources/${resourceId}/models`)) 
+        .then(() => cloudWithUser().delete(`/elements/${elementKeyOrId}/resources/${resourceId}`))
+        .then(() => cloudWithUser().post(`/elements/${elementKeyOrId}/hooks`, DEFAULT_ELEMENT_HOOK()))
+        .then(h => cloudWithUser().put(`/elements/${elementKeyOrId}/hooks/${h.body.id}`, DEFAULT_ELEMENT_HOOK()))
+        .then(h => cloudWithUser().delete(`/elements/${elementKeyOrId}/hooks/${h.body.id}`))
+        .then(() => cloudWithUser().post(`/elements/${elementKeyOrId}/parameters`, DEFAULT_ELEMENT_PARAMETER()))
+        .then(p => cloudWithUser().put(`/elements/${elementKeyOrId}/parameters/${p.body.id}`, DEFAULT_ELEMENT_PARAMETER()))
+        .then(p => cloudWithUser().delete(`/elements/${elementKeyOrId}/parameters/${p.body.id}`))
+        .then(p => cloudWithUser().delete(`/elements/${elementKeyOrId}/active`))
+        .then(p => cloudWithUser().put(`/elements/${elementKeyOrId}/active`, null, sufficientPrivilegesValidator))
         // delete without priv
         .then(() => removePrivilegeIfNecessary('deleteElements'))
-        .then(() => cloudWithUser().delete(`/elements/${elementId}`, insufficientPrivilegesValidator))
+        .then(() => cloudWithUser().delete(`/elements/${elementKeyOrId}`, insufficientPrivilegesValidator))
         // instances without priv
         .then(() => removePrivilegeIfNecessary('createElementInstances'))
-        .then(() => cloudWithUser().post(`/elements/${elementId}/instances`, DEFAULT_ELEMENT_INSTANCE(), insufficientPrivilegesValidator))
-        .then(() => cloudWithUser().put(`/elements/${elementId}/instances/12`, DEFAULT_ELEMENT_INSTANCE(), insufficientPrivilegesValidator))
+        .then(() => cloudWithUser().post(`/elements/${elementKeyOrId}/instances`, DEFAULT_ELEMENT_INSTANCE(), insufficientPrivilegesValidator))
+        .then(() => cloudWithUser().put(`/elements/${elementKeyOrId}/instances/12`, DEFAULT_ELEMENT_INSTANCE(), insufficientPrivilegesValidator))
         // instances with priv
         .then(() => addPrivilegeIfNecessary('createElementInstances'))
-        .then(() => cloudWithUser().post(`/elements/${elementId}/instances`, DEFAULT_ELEMENT_INSTANCE()))
-        .then(i => cloudWithUser().put(`/elements/${elementId}/instances/${i.body.id}`, DEFAULT_ELEMENT_INSTANCE()))
+        .then(() => cloudWithUser().post(`/elements/${elementKeyOrId}/instances`, DEFAULT_ELEMENT_INSTANCE()))
+        .then(i => cloudWithUser().put(`/elements/${elementKeyOrId}/instances/${i.body.id}`, DEFAULT_ELEMENT_INSTANCE()))
         // delete with priv
         .then(() => addPrivilegeIfNecessary('deleteElements'))
         .then(cleanup);
+    };
+
+    it('should restrict access to viewing elements by id without the viewElements privilege', () => {
+      return runReadElementTests('id');
+    });
+
+    it('should restrict access to viewing elements by key without the viewElements privilege', () => {
+      return runReadElementTests('key');
+    });
+
+    it('should restrict access to creating, editing, and deleting an element by id without the editElements privilege', () => {
+      return runCUDElementTests('id');
+    });
+
+    it('should restrict access to creating, editing, and deleting an element by key without the editElements privilege', () => {
+      return runCUDElementTests('key');
     });
   });
 


### PR DESCRIPTION
## Highlights
* More detailed RBAC privileges tests


### Added privilege tests for the following resources/APIs:
**roles** (/organizations/roles, /org/users/id/roles)

- put /organizations/roles/reset
- put /organizations/roles

**common objects**

- get /accounts/objects/definitions

**elements**

- clone
- resources
- parameters **found bug in read
- configuration
- hooks
- active
- resource parameters
- resource models
- resource hooks
- instances

**formulas**

- PATCH formulas
- triggers
- steps
- configs
- instances (updates)

## Related PRs
* https://github.com/cloud-elements/soba/pull/7836

## Closes
* [US5047](https://rally1.rallydev.com/#/144349238268d/detail/userstory/182651219456)