### PR TITLE
Fixed contacts and added POST /contacts/:id/merge tests

### DIFF
--- a/src/test/elements/marketo/assets/contacts.json
+++ b/src/test/elements/marketo/assets/contacts.json
@@ -1,7 +1,7 @@
 {
   "person": {
-    "lastName": "prsonccdssddc",
-    "firstName": "AHolxxdddddffffxlyss",
-    "email": "Holly.Rofff234on@cloud-elements.com"
+    "lastName": "<<name.lastName>>",
+    "firstName": "<<name.firstName>>",
+    "email": "<<internet.email>>"
   }
 }

--- a/src/test/elements/marketo/contacts.js
+++ b/src/test/elements/marketo/contacts.js
@@ -3,37 +3,61 @@
 const suite = require('core/suite');
 const tools = require('core/tools');
 const cloud = require('core/cloud');
-const payload = {
+const expect = require('chakram').expect;
+const payload = tools.requirePayload(`${__dirname}/assets/contacts.json`);
+const updatedPayload = {
   "person": {
     "lastName": tools.randomStr(),
     "firstName": tools.randomStr(),
     "email": tools.randomEmail()
   }
 };
+const interactionPayload = {
+  "id": tools.randomInt(),
+  "token": tools.randomInt()
+};
 
 suite.forElement('marketing', 'contacts', { payload: payload }, (test) => {
-  it('should allow CRUDS for /contacts , GET /deleted-contacts and GET/changed-contacts ', () => {
-    const updatedPayload = {
-      "person": {
-        "lastName": tools.randomStr(),
-        "firstName": tools.randomStr(),
-        "email": tools.randomEmail()
-      }
-    };
-    const interactionPayload = {
-      "id": tools.randomInt(),
-      "token": tools.randomInt()
-    };
-    let id, value;
+  it('should allow CRUDS for /contacts', () => {
+    let id;
     return cloud.post(test.api, payload)
       .then(r => id = r.body.person.id)
-      .then(r => value = `id in ( ${id} )`)
       .then(r => cloud.get(`${test.api}/${id}`))
       .then(r => cloud.patch(`${test.api}/${id}`, updatedPayload))
-      .then(r => cloud.withOptions({ qs: { where: `${value}` } }).get(`${test.api}`))
-      .then(r => cloud.post(`${test.api}/${id}/interactions`, interactionPayload))
-      .then(r => cloud.withOptions({ qs: { where: "sinceDate = '2016-11-25T11:39:58Z'" } }).get(`hubs/marketing/deleted-contacts`))
-      .then(r => cloud.withOptions({ qs: { where: "sinceDate = '2016-11-25T11:39:58Z'" } }).get(`hubs/marketing/changed-contacts`))
+      .then(r => cloud.withOptions({ qs: { where: `id in ( ${id} )` } }).get(test.api))
       .then(r => cloud.delete(`${test.api}/${id}`));
   });
+
+  it('should allow POST /contacts/:id/merge and POST /contacts/:id/interactions', () => {
+    let id, id2;
+    return cloud.post(test.api, payload)
+      .then(r => id = r.body.person.id)
+      .then(r => cloud.post(`${test.api}/${id}/interactions`, interactionPayload))
+      .then(r => cloud.post(test.api, updatedPayload))
+      .then(r => id2 = r.body.person.id)
+      .then(r => cloud.post(`${test.api}/${id}/merge`, { leadIds: [id2] }))
+      .then(r => cloud.delete(`${test.api}/${id}`));
+  });
+
+  test
+    .withApi('/changed-contacts')
+    .withName('should support sinceDate query on GET /changed-contacts')
+    .withOptions({ qs: { where: `sinceDate = '2016-11-25T11:39:58Z'` } })
+    .withValidation(r => {
+      expect(r).to.statusCode(200);
+      const validValues = r.body.filter(obj => obj.activityDate >= '2016-11-25T11:39:58Z');
+      expect(validValues.length).to.equal(r.body.length);
+    })
+    .should.return200OnGet();
+
+  test
+    .withApi('/deleted-contacts')
+    .withName('should support sinceDate query on GET /deleted-contacts')
+    .withOptions({ qs: { where: `sinceDate = '2016-11-25T11:39:58Z'` } })
+    .withValidation(r => {
+      expect(r).to.statusCode(200);
+      const validValues = r.body.filter(obj => obj.activityDate >= '2016-11-25T11:39:58Z');
+      expect(validValues.length).to.equal(r.body.length);
+    })
+    .should.return200OnGet();
 });

--- a/src/test/elements/marketo/contacts.js
+++ b/src/test/elements/marketo/contacts.js
@@ -5,13 +5,7 @@ const tools = require('core/tools');
 const cloud = require('core/cloud');
 const expect = require('chakram').expect;
 const payload = tools.requirePayload(`${__dirname}/assets/contacts.json`);
-const updatedPayload = {
-  "person": {
-    "lastName": tools.randomStr(),
-    "firstName": tools.randomStr(),
-    "email": tools.randomEmail()
-  }
-};
+const updatedPayload = tools.requirePayload(`${__dirname}/assets/contacts.json`);
 const interactionPayload = {
   "id": tools.randomInt(),
   "token": tools.randomInt()


### PR DESCRIPTION
## Highlights
* ☝️ 

## Screenshot
```
churros test elements/marketo


info: Using url: http://localhost:8080
info: Using user: system
info: Using oauth username: marketo@cloud-elements.com
info: Using api key: 19e7183b-53ac-4366-ad5a-205deb9bec84
info: Running tests for element: marketo
info: Provisioned with instance id of 938
  Basic tests
    ✓ should provision
    ✓ should GET /objects (785ms)
    - docs
    ✓ metadata (144ms)
error: Failed to retrieve or validate: /hubs/marketing/activities
error: Failed to retrieve or validate: /hubs/marketing/companies
error: Failed to retrieve or validate: /hubs/marketing/sampleBulkCustomObject_c
    ✓ transformations (4620ms)
    - should not allow provisioning with bad credentials

  activities
    ✓ should allow GET for /hubs/marketing/activity-types (717ms)
    ✓ should allow GET for /hubs/marketing/activities (5316ms)
    ✓ should allow paginating with page and nextPage /hubs/marketing/activities (1244ms)
    - should allow POST for /hubs/marketing/activities

  campaigns
    ✓ should allow SR for /hubs/marketing/campaigns (1467ms)

  channels
    ✓ should allow SR for /hubs/marketing/channels (1375ms)

  companies
    ✓ should allow CRUDS for /companies (5389ms)

  contacts
    ✓ should allow CRUDS for /contacts (7232ms)
    ✓ should allow POST /contacts/:id/merge and POST /contacts/:id/interactions (9383ms)
    ✓ should support sinceDate query on GET /changed-contacts (1528ms)
    ✓ should support sinceDate query on GET /deleted-contacts (4828ms)

  extended-resource
    ✓ should test newly added account resource extended-resource (1211ms)

  external-activity
    - should allow CS external-activity/types, PATCH external-activity/type/{apiName}/approve and PATCH external-activity/type/{apiName}/attributes 

  files
    ✓ should allow creating a file for an uploaded file, and should get the created file (13322ms)

  folders
    ✓ It should perform CRUS for /folders (4567ms)

  programs
    ✓ should allow R for programs/{id}/leads (2985ms)

  lists
    ✓ should allow SR for /lists and CRDS for /contacts (9554ms)

  partitions
    ✓ should allow R for /partitions (468ms)

  ping
    ✓ should allow GET for /hubs/marketing/ping (141ms)

  polling
    - polling /hubs/marketing/contacts

  programs
    ✓ should allow CRUD for /programs (3086ms)

  programsLeads
error: Failed to retrieve or validate: /hubs/marketing/bulk/122/status
    ✓ should allow bulk upload using CSV file for /hubs/marking/bulk/programsLeads (4629ms)
error: Failed to retrieve or validate: /hubs/marketing/bulk/123/status
    ✓ should allow bulk upload using JSON file for /hubs/marking/bulk/programsLeads (6182ms)

  sampleBulkCustomObject_c
    ✓ should allow CRUD for /hubs/marketing/sampleBulkCustomObject_c (8113ms)

  tagTypes
    ✓ should allow paginating with page and pageSize for /hubs/marketing/tagTypes (1558ms)
    ✓ should allow Sr for Tagtypes  (1026ms)


  27 passing (2m)
  5 pending
```

## Reference
* [SOBA](https://github.com/cloud-elements/soba/pull/7885)
* [churros-sauce](Link to Associated Churros-sauce PR, when applicable)
* [RALLY](https://rally1.rallydev.com/#/144349237612d/detail/task/188524946500)

## Closes
* [TA4763](https://rally1.rallydev.com/#/144349237612d/detail/task/188524946500)
