### PR TITLE
Enhanced OneDrive Business folders/contents API with ability to filter files by name and extension

### DIFF
--- a/src/test/elements/onedrivebusiness/folders.js
+++ b/src/test/elements/onedrivebusiness/folders.js
@@ -4,6 +4,7 @@ const suite = require('core/suite');
 const tools = require('core/tools');
 const cloud = require('core/cloud');
 const payload = require('./assets/folders');
+const expect = require('chakram').expect;
 const build = (overrides) => Object.assign({}, payload, overrides);
 const folderPayload = build({ name: `churros-${tools.random()}`, path: `/${tools.random()}` });
 const folderPayload1 = build({ name: `churros-${tools.random()}`, path: `/${tools.random()}/${tools.random()}` });
@@ -83,6 +84,21 @@ suite.forElement('documents', 'folders', (test) => {
     };
 
     return folderWrap(cb);
+  });
+
+  it('should allow GET /folders/contents', () => {
+    return cloud.withOptions({ qs: { path: `/` } }).get(`${test.api}/contents`)
+      .then(r => expect(r.body.length).to.equal(r.body.filter(obj => obj.directory === true || obj.directory === false).length));
+  });
+
+  it('should allow GET /folders/contents with name', () => {
+    return cloud.withOptions({ qs: { path: `/`, where: "name='donotdelete_text_churros'" } }).get(`${test.api}/contents`)
+      .then(r => expect(r.body[0].name).to.contain('donotdelete_text_churros'));
+  });
+
+  it('should allow GET /folders/contents with extension', () => {
+    return cloud.withOptions({ qs: { path: `/`, where: "extension='.txt'" } }).get(`${test.api}/contents`)
+      .then(r => expect(r.body[0].name).to.contain('.txt'));
   });
 
 });

--- a/src/test/elements/onedrivebusiness/folders.js
+++ b/src/test/elements/onedrivebusiness/folders.js
@@ -86,13 +86,8 @@ let folderId;
     return folderWrap(cb);
   });
 
-  it('should allow GET /folders/contents', () => {
-    return cloud.withOptions({ qs: { path: `/` } }).get(`${test.api}/contents`)
-      .then(r => {
-        expect(r.body.length).to.equal(r.body.filter(obj => obj.directory === true || obj.directory === false).length);
-        folderId = r.body.filter(obj => obj.name === "dontdelete_folder_churros")[0].id;
-      });
-  });
+  before(() => cloud.withOptions({ qs: { path: `/` } }).get(`${test.api}/contents`)
+      .then(r => folderId = r.body.filter(obj => obj.name === "dontdelete_folder_churros")[0].id));
 
   it('should allow GET /folders/contents with name', () => {
     return cloud.withOptions({ qs: { path: `/dontdelete_folder_churros`, where: "name='dontdelete_text_churros'" } }).get(`${test.api}/contents`)
@@ -102,11 +97,6 @@ let folderId;
   it('should allow GET /folders/contents with extension', () => {
     return cloud.withOptions({ qs: { path: `/dontdelete_folder_churros`, where: "extension='.txt'" } }).get(`${test.api}/contents`)
       .then(r => expect(r.body[0].name).to.contain('.txt'));
-  });
-
-  it('should allow GET /folders/:id/contents ', () => {
-    return cloud.get(`${test.api}/${folderId}/contents`)
-      .then(r => expect(r.body.length).to.equal(r.body.filter(obj => obj.directory === true || obj.directory === false).length));
   });
 
   it('should allow GET /folders/:id/contents with name', () => {

--- a/src/test/elements/onedrivebusiness/folders.js
+++ b/src/test/elements/onedrivebusiness/folders.js
@@ -9,7 +9,7 @@ const build = (overrides) => Object.assign({}, payload, overrides);
 const folderPayload = build({ name: `churros-${tools.random()}`, path: `/${tools.random()}` });
 const folderPayload1 = build({ name: `churros-${tools.random()}`, path: `/${tools.random()}/${tools.random()}` });
 suite.forElement('documents', 'folders', (test) => {
-
+let folderId;
   const folderWrap = (cb) => {
     let folder;
     let random = `${tools.random()}`;
@@ -88,16 +88,34 @@ suite.forElement('documents', 'folders', (test) => {
 
   it('should allow GET /folders/contents', () => {
     return cloud.withOptions({ qs: { path: `/` } }).get(`${test.api}/contents`)
-      .then(r => expect(r.body.length).to.equal(r.body.filter(obj => obj.directory === true || obj.directory === false).length));
+      .then(r => {
+        expect(r.body.length).to.equal(r.body.filter(obj => obj.directory === true || obj.directory === false).length);
+        folderId = r.body.filter(obj => obj.name === "dontdelete_folder_churros")[0].id;
+      })
   });
 
   it('should allow GET /folders/contents with name', () => {
-    return cloud.withOptions({ qs: { path: `/`, where: "name='donotdelete_text_churros'" } }).get(`${test.api}/contents`)
-      .then(r => expect(r.body[0].name).to.contain('donotdelete_text_churros'));
+    return cloud.withOptions({ qs: { path: `/dontdelete_folder_churros`, where: "name='dontdelete_text_churros'" } }).get(`${test.api}/contents`)
+      .then(r => expect(r.body[0].name).to.contain('dontdelete_text_churros'));
   });
 
   it('should allow GET /folders/contents with extension', () => {
-    return cloud.withOptions({ qs: { path: `/`, where: "extension='.txt'" } }).get(`${test.api}/contents`)
+    return cloud.withOptions({ qs: { path: `/dontdelete_folder_churros`, where: "extension='.txt'" } }).get(`${test.api}/contents`)
+      .then(r => expect(r.body[0].name).to.contain('.txt'));
+  });
+
+  it('should allow GET /folders/:id/contents ', () => {
+    return cloud.get(`${test.api}/${folderId}/contents`)
+      .then(r => expect(r.body.length).to.equal(r.body.filter(obj => obj.directory === true || obj.directory === false).length));
+  });
+
+  it('should allow GET /folders/:id/contents with name', () => {
+    return cloud.withOptions({ qs: { where: "name='dontdelete_text_churros'" } }).get(`${test.api}/${folderId}/contents`)
+      .then(r => expect(r.body[0].name).to.contain('dontdelete_text_churros'));
+  });
+
+  it('should allow GET /folders/:id/contents with extension', () => {
+    return cloud.withOptions({ qs: { where: "extension='.txt'" } }).get(`${test.api}/${folderId}/contents`)
       .then(r => expect(r.body[0].name).to.contain('.txt'));
   });
 

--- a/src/test/elements/onedrivebusiness/folders.js
+++ b/src/test/elements/onedrivebusiness/folders.js
@@ -91,7 +91,7 @@ let folderId;
       .then(r => {
         expect(r.body.length).to.equal(r.body.filter(obj => obj.directory === true || obj.directory === false).length);
         folderId = r.body.filter(obj => obj.name === "dontdelete_folder_churros")[0].id;
-      })
+      });
   });
 
   it('should allow GET /folders/contents with name', () => {


### PR DESCRIPTION
## Highlights
* `GET /folders/:id/contents`
* `GET /folders/contents`

## Non-customer Highlights
* `GET /folders/:id/contents where : (name = 'filename')`
* `GET /folders/contents where : (extension = '.txt')`

## Checklist
* [x] applicable churros tests are still passing
* [x] includes a dbdeploy script that is backward-incompatible with one previous Soba minor version

## Unit-test cases:
Sr No. | Test Case | Status
-- | -- | --
1 | Tested GET operations manually | Passed
2 | Tested API's through Churros | Passed
3 | Verify that documentation is loading | Passed
4 | Verify that model structure is exactly the same as actual request and response of the API | Passed

## Screenshot

<img width="794" alt="screen shot 2017-12-28 at 11 34 53 am" src="https://user-images.githubusercontent.com/26943831/34418419-9f360898-ebc3-11e7-9754-d7a53a68512e.png">


## Related PRs
[Soba](https://github.com/cloud-elements/soba/pull/7841) 

## Closes
[Rally](https://rally1.rallydev.com/#/144349237612d/detail/userstory/175564889260)