### PR TITLE
Added test cases for leads and corrected for pages on Facebook Lead Ads

### DIFF
--- a/src/test/elements/facebookleadads/leads.js
+++ b/src/test/elements/facebookleadads/leads.js
@@ -1,0 +1,13 @@
+'use strict';
+
+const suite = require('core/suite');
+const cloud = require('core/cloud');
+
+suite.forElement('marketing', 'leads', null, (test) => {
+  // As we do not have a GET all API for leads, hardcoding the leadId
+  let leadId = 239907496137483;
+  it('should allow R for /hubs/marketing/leads', () => {
+    return cloud.get(`${test.api}/${leadId}`)
+      .then(r => cloud.withOptions({ qs: { fields: 'id,name' } }).get(`${test.api}/${leadId}`));
+  });
+});

--- a/src/test/elements/facebookleadads/pages.js
+++ b/src/test/elements/facebookleadads/pages.js
@@ -6,10 +6,11 @@ const cloud = require('core/cloud');
 suite.forElement('marketing', 'pages', null, (test) => {
   let pageId;
   test.should.supportSr();
-  it('should allow R for /hubs/marketing/leads', () => {
+  it('should allow SR for /hubs/marketing/pages', () => {
     return cloud.get(test.api)
       .then(r => pageId = r.body[0].id)
-      .then(r => cloud.get(`/hubs/marketing/leads/${pageId}`));
+      .then(r => cloud.get(`${test.api}/${pageId}`))
+      .then(r => cloud.withOptions({ qs: { fields: 'id,name' } }).get(`${test.api}/${pageId}`));
   });
 
   it(`should allow CR for ${test.api}/${pageId}/subscribed-apps`, () => {

--- a/src/test/elements/facebookleadads/pages.js
+++ b/src/test/elements/facebookleadads/pages.js
@@ -8,9 +8,14 @@ suite.forElement('marketing', 'pages', null, (test) => {
   test.should.supportSr();
   it('should allow SR for /hubs/marketing/pages', () => {
     return cloud.get(test.api)
-      .then(r => pageId = r.body[0].id)
-      .then(r => cloud.get(`${test.api}/${pageId}`))
-      .then(r => cloud.withOptions({ qs: { fields: 'id,name' } }).get(`${test.api}/${pageId}`));
+      .then(r => {
+        if (r.body.length <= 0) {
+          return;
+        } else {
+          pageId = pageId = r.body[0].id;
+          return cloud.withOptions({ qs: { fields: 'id,name' } }).get(`${test.api}/${pageId}`);
+        }
+      });
   });
 
   it(`should allow CR for ${test.api}/${pageId}/subscribed-apps`, () => {


### PR DESCRIPTION
## Non-customer Highlights
* Added test cases for `leads` resource
* In the test cases for `pages` resource, the `GET /leads/{leadId}` API was being used. Changed those to use the correct API.
* Also added test cases for testing the `fields` param on both the resources GET by `id` APIs

## Screenshot
![image](https://user-images.githubusercontent.com/20282215/34482119-1995f17c-efdc-11e7-8a27-3ba8b4129de7.png)


## Reference
* [SOBA for pages resource](https://github.com/cloud-elements/soba/pull/7849)
* [SOBA for leads resource](https://github.com/cloud-elements/soba/pull/7849)
* [RALLY-#US5585](https://rally1.rallydev.com/#/144349237612d/detail/userstory/185452570132)
* [RALLY-#US5653](https://rally1.rallydev.com/#/144349237612d/detail/userstory/186259325732)

## Closes
* [#US5586](https://rally1.rallydev.com/#/144349237612d/detail/userstory/185452570552)
* [#US5653](https://rally1.rallydev.com/#/144349237612d/detail/userstory/186259325732)

  