### PR TITLE
Updated Intacct tests

### DIFF
--- a/src/test/elements/assets/object.definitions.json
+++ b/src/test/elements/assets/object.definitions.json
@@ -1025,6 +1025,15 @@
       "type": "string"
     }]
   },
+  "bills-payments": {
+    "fields": [{
+      "path": "idTransformed",
+      "type": "string"
+    },{
+      "path": "id",
+      "type": "string"
+    }]
+  },
   "projects": {
     "fields": [{
       "path": "idTransformed",

--- a/src/test/elements/intacct/assets/bill-payments.json
+++ b/src/test/elements/intacct/assets/bill-payments.json
@@ -1,0 +1,14 @@
+{
+  "financialentity": "CHK-WFB0004",
+  "vendorid": "V100",
+  "paymentmethod": "Cash",
+  "paymentdate": "10/25/2010",
+  "appymtdetails":
+    {
+      "appymtdetail": {
+        "trx_paymentamount": "50",
+        "recordkey": "82"
+      }
+    }
+
+}

--- a/src/test/elements/intacct/assets/transformations.json
+++ b/src/test/elements/intacct/assets/transformations.json
@@ -1,200 +1,163 @@
 {
-"contacts": {
-  "vendorName": "",
-  "fields": [
-    {
+  "contacts": {
+    "vendorName": "contacts",
+    "fields": [{
       "path": "id",
       "vendorPath": "contactid"
-    }
-  ]
-},
-"departments": {
-  "vendorName": "",
-  "fields": [
-    {
+    }]
+  },
+  "departments": {
+    "vendorName": "departments",
+    "fields": [{
       "path": "id",
       "vendorPath": "departmentid"
-    }
-  ]
-},
-"employees": {
-  "vendorName": "",
-  "fields": [
-    {
+    }]
+  },
+  "employees": {
+    "vendorName": "employees",
+    "fields": [{
       "path": "id",
       "vendorPath": "employeeid"
-    }
-  ]
-},
-"journals": {
-  "vendorName": "",
-  "fields": [
-    {
+    }]
+  },
+  "journals": {
+    "vendorName": "journals",
+    "fields": [{
       "path": "id",
       "vendorPath": "journalid"
-    }
-  ]
-},
-"locations": {
-  "vendorName": "",
-  "fields": [
-    {
+    }]
+  },
+  "locations": {
+    "vendorName": "locations",
+    "fields": [{
       "path": "id",
       "vendorPath": "locationid"
-    }
-  ]
-},
-"classes": {
-  "vendorName": "",
-  "fields": [
-    {
+    }]
+  },
+  "classes": {
+    "vendorName": "classes",
+    "fields": [{
       "path": "id",
       "vendorPath": "classid"
-    }
-  ]
-},
-"customers": {
-  "vendorName": "",
-  "fields": [
-    {
+    }]
+  },
+  "customers": {
+    "vendorName": "customers",
+    "fields": [{
       "path": "id",
       "vendorPath": "customerid"
-    }
-  ]
-},
-"bills": {
-  "vendorName": "",
-  "fields": [
-    {
+    }]
+  },
+  "bills": {
+    "vendorName": "bills",
+    "fields": [{
       "path": "id",
       "vendorPath": "billid"
-    }
-  ]
-},
-"invoices": {
-  "vendorName": "",
-  "fields": [
-    {
+    }]
+  },
+  "invoices": {
+    "vendorName": "invoices",
+    "fields": [{
       "path": "id",
       "vendorPath": "invoiceid"
-    }
-  ]
-},
-"payments": {
-  "vendorName": "",
-  "fields": [
-    {
+    }]
+  },
+  "payments": {
+    "vendorName": "payments",
+    "fields": [{
       "path": "id",
       "vendorPath": "arpaymentid"
-    }
-  ]
-},
-"projects": {
-  "vendorName": "",
-  "fields": [
-    {
+    }]
+  },
+  "projects": {
+    "vendorName": "projects",
+    "fields": [{
       "path": "id",
       "vendorPath": "projectid"
-    }
-  ]
-},
-"purchase-orders": {
-  "vendorName": "",
-  "fields": [
-    {
+    }]
+  },
+  "purchase-orders": {
+    "vendorName": "purchase-orders",
+    "fields": [{
       "path": "id",
       "vendorPath": "potransactionid"
-    }
-  ]
-},
-"sales-orders": {
-  "vendorName": "",
-  "fields": [
-    {
+    }]
+  },
+  "sales-orders": {
+    "vendorName": "sales-orders",
+    "fields": [{
       "path": "id",
       "vendorPath": "sotransactionid"
-    }
-  ]
-},
-"terms": {
-  "vendorName": "",
-  "fields": [
-    {
+    }]
+  },
+  "terms": {
+    "vendorName": "terms",
+    "fields": [{
       "path": "id",
       "vendorPath": "termid"
-    }
-  ]
-},
-"vendors": {
-  "vendorName": "",
-  "fields": [
-    {
+    }]
+  },
+  "vendors": {
+    "vendorName": "vendors",
+    "fields": [{
       "path": "id",
       "vendorPath": "vendorid"
-    }
-  ]
-},
-"vouchers": {
-  "vendorName": "",
-  "fields": [
-    {
+    }]
+  },
+  "vouchers": {
+    "vendorName": "vouchers",
+    "fields": [{
       "path": "id",
       "vendorPath": "apadjustmentid"
-    }
-  ]
-},
-"warehouses": {
-  "vendorName": "",
-  "fields": [
-    {
+    }]
+  },
+  "warehouses": {
+    "vendorName": "warehouses",
+    "fields": [{
       "path": "id",
       "vendorPath": "warehouseid"
-    }
-  ]
-},
-"ledger-accounts": {
-  "vendorName": "",
-  "fields": [
-    {
+    }]
+  },
+  "ledger-accounts": {
+    "vendorName": "ledger-accounts",
+    "fields": [{
       "path": "id",
       "vendorPath": "glaccountid"
-    }
-  ]
-},
-"terms": {
-  "vendorName": "",
-  "fields": [
-    {
+    }]
+  },
+  "terms": {
+    "vendorName": "terms",
+    "fields": [{
       "path": "id",
       "vendorPath": "name"
-    }
-  ]
-},
-"transactions": {
-  "vendorName": "",
-  "fields": [
-    {
+    }]
+  },
+  "transactions": {
+    "vendorName": "transactions",
+    "fields": [{
       "path": "id",
       "vendorPath": "gltransactionid"
-    }
-  ]
-},
-"items": {
-  "vendorName": "",
-  "fields": [
-    {
+    }]
+  },
+  "items": {
+    "vendorName": "items",
+    "fields": [{
       "path": "id",
       "vendorPath": "icitemid"
-    }
-  ]
-},
-"attachments": {
-  "vendorName": "",
-  "fields": [
-   {
-     "path": "id",
-     "vendorPath": "supdocid"
-   }
-  ]
- }
+    }]
+  },
+  "attachments": {
+    "vendorName": "attachments",
+    "fields": [{
+      "path": "id",
+      "vendorPath": "supdocid"
+    }]
+  },
+  "bills-payments": {
+    "vendorName": "bills-payments",
+    "fields": [{
+      "path": "id",
+      "vendorPath": "RECORDNO"
+    }]
+  }
 }

--- a/src/test/elements/intacct/bills-payments.js
+++ b/src/test/elements/intacct/bills-payments.js
@@ -1,36 +1,18 @@
 'use strict';
 
 const suite = require('core/suite');
-const cloud = require('core/cloud');
 const expect = require('chakram').expect;
 
-
-suite.forElement('finance', 'bills-payments', null, (test) => {
-  
- let id;
-  it(`should allow GET for ${test.api}`, () => {
-  return cloud.get(`${test.api}`)
-    .then(r => {
-      if (r.body.length <= 0) {
-        return;
-      } else {
-        id = r.body[0].RECORDNO;
-        return cloud.get(`${test.api}/${id}`);
-      }
-    });});
-  if (id !== null) {
-
-
-
- return cloud.withOptions({ qs: { where: 'whenmodified>\'08/13/2016 05:26:37\'' } })
-        .get(test.api)
-        .then((r) => {
-          expect(r).to.statusCode(200);
-          const validValues = r.body.filter(obj =>
-            obj.whenmodified >= '08/13/2016 05:26:37');
-          expect(validValues.length).to.equal(r.body.length);
-        });
-
-}
-
+// Posting a new bills-payment (AP payment) goes to confirmed state. Delete and update on a confirmed AP payment is not allowed by Intacct
+suite.forElement('finance', 'bills-payments', (test) => {
+  test.should.supportSr();
+  test
+    .withOptions({ qs: { where: `WHENMODIFIED > '06/23/2013 14:25:17'` } })
+    .withName('should support Ceql date search')
+    .withValidation(r => {
+      expect(r).to.statusCode(200);
+      const validValues = r.body.filter(obj => obj['WHENMODIFIED'] >= '06/23/2013 14:25:17');
+      expect(validValues.length).to.equal(r.body.length);
+    })
+    .should.return200OnGet();
 });

--- a/src/test/elements/intacct/bills-payments.js
+++ b/src/test/elements/intacct/bills-payments.js
@@ -11,7 +11,7 @@ suite.forElement('finance', 'bills-payments', (test) => {
     .withName('should support Ceql date search')
     .withValidation(r => {
       expect(r).to.statusCode(200);
-      const validValues = r.body.filter(obj => obj['WHENMODIFIED'] >= '06/23/2013 14:25:17');
+      const validValues = r.body.filter(obj => obj.WHENMODIFIED >= '06/23/2013 14:25:17');
       expect(validValues.length).to.equal(r.body.length);
     })
     .should.return200OnGet();


### PR DESCRIPTION
## Highlights
* Updated tests to use transformations 
* Fixed bill-payments tests

## Screenshot
```
churros test elements/intacct


info: Using url: http://localhost:8080
info: Using user: system
info: Running tests for element: intacct
info: Provisioned with instance id of 824
  Basic tests
    ✓ should provision
    ✓ should GET /objects (146ms)
    - docs
    ✓ metadata (210ms)
error: Failed to retrieve or validate: /hubs/finance/attachments
    1) transformations
    - should not allow provisioning with bad credentials

  attachments
error: Failed to retrieve or validate: /hubs/finance/attachments
    2) should allow CRUDS for /hubs/finance/attachments
error: Failed to retrieve or validate: /hubs/finance/attachments
    3) should allow paginating with page and pageSize for /hubs/finance/attachments
error: Failed to retrieve or validate: /hubs/finance/attachments
    4) should support updated > {date} Ceql search

  bills-payments
    ✓ should allow SR for /hubs/finance/bills-payments (2034ms)
    ✓ should support Ceql date search (922ms)

  bills
    ✓ should allow CRDS for /hubs/finance/bills (6545ms)
    ✓ should allow paginating with page and pageSize for /hubs/finance/bills (1969ms)
    ✓ should support updated > {date} Ceql search (1579ms)

  classes
    ✓ should allow CRUDS for /hubs/finance/classes (3239ms)
    ✓ should allow paginating with page and pageSize for /hubs/finance/classes (1941ms)
    ✓ should support updated > {date} Ceql search (737ms)

  contacts
    ✓ should allow CRDS for /hubs/finance/contacts (2891ms)
    ✓ should allow PATCH for /hubs/finance/contacts/{id} (2116ms)
    ✓ should allow paginating with page and pageSize for /hubs/finance/contacts (1988ms)
    ✓ should support status Ceql search (920ms)

  customers
    ✓ should allow CRUDS for /hubs/finance/customers (4544ms)
    ✓ should allow paginating with page and pageSize for /hubs/finance/customers (2466ms)
    ✓ should support updated > {date} Ceql search (1025ms)

  departments
    ✓ should allow CRUDS for /hubs/finance/departments (3223ms)
    ✓ should allow paginating with page and pageSize for /hubs/finance/departments (1833ms)
    ✓ should support updated > {date} Ceql search (669ms)

  employees
    ✓ should allow CRDS for /hubs/finance/employees (2822ms)
    ✓ should allow PATCH for /hubs/finance/employees/{id} (2711ms)
    ✓ should allow paginating with page and pageSize for /hubs/finance/employees (1869ms)
    ✓ should support updated > {date} Ceql search (1038ms)

  invoices
    ✓ should allow CRUDS for /hubs/finance/invoices (5176ms)
    ✓ should allow paginating with page and pageSize for /hubs/finance/invoices (1948ms)
    ✓ should support updated > {date} Ceql search (1318ms)

  items
    ✓ should allow CRUDS for /hubs/finance/items (3905ms)
    ✓ should allow paginating with page and pageSize for /hubs/finance/items (2581ms)
    ✓ should support updated > {date} Ceql search (730ms)

  journals
    ✓ should allow CRUDS for /hubs/finance/journals (3654ms)
    ✓ should allow paginating with page and pageSize for /hubs/finance/journals (1852ms)
    ✓ should support updated > {date} Ceql search (747ms)

  ledger-accounts
    ✓ should allow CRUDS for /hubs/finance/ledger-accounts (3390ms)
    ✓ should allow paginating with page and pageSize for /hubs/finance/ledger-accounts (1785ms)
    ✓ should support updated > {date} Ceql search (1205ms)

  locations
    ✓ should allow CRUDS for /hubs/finance/locations (4334ms)
    ✓ should allow paginating with page and pageSize for /hubs/finance/locations (2285ms)
    ✓ should support updated > {date} Ceql search (695ms)

  payments
    - should allow CRS for /hubs/finance/payments
    - should allow paginating with page and pageSize for /hubs/finance/payments
    - should support updated > {date} Ceql search
    - should allow C for /hubs/finance/payments/{id}/apply

  ping
    ✓ should allow GET for /hubs/finance/ping (135ms)

  polling
    - polling /hubs/finance/customers
    - polling /hubs/finance/employees
    - polling /hubs/finance/invoices
    - polling /hubs/finance/items
    - polling /hubs/finance/journals
    - polling /hubs/finance/ledger-accounts
    - polling /hubs/finance/payments
    - polling /hubs/finance/vendors

  projects
    ✓ should allow CRUDS for /hubs/finance/projects (3566ms)
    ✓ should allow paginating with page and pageSize for /hubs/finance/projects (2086ms)
    ✓ should support updated > {date} Ceql search (745ms)

  purchase-orders
    - should allow CRDS for /hubs/finance/purchase-orders
    - should allow paginating with page and pageSize for /hubs/finance/purchase-orders
    - should support updated > {date} Ceql search

  reporting-periods
error: Failed to retrieve or validate: /hubs/finance/reporting-periods
    5) should allow GET for /hubs/finance/reporting-periods
error: Failed to retrieve or validate: /hubs/finance/reporting-periods
    6) should allow paginating with page and pageSize for /hubs/finance/reporting-periods
error: Failed to retrieve or validate: /hubs/finance/reporting-periods
    7) should support updated > {date} Ceql search

  sales-orders
    ✓ should allow CRUDS for /hubs/finance/sales-orders (5185ms)
    ✓ should allow paginating with page and pageSize for /hubs/finance/sales-orders (2382ms)
    ✓ should support updated > {date} Ceql search (930ms)

  terms
    ✓ should allow SR for /hubs/finance/terms (1345ms)
    ✓ should allow CUD for /hubs/finance/terms (1863ms)
    ✓ should allow paginating with page and pageSize for /hubs/finance/terms (1861ms)
    ✓ should support updated > {date} Ceql search (612ms)

  transactions
    - should allow CRDS for /hubs/finance/transactions
    - should allow GET for /hubs/finance/transactions-entries
    - should allow paginating with page and pageSize for /hubs/finance/transactions
    - should support updated > {date} Ceql search

  vendors
    ✓ should allow CRDS for /hubs/finance/vendors (3788ms)
    ✓ should allow paginating with page and pageSize for /hubs/finance/vendors (2211ms)
    ✓ should support updated > {date} Ceql search (1496ms)

  vouchers
    ✓ should allow CRDS for /hubs/finance/vouchers (5116ms)
    ✓ should allow paginating with page and pageSize for /hubs/finance/vouchers (2024ms)
    ✓ should support updated > {date} Ceql search (648ms)

  warehouses
    ✓ should allow SR for /hubs/finance/warehouses (1197ms)
    ✓ should allow paginating with page and pageSize for /hubs/finance/warehouses (1820ms)
    ✓ should support updated > {date} Ceql search (624ms)


  60 passing (3m)
  21 pending
  7 failing

  1) Basic tests transformations:
     Error: AssertionError: expected 45 to equal 0
      at cloud.delete.catch.then.catch.then.then.catch.then (src/test/elements/assets/basics.js:116:17)
      at _fulfilled (node_modules/q/q.js:854:54)
      at self.promiseDispatch.done (node_modules/q/q.js:883:30)
      at Promise.promise.promiseDispatch (node_modules/q/q.js:816:13)
      at node_modules/q/q.js:624:44
      at runSingle (node_modules/q/q.js:137:13)
      at flush (node_modules/q/q.js:125:13)
      at _combinedTickCallback (internal/process/next_tick.js:73:7)
      at process._tickCallback (internal/process/next_tick.js:104:9)

  2) attachments should allow CRUDS for /hubs/finance/attachments:

      AssertionError: expected status code 400 to equal 200 - {"requestId":"5a42b32c77c87f3e6442dcf0","message":"This API is not currently supported for this element"}
      + expected - actual

      -false
      +true
      
      at chakram.addMethod (src/core/assertions.js:17:3)
      at .<anonymous> (node_modules/chakram/lib/plugins.js:123:22)
      at ctx.(anonymous function) (node_modules/chai/lib/chai/utils/addMethod.js:41:25)
      at doAsserterAsyncAndAddThen (node_modules/chai-as-promised/lib/chai-as-promised.js:296:33)
      at .<anonymous> (node_modules/chai-as-promised/lib/chai-as-promised.js:255:21)
      at ctx.(anonymous function) (node_modules/chai/lib/chai/utils/overwriteMethod.js:49:33)
      at doAsserterAsyncAndAddThen (node_modules/chai-as-promised/lib/chai-as-promised.js:296:33)
      at .<anonymous> (node_modules/chai-as-promised/lib/chai-as-promised.js:255:21)
      at ctx.(anonymous function) [as statusCode] (node_modules/chai/lib/chai/utils/overwriteMethod.js:49:33)
      at src/core/cloud.js:33:25
      at chakram.get.then.r (src/core/cloud.js:69:44)
      at _fulfilled (node_modules/q/q.js:854:54)
      at self.promiseDispatch.done (node_modules/q/q.js:883:30)
      at Promise.promise.promiseDispatch (node_modules/q/q.js:816:13)
      at node_modules/q/q.js:624:44
      at runSingle (node_modules/q/q.js:137:13)
      at flush (node_modules/q/q.js:125:13)
      at _combinedTickCallback (internal/process/next_tick.js:73:7)
      at process._tickCallback (internal/process/next_tick.js:104:9)

  3) attachments should allow paginating with page and pageSize for /hubs/finance/attachments:

      AssertionError: expected status code 400 to equal 200 - {"requestId":"5a42b32c77c87f3e6442dcf1","message":"This API is not currently supported for this element"}
      + expected - actual

      -false
      +true
      
      at chakram.addMethod (src/core/assertions.js:17:3)
      at .<anonymous> (node_modules/chakram/lib/plugins.js:123:22)
      at ctx.(anonymous function) (node_modules/chai/lib/chai/utils/addMethod.js:41:25)
      at doAsserterAsyncAndAddThen (node_modules/chai-as-promised/lib/chai-as-promised.js:296:33)
      at .<anonymous> (node_modules/chai-as-promised/lib/chai-as-promised.js:255:21)
      at ctx.(anonymous function) (node_modules/chai/lib/chai/utils/overwriteMethod.js:49:33)
      at doAsserterAsyncAndAddThen (node_modules/chai-as-promised/lib/chai-as-promised.js:296:33)
      at .<anonymous> (node_modules/chai-as-promised/lib/chai-as-promised.js:255:21)
      at ctx.(anonymous function) [as statusCode] (node_modules/chai/lib/chai/utils/overwriteMethod.js:49:33)
      at src/core/cloud.js:33:25
      at chakram.get.then.r (src/core/cloud.js:69:44)
      at _fulfilled (node_modules/q/q.js:854:54)
      at self.promiseDispatch.done (node_modules/q/q.js:883:30)
      at Promise.promise.promiseDispatch (node_modules/q/q.js:816:13)
      at node_modules/q/q.js:624:44
      at runSingle (node_modules/q/q.js:137:13)
      at flush (node_modules/q/q.js:125:13)
      at _combinedTickCallback (internal/process/next_tick.js:73:7)
      at process._tickCallback (internal/process/next_tick.js:104:9)

  4) attachments should support updated > {date} Ceql search:

      AssertionError: expected status code 400 to equal 200 - {"requestId":"5a42b32c77c87f3e6442dcf2","message":"This API is not currently supported for this element"}
      + expected - actual

      -false
      +true
      
      at chakram.addMethod (src/core/assertions.js:35:3)
      at .<anonymous> (node_modules/chakram/lib/plugins.js:123:22)
      at ctx.(anonymous function) (node_modules/chai/lib/chai/utils/addMethod.js:41:25)
      at doAsserterAsyncAndAddThen (node_modules/chai-as-promised/lib/chai-as-promised.js:296:33)
      at .<anonymous> (node_modules/chai-as-promised/lib/chai-as-promised.js:255:21)
      at ctx.(anonymous function) [as schemaAnd200] (node_modules/chai/lib/chai/utils/overwriteMethod.js:49:33)
      at src/core/cloud.js:42:25
      at chakram.get.then.r (src/core/cloud.js:69:44)
      at _fulfilled (node_modules/q/q.js:854:54)
      at self.promiseDispatch.done (node_modules/q/q.js:883:30)
      at Promise.promise.promiseDispatch (node_modules/q/q.js:816:13)
      at node_modules/q/q.js:624:44
      at runSingle (node_modules/q/q.js:137:13)
      at flush (node_modules/q/q.js:125:13)
      at _combinedTickCallback (internal/process/next_tick.js:73:7)
      at process._tickCallback (internal/process/next_tick.js:104:9)

  5) reporting-periods should allow GET for /hubs/finance/reporting-periods:

      AssertionError: expected status code 400 to equal 200 - {"requestId":"5a42b38877c87f3e6442dd6a","message":"This API is not currently supported for this element"}
      + expected - actual

      -false
      +true
      
      at chakram.addMethod (src/core/assertions.js:17:3)
      at .<anonymous> (node_modules/chakram/lib/plugins.js:123:22)
      at ctx.(anonymous function) (node_modules/chai/lib/chai/utils/addMethod.js:41:25)
      at doAsserterAsyncAndAddThen (node_modules/chai-as-promised/lib/chai-as-promised.js:296:33)
      at .<anonymous> (node_modules/chai-as-promised/lib/chai-as-promised.js:255:21)
      at ctx.(anonymous function) (node_modules/chai/lib/chai/utils/overwriteMethod.js:49:33)
      at doAsserterAsyncAndAddThen (node_modules/chai-as-promised/lib/chai-as-promised.js:296:33)
      at .<anonymous> (node_modules/chai-as-promised/lib/chai-as-promised.js:255:21)
      at ctx.(anonymous function) [as statusCode] (node_modules/chai/lib/chai/utils/overwriteMethod.js:49:33)
      at run (src/core/suite.js:722:133)
      at src/core/cloud.js:25:7
      at chakram.get.then.r (src/core/cloud.js:69:44)
      at _fulfilled (node_modules/q/q.js:854:54)
      at self.promiseDispatch.done (node_modules/q/q.js:883:30)
      at Promise.promise.promiseDispatch (node_modules/q/q.js:816:13)
      at node_modules/q/q.js:624:44
      at runSingle (node_modules/q/q.js:137:13)
      at flush (node_modules/q/q.js:125:13)
      at _combinedTickCallback (internal/process/next_tick.js:73:7)
      at process._tickCallback (internal/process/next_tick.js:104:9)

  6) reporting-periods should allow paginating with page and pageSize for /hubs/finance/reporting-periods:

      AssertionError: expected status code 400 to equal 200 - {"requestId":"5a42b38877c87f3e6442dd6b","message":"This API is not currently supported for this element"}
      + expected - actual

      -false
      +true
      
      at chakram.addMethod (src/core/assertions.js:17:3)
      at .<anonymous> (node_modules/chakram/lib/plugins.js:123:22)
      at ctx.(anonymous function) (node_modules/chai/lib/chai/utils/addMethod.js:41:25)
      at doAsserterAsyncAndAddThen (node_modules/chai-as-promised/lib/chai-as-promised.js:296:33)
      at .<anonymous> (node_modules/chai-as-promised/lib/chai-as-promised.js:255:21)
      at ctx.(anonymous function) (node_modules/chai/lib/chai/utils/overwriteMethod.js:49:33)
      at doAsserterAsyncAndAddThen (node_modules/chai-as-promised/lib/chai-as-promised.js:296:33)
      at .<anonymous> (node_modules/chai-as-promised/lib/chai-as-promised.js:255:21)
      at ctx.(anonymous function) [as statusCode] (node_modules/chai/lib/chai/utils/overwriteMethod.js:49:33)
      at src/core/cloud.js:33:25
      at chakram.get.then.r (src/core/cloud.js:69:44)
      at _fulfilled (node_modules/q/q.js:854:54)
      at self.promiseDispatch.done (node_modules/q/q.js:883:30)
      at Promise.promise.promiseDispatch (node_modules/q/q.js:816:13)
      at node_modules/q/q.js:624:44
      at runSingle (node_modules/q/q.js:137:13)
      at flush (node_modules/q/q.js:125:13)
      at _combinedTickCallback (internal/process/next_tick.js:73:7)
      at process._tickCallback (internal/process/next_tick.js:104:9)

  7) reporting-periods should support updated > {date} Ceql search:

      AssertionError: expected status code 400 to equal 200 - {"requestId":"5a42b38877c87f3e6442dd6c","message":"This API is not currently supported for this element"}
      + expected - actual

      -false
      +true
      
      at chakram.addMethod (src/core/assertions.js:35:3)
      at .<anonymous> (node_modules/chakram/lib/plugins.js:123:22)
      at ctx.(anonymous function) (node_modules/chai/lib/chai/utils/addMethod.js:41:25)
      at doAsserterAsyncAndAddThen (node_modules/chai-as-promised/lib/chai-as-promised.js:296:33)
      at .<anonymous> (node_modules/chai-as-promised/lib/chai-as-promised.js:255:21)
      at ctx.(anonymous function) [as schemaAnd200] (node_modules/chai/lib/chai/utils/overwriteMethod.js:49:33)
      at src/core/cloud.js:42:25
      at chakram.get.then.r (src/core/cloud.js:69:44)
      at _fulfilled (node_modules/q/q.js:854:54)
      at self.promiseDispatch.done (node_modules/q/q.js:883:30)
      at Promise.promise.promiseDispatch (node_modules/q/q.js:816:13)
      at node_modules/q/q.js:624:44
      at runSingle (node_modules/q/q.js:137:13)
      at flush (node_modules/q/q.js:125:13)
      at _combinedTickCallback (internal/process/next_tick.js:73:7)
      at process._tickCallback (internal/process/next_tick.js:104:9)
```

## Reference
* [SOBA](https://github.com/cloud-elements/soba/pull/7832)
* [CircleCI](Link to SOBA PR adding Tests to `circle.yml`, when applicable)
* [churros-sauce](Link to Associated Churros-sauce PR, when applicable)
* [TA4240](https://rally1.rallydev.com/#/144349237612d/detail/task/186258984040)

## Closes
* Closes [TA4240](https://rally1.rallydev.com/#/144349237612d/detail/task/186258984040)
