### PR TITLE
Fixed and cleaned up Zuora tests

### DIFF
--- a/src/test/elements/zuorav2/assets/transformations.json
+++ b/src/test/elements/zuorav2/assets/transformations.json
@@ -3,6 +3,9 @@
     "vendorName": "customers",
     "fields": [{
       "path": "id",
+      "vendorPath": "Id"
+    }, {
+      "path": "id",
       "vendorPath": "accountId"
     }]
   },
@@ -37,6 +40,9 @@
   "subscriptions": {
     "vendorName": "subscriptions",
     "fields": [{
+      "path": "id",
+      "vendorPath": "Id"
+    }, {
       "path": "id",
       "vendorPath": "subscriptionId"
     }]

--- a/src/test/elements/zuorav2/customers.js
+++ b/src/test/elements/zuorav2/customers.js
@@ -17,7 +17,7 @@ suite.forElement('payment', 'customers', { payload: payload }, (test) => {
       }
     }
   };
- const ceqlOptions = {
+  const ceqlOptions = {
     name: "should support CreatedDate > {date} Ceql search",
     qs: { where: 'CreatedDate>\'2017-02-22T08:21:00.000Z\'' }
   };
@@ -62,14 +62,11 @@ suite.forElement('payment', 'customers', { payload: payload }, (test) => {
 
   it(`should allow GET ${test.api}/id/history,GET ${test.api}/id/payments`, () => {
     return cloud.get(`${test.api}/${customerId}/history`);
-
   });
   it(`GET ${test.api}/id/payments`, () => {
     return cloud.get(`${test.api}/${customerId}/payments`);
-
   });
   it.skip(`should allow CS for ${test.api}/id/subscriptions `, () => {
-
     return cloud.post(`${test.api}/${customerId}/subscriptions`, subscriptionPayload)
       .then(r => cloud.get(`${test.api}/${customerId}/subscriptions`));
   });

--- a/src/test/elements/zuorav2/invoices.js
+++ b/src/test/elements/zuorav2/invoices.js
@@ -23,7 +23,7 @@ suite.forElement('payment', 'invoices', { payload: invoicesPayload }, (test) => 
     name: "should support CreatedDate > {date} Ceql search",
     qs: { where: 'CreatedDate>\'2017-02-22T08:21:00.000Z\'' }
   };
-  before(() => {
+  before(done => {
     cloud.withOptions({ qs: { where: 'expand=true' } }).get(`/hubs/payment/products`)
       .then(r => {
         var match = r.body.filter(function(list) {
@@ -43,7 +43,8 @@ suite.forElement('payment', 'invoices', { payload: invoicesPayload }, (test) => 
       .then(r => customerId = r.body.id ? r.body.id : r.body.accountId)
       .then(r => subscriptionPayload.accountKey = customerId)
       .then(r => cloud.post(`/hubs/payment/subscriptions`, subscriptionPayload))
-      .then(r => invoicesPayload.AccountId = customerId);
+      .then(r => invoicesPayload.AccountId = customerId)
+      .then(r => done());
   });
   test.should.supportNextPagePagination(2);
   test.withName(ceqlOptions.name).withOptions(ceqlOptions).should.return200OnGet();

--- a/src/test/elements/zuorav2/subscriptions.js
+++ b/src/test/elements/zuorav2/subscriptions.js
@@ -7,18 +7,19 @@ const customerPayload = require('./assets/customers');
 const cloud = require('core/cloud');
 const chakram = require('chakram');
 suite.forElement('payment', 'subscriptions', { payload: payload }, (test) => {
- const options = {
+  const options = {
     churros: {
       updatePayload: {
-       "notes": tools.random()
+        "notes": tools.random()
       }
     }
   };
-const ceqlOptions = {
+  const ceqlOptions = {
     name: "should support CreatedDate > {date} Ceql search",
     qs: { where: 'CreatedDate>\'2017-02-22T08:21:00.000Z\'' }
   };
-  let rateId, charge,customerId;
+  
+  let rateId, charge, customerId;
   before(() => {
     return cloud.withOptions({ qs: { where: 'expand=true' } }).get(`/hubs/payment/products`)
       .then(r => {
@@ -35,7 +36,7 @@ const ceqlOptions = {
           // bail
         }
       })
-      .then(r=> cloud.post(`/hubs/payment/customers`, customerPayload))
+      .then(r => cloud.post(`/hubs/payment/customers`, customerPayload))
       .then(r => customerId = r.body.id)
       .then(r => payload.accountKey = customerId);
   });
@@ -46,7 +47,7 @@ const ceqlOptions = {
 
 
 
- it.skip(`should allow POST ${test.api}/preview `, () => {
+  it.skip(`should allow POST ${test.api}/preview `, () => {
     const previewPayload = {
       "contractEffectiveDate": "2015-1-15",
       "initialTerm": 12,
@@ -72,52 +73,48 @@ const ceqlOptions = {
     };
     previewPayload.subscribeToRatePlans[0].productRatePlanId = rateId;
     previewPayload.subscribeToRatePlans[0].chargeOverrides[0].productRatePlanChargeId = charge;
-      return cloud.post(`${test.api}/preview`, previewPayload);
-});
- it.skip(`should allow PUT ${test.api}/{id}/renew `, () => {
+    return cloud.post(`${test.api}/preview`, previewPayload);
+  });
 
+  it.skip(`should allow PUT ${test.api}/{id}/renew `, () => {
     let id;
     const renewUpdatePayload = {
       "collect": false,
       "invoice": true
     };
-     return cloud.post(`${test.api}`, payload)
-             .then(r => id = r.body.id)
-             .then(r => cloud.put(`${test.api}/${id}/renew`, renewUpdatePayload));
+    return cloud.post(`${test.api}`, payload)
+      .then(r => id = r.body.id)
+      .then(r => cloud.put(`${test.api}/${id}/renew`, renewUpdatePayload));
 
-});
- it.skip(`should allow PUT ${test.api}/{id}/cancle `, () => {
-
+  });
+  it.skip(`should allow PUT ${test.api}/{id}/cancel`, () => {
     let id;
-      const cancleUpdatePayload = {
+    const cancleUpdatePayload = {
       "cancellationEffectiveDate": "2015-01-31",
       "cancellationPolicy": "SpecificDate",
       "collect": false,
       "invoice": true
     };
-     return cloud.post(`${test.api}`, payload)
-             .then(r => id = r.body.id)
-             .then(r => cloud.put(`${test.api}/${id}/cancel`, cancleUpdatePayload));
-
-});
-it.skip(`should allow PUT ${test.api}/{id}/suspend and ${test.api}/{id}/resume `, () => {
-
-   let id;
-   let idNew;
-     const suspendUpdatePayload = {
-     "suspendPolicy": "Today"
-   };
-   const resumeUpdatePayload = {
-   "resumePolicy": "SpecificDate",
-   "resumeSpecificDate": "2018-11-23"
- };
     return cloud.post(`${test.api}`, payload)
-            .then(r => id = r.body.id)
-            .then(r => cloud.put(`${test.api}/${id}/suspend`, suspendUpdatePayload))
-            .then(r => idNew = r.body.subscriptionId)
-            .then(r => cloud.put(`${test.api}/${idNew}/resume`, resumeUpdatePayload));
+      .then(r => id = r.body.id)
+      .then(r => cloud.put(`${test.api}/${id}/cancel`, cancleUpdatePayload));
 
-});
+  });
+  it.skip(`should allow PUT ${test.api}/{id}/suspend and ${test.api}/{id}/resume `, () => {
+    let id, idNew;
+    const suspendUpdatePayload = {
+      "suspendPolicy": "Today"
+    };
+    const resumeUpdatePayload = {
+      "resumePolicy": "SpecificDate",
+      "resumeSpecificDate": "2018-11-23"
+    };
+    return cloud.post(`${test.api}`, payload)
+      .then(r => id = r.body.id)
+      .then(r => cloud.put(`${test.api}/${id}/suspend`, suspendUpdatePayload))
+      .then(r => idNew = r.body.subscriptionId)
+      .then(r => cloud.put(`${test.api}/${idNew}/resume`, resumeUpdatePayload));
+  });
 
 
   after(() => cloud.delete(`/hubs/payment/customers/${customerId}`));


### PR DESCRIPTION
## Highlights
* ☝️ 

## Screenshot
```
churros test elements/zuorav2


info: Using url: http://localhost:8080
info: Using user: system
info: Using oauth username: kelly@cloud-elements.com
info: Running tests for element: zuorav2
info: Provisioned with instance id of 868
  Basic tests
    ✓ should provision
    ✓ should GET /objects (126ms)
    - docs
    ✓ metadata (212ms)
    ✓ transformations (4159ms)
    - should not allow provisioning with bad credentials

  customers
    ✓ should support CreatedDate > {date} Ceql search (340ms)
    ✓ should allow paginating with page and nextPage /hubs/payment/customers (981ms)
    ✓ should allow CRUDS for /hubs/payment/customers (1384ms)
    ✓ should allow CRUDS /hubs/payment/customers/id/payment-method (2292ms)
    ✓ should allow GET /hubs/payment/customers/id/history,GET /hubs/payment/customers/id/payments (260ms)
    ✓ GET /hubs/payment/customers/id/payments (312ms)
    - should allow CS for /hubs/payment/customers/id/subscriptions 
    - should allow CS for /hubs/payment/customers/id/invoices 

  invoices
    ✓ should allow paginating with page and nextPage /hubs/payment/invoices (1415ms)
    ✓ should support CreatedDate > {date} Ceql search (322ms)
    ✓ should allow CRUDS for /hubs/payment/invoices (2082ms)

  payment-methods
    ✓ should allow paginating with page and nextPage /hubs/payment/payment-methods (702ms)
    ✓ should support CreatedDate > {date} Ceql search (360ms)
    ✓ should allow CRUDS for /hubs/payment/payment-methods (1187ms)

  payments
    ✓ should support CreatedDate > {date} Ceql search (372ms)
    ✓ should allow paginating with page and nextPage /hubs/payment/payments (676ms)
    ✓ should allow CRUDS for /hubs/payment/payments (1475ms)

  products
    ✓ should allow CRUDS for /hubs/payment/products (1268ms)
    ✓ should allow paginating with page and nextPage /hubs/payment/products (600ms)
    ✓ should support searching /hubs/payment/products by id (863ms)

  subscriptions
    ✓ should support CreatedDate > {date} Ceql search (410ms)
    ✓ should allow paginating with page and nextPage /hubs/payment/subscriptions (730ms)
    ✓ should allow CRUDS for /hubs/payment/subscriptions (1658ms)
    - should allow POST /hubs/payment/subscriptions/preview 
    - should allow PUT /hubs/payment/subscriptions/{id}/renew 
    - should allow PUT /hubs/payment/subscriptions/{id}/cancel
    - should allow PUT /hubs/payment/subscriptions/{id}/suspend and /hubs/payment/subscriptions/{id}/resume 


  25 passing (41s)
  8 pending
```

## Reference
* [SOBA](https://github.com/cloud-elements/soba/pull/7838)
* [CircleCI](Link to SOBA PR adding Tests to `circle.yml`, when applicable)
* [churros-sauce](Link to Associated Churros-sauce PR, when applicable)
* [RALLY-#${ticketNumber}](Link to Rally User Story or Task)

## Closes
* [DE116](https://rally1.rallydev.com/#/144349237612d/detail/defect/161831229152)
