### PR TITLE
Enhanced OneDrive with revisions API

### DIFF
--- a/src/test/elements/onedrivev2/files.js
+++ b/src/test/elements/onedrivev2/files.js
@@ -6,6 +6,7 @@ const cloud = require('core/cloud');
 
 suite.forElement('documents', 'files', (test) => {
   let path = __dirname + '/assets/brady.jpg';
+  let fileId,filePath,revisionId;
   let query = { path: `/brady-${tools.random()}.jpg` };
 
   const fileWrap = (cb) => {
@@ -71,4 +72,26 @@ suite.forElement('documents', 'files', (test) => {
 
     return fileWrap(cb);
   });
+
+
+     before(() => cloud.withOptions({ qs : { path: `/brady-${tools.randomStr('abcdefghijklmnopqrstuvwxyz1234567890', 10)}.jpg` } }).postFile(test.api, path)
+     .then(r => {
+       fileId = r.body.id;
+       filePath = r.body.path;
+     }));
+
+     after(() => cloud.delete(`${test.api}/${fileId}`));
+
+     it('it should allow RS for documents/files/:id/revisions', () => {
+         return cloud.get(`${test.api}/${fileId}/revisions`)
+         .then(r => revisionId = r.body[0].id)
+         .then(() => cloud.get(`${test.api}/${fileId}/revisions/${revisionId}`));
+     });
+
+    it('it should allow RS for documents/files/revisions by path', () => {
+         return cloud.withOptions({ qs: { path : `${filePath}` } }).get(`${test.api}/revisions`)
+         .then(r => revisionId = r.body[0].id)
+         .then(() => cloud.withOptions({ qs: { path : `${filePath}` } }).get(`${test.api}/revisions/${revisionId}`));
+     });
+
 });


### PR DESCRIPTION
## Highlights
* `GET /files/:id/revisions`
* `GET /files/:id/revisions/:revisionId`
* `GET /files/revisions`
* `GET /files/revisions/:revisionId`

## Non-customer Highlights
* `GET /files/:id/revisions`  (List all revisions by file Id.)
* `GET /files/:id/revisions/:revisionId` (Retrieve revision by file Id.)
* `GET /files/revisions`  (List all revisions by file Path.)
* `GET /files/revisions/:revisionId` (Retrieve revision by file Path.)

## Checklist
* [x] applicable churros tests are still passing
* [x] includes a dbdeploy script that is backward-incompatible with one previous Soba minor version

## Unit-test cases:
Sr No. | Test Case | Status
-- | -- | --
1 | Tested GET operations manually | Passed
2 | Tested API's through Churros | Passed
3 | Verify that documentation is loading | Passed
4 | Verify that model structure is exactly the same as actual request and response of the API | Passed

## Screenshot

<img width="944" alt="screen shot 2017-12-21 at 12 57 52 pm" src="https://user-images.githubusercontent.com/26943831/34270689-a3d47cce-e64e-11e7-989c-371d330adc41.png">

## Related PRs
[SOBA](https://github.com/cloud-elements/soba/pull/7817)

## Closes
[Rally](https://rally1.rallydev.com/#/144349237612d/detail/userstory/175563857700)