### PR TITLE
Enhanced OneDrive folders/contents API with ability to filter files by name and extension

### DIFF
--- a/src/test/elements/onedrivev2/folders.js
+++ b/src/test/elements/onedrivev2/folders.js
@@ -95,13 +95,8 @@ let folderId;
       });
   });
 
-  it('should allow GET /folders/contents', () => {
-    return cloud.withOptions({ qs: { path: `/` } }).get(`${test.api}/contents`)
-      .then(r => {
-        expect(r.body.length).to.equal(r.body.filter(obj => obj.directory === true || obj.directory === false).length);
-        folderId = r.body.filter(obj => obj.name === "dontdelete_folder_churros")[0].id;
-      });
-  });
+  before(() => cloud.withOptions({ qs: { path: `/` } }).get(`${test.api}/contents`)
+      .then(r => folderId = r.body.filter(obj => obj.name === "dontdelete_folder_churros")[0].id));
 
   it('should allow GET /folders/contents with name', () => {
     return cloud.withOptions({ qs: { path: `/dontdelete_folder_churros`, where: "name='dontdelete_text_churros'" } }).get(`${test.api}/contents`)
@@ -111,11 +106,6 @@ let folderId;
   it('should allow GET /folders/contents with extension', () => {
     return cloud.withOptions({ qs: { path: `/dontdelete_folder_churros`, where: "extension='.txt'" } }).get(`${test.api}/contents`)
       .then(r => expect(r.body[0].name).to.contain('.txt'));
-  });
-
-  it('should allow GET /folders/:id/contents ', () => {
-    return cloud.get(`${test.api}/${folderId}/contents`)
-      .then(r => expect(r.body.length).to.equal(r.body.filter(obj => obj.directory === true || obj.directory === false).length));
   });
 
   it('should allow GET /folders/:id/contents with name', () => {

--- a/src/test/elements/onedrivev2/folders.js
+++ b/src/test/elements/onedrivev2/folders.js
@@ -10,7 +10,7 @@ const folderPayload = build({ name: `churros-${tools.random()}`, path: `/${tools
 const expect = require('chakram').expect;
 
 suite.forElement('documents', 'folders', (test) => {
-
+let folderId;
   const folderWrap = (cb) => {
     let folder;
     let random = `${tools.random()}`;
@@ -97,17 +97,35 @@ suite.forElement('documents', 'folders', (test) => {
 
   it('should allow GET /folders/contents', () => {
     return cloud.withOptions({ qs: { path: `/` } }).get(`${test.api}/contents`)
-      .then(r => expect(r.body.length).to.equal(r.body.filter(obj => obj.directory === true || obj.directory === false).length));
+      .then(r => {
+        expect(r.body.length).to.equal(r.body.filter(obj => obj.directory === true || obj.directory === false).length);
+        folderId = r.body.filter(obj => obj.name === "dontdelete_folder_churros")[0].id;
+      });
   });
 
   it('should allow GET /folders/contents with name', () => {
-    return cloud.withOptions({ qs: { path: `/`, where: "name='DONT_DELETE_churros'" } }).get(`${test.api}/contents`)
-      .then(r => expect(r.body[0].name).to.contain('DONT_DELETE_churros'));
+    return cloud.withOptions({ qs: { path: `/dontdelete_folder_churros`, where: "name='dontdelete_text_churros'" } }).get(`${test.api}/contents`)
+      .then(r => expect(r.body[0].name).to.contain('dontdelete_text_churros'));
   });
 
   it('should allow GET /folders/contents with extension', () => {
-    return cloud.withOptions({ qs: { path: `/`, where: "extension='.csv'" } }).get(`${test.api}/contents`)
-      .then(r => expect(r.body[0].name).to.contain('.csv'));
+    return cloud.withOptions({ qs: { path: `/dontdelete_folder_churros`, where: "extension='.txt'" } }).get(`${test.api}/contents`)
+      .then(r => expect(r.body[0].name).to.contain('.txt'));
+  });
+
+  it('should allow GET /folders/:id/contents ', () => {
+    return cloud.get(`${test.api}/${folderId}/contents`)
+      .then(r => expect(r.body.length).to.equal(r.body.filter(obj => obj.directory === true || obj.directory === false).length));
+  });
+
+  it('should allow GET /folders/:id/contents with name', () => {
+    return cloud.withOptions({ qs: { where: "name='dontdelete_text_churros'" } }).get(`${test.api}/${folderId}/contents`)
+      .then(r => expect(r.body[0].name).to.contain('dontdelete_text_churros'));
+  });
+
+  it('should allow GET /folders/:id/contents with extension', () => {
+    return cloud.withOptions({ qs: { where: "extension='.txt'" } }).get(`${test.api}/${folderId}/contents`)
+      .then(r => expect(r.body[0].name).to.contain('.txt'));
   });
 
 });

--- a/src/test/elements/onedrivev2/folders.js
+++ b/src/test/elements/onedrivev2/folders.js
@@ -94,4 +94,20 @@ suite.forElement('documents', 'folders', (test) => {
         expect(r).to.have.statusCode(200);
       });
   });
+
+  it('should allow GET /folders/contents', () => {
+    return cloud.withOptions({ qs: { path: `/` } }).get(`${test.api}/contents`)
+      .then(r => expect(r.body.length).to.equal(r.body.filter(obj => obj.directory === true || obj.directory === false).length));
+  });
+
+  it('should allow GET /folders/contents with name', () => {
+    return cloud.withOptions({ qs: { path: `/`, where: "name='DONT_DELETE_churros'" } }).get(`${test.api}/contents`)
+      .then(r => expect(r.body[0].name).to.contain('DONT_DELETE_churros'));
+  });
+
+  it('should allow GET /folders/contents with extension', () => {
+    return cloud.withOptions({ qs: { path: `/`, where: "extension='.csv'" } }).get(`${test.api}/contents`)
+      .then(r => expect(r.body[0].name).to.contain('.csv'));
+  });
+
 });


### PR DESCRIPTION
## Highlights
* `GET /folders/:id/contents`
* `GET /folders/contents`

## Non-customer Highlights
* `GET /folders/:id/contents where : (name = 'filename')`
* `GET /folders/contents where : (extension = '.txt')`

## Checklist
* [x] applicable churros tests are still passing
* [x] includes a dbdeploy script that is backward-incompatible with one previous Soba minor version

## Unit-test cases:
Sr No. | Test Case | Status
-- | -- | --
1 | Tested GET operations manually | Passed
2 | Tested API's through Churros | Passed
3 | Verify that documentation is loading | Passed
4 | Verify that model structure is exactly the same as actual request and response of the API | Passed

## Screenshot

<img width="850" alt="screen shot 2017-12-28 at 11 58 15 am" src="https://user-images.githubusercontent.com/26943831/34418987-d02410aa-ebc6-11e7-8df3-baaaada31708.png">

## Related PRs
[Soba](https://github.com/cloud-elements/soba/compare/OneDrive_US3209?expand=1) 

## Closes
[Rally](https://rally1.rallydev.com/#/144349237612d/detail/userstory/175564890248)