### PR TITLE
Added tests for the OneDriveV2 element for root and Documents folder contents

### DIFF
--- a/src/test/elements/onedrivev2/folders.js
+++ b/src/test/elements/onedrivev2/folders.js
@@ -77,4 +77,21 @@ suite.forElement('documents', 'folders', (test) => {
       .then(r => cloud.delete(`${test.api}/${id}`));
   });
 
+  it('should allow GET /folders/contents for root folder', () => {
+    let path = "/";
+    let query = { path: path };
+    return cloud.withOptions({ qs: query }).get("/hubs/documents/folders/contents")
+      .then(r => {
+        expect(r).to.have.statusCode(200);
+      });
+  });
+
+  it('should allow GET /folders/contents for Documents folder', () => {
+    let path = "/Documents";
+    let query = { path: path };
+    return cloud.withOptions({ qs: query }).get("/hubs/documents/folders/contents")
+      .then(r => {
+        expect(r).to.have.statusCode(200);
+      });
+  });
 });


### PR DESCRIPTION
## Highlights
* The `GET /folders/contents?path=%2F` and `GET /folders/contents?path=%2FDocuments` APIs were failing for Total Jobs for the OneDriveV2 element due to a soba class loader issue that was seen only in the EU production environment.
* Added tests for the above APIs

## Screenshot
![image](https://user-images.githubusercontent.com/3017448/34232806-53aebb06-e59f-11e7-9af2-3cedd435fc57.png)

## Reference
* [SOBA](Link to SOBA or Other PR for which tests were written, when applicable)
* [RALLY- #DE619] https://rally1.rallydev.com/slm/detail/df/184793607740

## Closes
* Closes #DE619
