### PR TITLE
Enhanced test cases for Bullhorn

### DIFF
--- a/src/test/elements/bullhorn/assets/candidates.json
+++ b/src/test/elements/bullhorn/assets/candidates.json
@@ -3,5 +3,11 @@
   "lastName": "test1",
   "name": "TestFirst TestLast",
   "username": "TestCandidateChurros",
-  "status": "active"
+  "status": "active",
+  "address": {
+    "countryCode": "US"
+  },
+  "secondaryAddress": {
+    "countryCode": "US"
+  }
 }

--- a/src/test/elements/bullhorn/assets/company.json
+++ b/src/test/elements/bullhorn/assets/company.json
@@ -1,3 +1,6 @@
 {
-		  "name": "<<random.word>>"
+  "name": "<<random.word>>",
+  "department": {
+    "name": "comp"
+  }
 }

--- a/src/test/elements/bullhorn/assets/contacts.json
+++ b/src/test/elements/bullhorn/assets/contacts.json
@@ -1,4 +1,8 @@
-{ "clientCorporation": {
-    "id": 51
-}
+{
+  "clientCorporation": {
+    "id": 51,
+    "secondaryAddress": {
+      "countryCode": "US"
+    }
+  }
 }

--- a/src/test/elements/bullhorn/assets/opportunities.json
+++ b/src/test/elements/bullhorn/assets/opportunities.json
@@ -2,7 +2,7 @@
   "id": 656,
 
   "clientCorporation": {
-      "name": "Imported Contacts",
- "id": 4
-    }
+    "name": "Imported Contacts",
+    "id": 4
+  }
 }

--- a/src/test/elements/bullhorn/candidates.js
+++ b/src/test/elements/bullhorn/candidates.js
@@ -14,6 +14,7 @@ suite.forElement('crm', 'candidates', { payload: payload }, (test) => {
       .then(r => candidateId = r.body.changedEntityId)
       .then(r => cloud.get(test.api))
       .then(r => cloud.get(`${test.api}/${candidateId}`))
+      .then(r => cloud.withOptions({ qs: { fields: 'id,address.countryCode,secondaryAddress.countryCode' } }).get(`${test.api}/${candidateId}`))
       .then(r => cloud.patch(`${test.api}/${candidateId}`, updatePayload))
       .then(r => cloud.delete(`${test.api}/${candidateId}`));
   });

--- a/src/test/elements/bullhorn/candidates.js
+++ b/src/test/elements/bullhorn/candidates.js
@@ -2,7 +2,7 @@
 const suite = require('core/suite');
 const cloud = require('core/cloud');
 const payload = require('./assets/candidates');
-const updatePayload = {
+const expect = require('chakram').expect;const updatePayload = {
   "name": "John Snow",
   "firstName": "John",
   "lastName": "Snow"
@@ -14,7 +14,15 @@ suite.forElement('crm', 'candidates', { payload: payload }, (test) => {
       .then(r => candidateId = r.body.changedEntityId)
       .then(r => cloud.get(test.api))
       .then(r => cloud.get(`${test.api}/${candidateId}`))
-      .then(r => cloud.withOptions({ qs: { fields: 'id,address.countryCode,secondaryAddress.countryCode' } }).get(`${test.api}/${candidateId}`))
+      .then(r => cloud.withOptions({ qs: { fields: 'id,address.countryCode,secondaryAddress.countryCode' } })
+        .get(`${test.api}/${candidateId}`)
+        .then(r => {
+          expect(r.body).to.contain.key('id');
+          expect(r.body).to.contain.key('address');
+          expect(r.body.address).to.contain.key('countryCode');
+          expect(r.body).to.contain.key('secondaryAddress');
+          expect(r.body.secondaryAddress).to.contain.key('countryCode');
+        }))
       .then(r => cloud.patch(`${test.api}/${candidateId}`, updatePayload))
       .then(r => cloud.delete(`${test.api}/${candidateId}`));
   });

--- a/src/test/elements/bullhorn/company.js
+++ b/src/test/elements/bullhorn/company.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const suite = require('core/suite');
+const expect = require('chakram').expect;
 const cloud = require('core/cloud');
 const tools = require('core/tools');
 const payload = tools.requirePayload(`${__dirname}/assets/company.json`);
@@ -14,7 +15,13 @@ suite.forElement('crm', 'companies', { payload: payload }, (test) => {
       .then(r => companyId = r.body.changedEntityId)
       .then(r => cloud.get(test.api))
       .then(r => cloud.get(`${test.api}/${companyId}`))
-      .then(r => cloud.withOptions({ qs: { fields: 'id,department.name' } }).get(`${test.api}/${companyId}`))
+      .then(r => cloud.withOptions({ qs: { fields: 'id,department.name' } })
+        .get(`${test.api}/${companyId}`)
+        .then(r => {
+          expect(r.body).to.contain.key('id');
+          expect(r.body).to.contain.key('department');
+          expect(r.body.department).to.contain.key('name');
+        }))
       .then(r => cloud.patch(`${test.api}/${companyId}`, updatePayload));
 
 

--- a/src/test/elements/bullhorn/company.js
+++ b/src/test/elements/bullhorn/company.js
@@ -7,13 +7,14 @@ const payload = tools.requirePayload(`${__dirname}/assets/company.json`);
 
 const updatePayload = {};
 //Skipping the test since Delete is not supported for this Company resource.
-suite.forElement('crm', 'company', { payload: payload }, (test) => {
+suite.forElement('crm', 'companies', { payload: payload }, (test) => {
   it.skip('should support CRUDS for company', () => {
     let companyId;
     return cloud.post(test.api, payload)
       .then(r => companyId = r.body.changedEntityId)
       .then(r => cloud.get(test.api))
       .then(r => cloud.get(`${test.api}/${companyId}`))
+      .then(r => cloud.withOptions({ qs: { fields: 'id,department.name' } }).get(`${test.api}/${companyId}`))
       .then(r => cloud.patch(`${test.api}/${companyId}`, updatePayload));
 
 

--- a/src/test/elements/bullhorn/contacts.js
+++ b/src/test/elements/bullhorn/contacts.js
@@ -2,6 +2,7 @@
 const suite = require('core/suite');
 const cloud = require('core/cloud');
 const payload = require('./assets/contacts');
+const expect = require('chakram').expect;
 
 const updatePayload = {
   "name": "John Snow",
@@ -16,8 +17,13 @@ suite.forElement('crm', 'contacts', { payload: payload }, (test) => {
       .then(r => contactId = r.body.changedEntityId)
       .then(r => cloud.get(test.api))
       .then(r => cloud.get(`${test.api}/${contactId}`))
-      .then(r => cloud.withOptions({ qs: { fields: 'id  ,secondaryAddress.countryCode' } }).get(`${test.api}/${contactId}`))
-      .then(r => cloud.patch(`${test.api}/${contactId}`, updatePayload))
+      .then(r => cloud.withOptions({ qs: { fields: 'id  ,secondaryAddress.countryCode' } })
+      .get(`${test.api}/${contactId}`)
+      .then(r => {
+      expect(r.body).to.contain.key('id');
+      expect(r.body).to.contain.key('secondaryAddress');
+      expect(r.body.secondaryAddress).to.contain.key('countryCode');
+      }))      .then(r => cloud.patch(`${test.api}/${contactId}`, updatePayload))
       .then(r => cloud.delete(`${test.api}/${contactId}`));
   });
 });

--- a/src/test/elements/bullhorn/contacts.js
+++ b/src/test/elements/bullhorn/contacts.js
@@ -16,6 +16,7 @@ suite.forElement('crm', 'contacts', { payload: payload }, (test) => {
       .then(r => contactId = r.body.changedEntityId)
       .then(r => cloud.get(test.api))
       .then(r => cloud.get(`${test.api}/${contactId}`))
+      .then(r => cloud.withOptions({ qs: { fields: 'id  ,secondaryAddress.countryCode' } }).get(`${test.api}/${contactId}`))
       .then(r => cloud.patch(`${test.api}/${contactId}`, updatePayload))
       .then(r => cloud.delete(`${test.api}/${contactId}`));
   });

--- a/src/test/elements/bullhorn/leads.js
+++ b/src/test/elements/bullhorn/leads.js
@@ -12,6 +12,7 @@ suite.forElement('crm', 'leads', { payload: payload }, (test) => {
     return cloud.post(test.api, payload)
       .then(r => leadId = r.body.changedEntityId)
       .then(r => cloud.get(`${test.api}/${leadId}`))
+      .then(r => cloud.withOptions({ qs: { fields: 'id,secondaryAddress.countryCode' } }).get(`${test.api}/${leadId}`))
       .then(r => cloud.patch(`${test.api}/${leadId}`, updatePayload))
       .then(r => cloud.delete(`${test.api}/${leadId}`));
   });

--- a/src/test/elements/bullhorn/leads.js
+++ b/src/test/elements/bullhorn/leads.js
@@ -2,6 +2,7 @@
 
 const suite = require('core/suite');
 const cloud = require('core/cloud');
+const expect = require('chakram').expect;
 const payload = require('./assets/leads');
 const updatePayload = {
   "email": "test@gamil.com"
@@ -12,7 +13,13 @@ suite.forElement('crm', 'leads', { payload: payload }, (test) => {
     return cloud.post(test.api, payload)
       .then(r => leadId = r.body.changedEntityId)
       .then(r => cloud.get(`${test.api}/${leadId}`))
-      .then(r => cloud.withOptions({ qs: { fields: 'id,secondaryAddress.countryCode' } }).get(`${test.api}/${leadId}`))
+      .then(r => cloud.withOptions({ qs: { fields: 'id,owner.firstName' } })
+        .get(`${test.api}/${leadId}`)
+        .then(r => {
+          expect(r.body).to.contain.key('id');
+          expect(r.body).to.contain.key('owner');
+          expect(r.body.owner).to.contain.key('firstName');
+        }))
       .then(r => cloud.patch(`${test.api}/${leadId}`, updatePayload))
       .then(r => cloud.delete(`${test.api}/${leadId}`));
   });

--- a/src/test/elements/bullhorn/notes.js
+++ b/src/test/elements/bullhorn/notes.js
@@ -2,6 +2,7 @@
 
 const suite = require('core/suite');
 const tools = require('core/tools');
+const expect = require('chakram').expect;
 const cloud = require('core/cloud');
 const notesPayload = require('./assets/notes');
 
@@ -17,7 +18,13 @@ suite.forElement('crm', 'notes', { payload: notesPayload }, (test) => {
     return cloud.post(test.api, payload)
       .then(r => noteId = r.body.changedEntityId)
       .then(r => cloud.get(`${test.api}/${noteId}`))
-      .then(r => cloud.withOptions({ qs: { fields: 'id,personReference.firstName' } }).get(`${test.api}/${noteId}`))
+      .then(r => cloud.withOptions({ qs: { fields: 'comments,personReference.id' } })
+        .get(`${test.api}/${noteId}`)
+        .then(r => {
+          expect(r.body).to.contain.key('comments');
+          expect(r.body).to.contain.key('personReference');
+          expect(r.body.personReference).to.contain.key('id');
+        }))
       .then(r => cloud.patch(`${test.api}/${noteId}`, updatePayload))
       .then(r => cloud.delete(`${test.api}/${noteId}`));
   });

--- a/src/test/elements/bullhorn/notes.js
+++ b/src/test/elements/bullhorn/notes.js
@@ -17,6 +17,7 @@ suite.forElement('crm', 'notes', { payload: notesPayload }, (test) => {
     return cloud.post(test.api, payload)
       .then(r => noteId = r.body.changedEntityId)
       .then(r => cloud.get(`${test.api}/${noteId}`))
+      .then(r => cloud.withOptions({ qs: { fields: 'id,personReference.firstName' } }).get(`${test.api}/${noteId}`))
       .then(r => cloud.patch(`${test.api}/${noteId}`, updatePayload))
       .then(r => cloud.delete(`${test.api}/${noteId}`));
   });

--- a/src/test/elements/bullhorn/opportunities.js
+++ b/src/test/elements/bullhorn/opportunities.js
@@ -2,10 +2,11 @@
 
 const suite = require('core/suite');
 const cloud = require('core/cloud');
+const expect = require('chakram').expect;
 const payload = require('./assets/opportunities');
 
 const updatePayload = {
-    "type": "contract"
+  "type": "contract"
 };
 
 suite.forElement('crm', 'opportunities', { payload: payload }, (test) => {
@@ -14,7 +15,13 @@ suite.forElement('crm', 'opportunities', { payload: payload }, (test) => {
     return cloud.post(test.api, payload)
       .then(r => opportunityId = r.body.changedEntityId)
       .then(r => cloud.get(`${test.api}/${opportunityId}`))
-      .then(r => cloud.withOptions({ qs: { fields: 'id,owner.firstName' } }).get(`${test.api}/${opportunityId}`))
+      .then(r => cloud.withOptions({ qs: { fields: 'id,clientCorporation.name' } })
+        .get(`${test.api}/${opportunityId}`)
+        .then(r => {
+          expect(r.body).to.contain.key('id');
+          expect(r.body).to.contain.key('clientCorporation');
+          expect(r.body.clientCorporation).to.contain.key('name');
+        }))
       .then(r => cloud.patch(`${test.api}/${opportunityId}`, updatePayload))
       .then(r => cloud.delete(`${test.api}/${opportunityId}`));
   });

--- a/src/test/elements/bullhorn/opportunities.js
+++ b/src/test/elements/bullhorn/opportunities.js
@@ -14,6 +14,7 @@ suite.forElement('crm', 'opportunities', { payload: payload }, (test) => {
     return cloud.post(test.api, payload)
       .then(r => opportunityId = r.body.changedEntityId)
       .then(r => cloud.get(`${test.api}/${opportunityId}`))
+      .then(r => cloud.withOptions({ qs: { fields: 'id,owner.firstName' } }).get(`${test.api}/${opportunityId}`))
       .then(r => cloud.patch(`${test.api}/${opportunityId}`, updatePayload))
       .then(r => cloud.delete(`${test.api}/${opportunityId}`));
   });


### PR DESCRIPTION
## Non-customer Highlights:
* Added test cases on every resource to test the GET APIs with `fields` parameter.
* Corrected the test cases for `companies` resource as they were initially refering to a non-existing URL with enpoint as `company`. Changed this to `companies`
* The credentials for Bullhorn are not specified in the `sauce.js` file. A valid set of credentials is not yet available. Have requested for the same. Will add those  when available.

## Screenshot
![image](https://user-images.githubusercontent.com/20282215/35166451-fb2631d0-fd77-11e7-9046-e7aac3e7f249.png)

## Reference
* [SOBA](https://github.com/cloud-elements/soba/pull/7862)
* [RALLY-#DE642](https://rally1.rallydev.com/#/144349237612d/detail/defect/186246933788)

## Closes
* Closes [#DE642](https://rally1.rallydev.com/#/144349237612d/detail/defect/186246933788)

  