### PR TITLE
Added /users API  of Abode-Sign 

### DIFF
--- a/src/test/elements/adobe-esign/users.js
+++ b/src/test/elements/adobe-esign/users.js
@@ -3,6 +3,8 @@
 const suite = require('core/suite');
 const cloud = require('core/cloud');
 const tools = require('core/tools');
+const chakram = require('chakram');
+const expect = chakram.expect; 
 
 const createUsers = () => ({
   "lastName": tools.random(),
@@ -30,6 +32,13 @@ suite.forElement('esignature', 'users', (test) => {
     test.withJson(createUsers()).should.supportCrs();
   */
   test.withJson(createUsers()).should.supportSr();
+ test.withName(`should support searching ${test.api} by email`)
+    .withOptions({ qs: { where: `email ='greg@cloud-elements.com'` } })
+    .withValidation((r) => {
+      expect(r).to.have.statusCode(200);
+      const validValues = r.body.filter(obj => obj.Comp_Name = 'greg@cloud-elements.com');
+      expect(validValues.length).to.equal(r.body.length);
+    }).should.return200OnGet();
   it(`should allow PUT for ${test.api}/{userId}`, () => {
     let userId;
     return cloud.get(test.api)


### PR DESCRIPTION
## Highlights
* Added Search test in /users API of Abode-Sign
## Examples
If applicable, please include any images, GIFs, etc. showing up these changes

## Screenshot
![adobechurros1](https://user-images.githubusercontent.com/22440353/34351585-a19ae60c-ea43-11e7-8976-573859a83474.JPG)

## Reference
* [SOBA](https://github.com/cloud-elements/soba/pull/7830)
* [CircleCI](Link to SOBA PR adding Tests to `circle.yml`, when applicable)
* [churros-sauce](Link to Associated Churros-sauce PR, when applicable)
* [RALLY-#${DE-558}](https://rally1.rallydev.com/#/144349237612d/detail/defect/181105993840)

## Closes
* Closes #${[DE-558](https://rally1.rallydev.com/#/144349237612d/detail/defect/181105993840)}
