### PR TITLE
Churros for /orders api

### DIFF
--- a/src/test/elements/clover/assets/order.json
+++ b/src/test/elements/clover/assets/order.json
@@ -1,0 +1,11 @@
+{
+    "note": "This is my latest order",
+    "isVat": false,
+    "manualTransaction": true,
+    "title": "<<random.word>>",
+    "testMode": true,
+    "currency": "USD",
+    "taxRemoved": true,
+    "state": "open",
+    "groupLineItems": true
+  }

--- a/src/test/elements/clover/orders.js
+++ b/src/test/elements/clover/orders.js
@@ -1,0 +1,21 @@
+const suite = require('core/suite');
+const tools = require('core/tools');
+const expect = require('chakram').expect;
+const payload = tools.requirePayload(`${__dirname}/assets/order.json`);
+
+suite.forElement('employee', 'orders', {payload:payload}, (test) => {
+  test.withApi(test.api)
+    .withOptions({ qs: { where: "modifiedTime>1508943600000" } })
+    .withValidation(r => expect(r.body.filter(obj => obj.id !== "")).to.not.be.empty)
+    .withName('should allow GET with option modifiedTime')
+    .should.return200OnGet();
+
+  test.withApi(test.api)
+    .withOptions({ qs: { where: "title='sweater'" } })
+    .withValidation(r => expect(r.body.filter(obj => obj.title === 'Sweater')).to.not.be.empty)
+    .withName('should allow GET with option title')
+    .should.return200OnGet();
+
+  test.should.supportPagination();
+  test.should.supportCruds();
+});


### PR DESCRIPTION
## Highlights
* Added churros for /orders api

## Screenshot
![screen shot 2018-01-09 at 5 14 40 pm](https://user-images.githubusercontent.com/26589919/34748621-0dd9db64-f563-11e7-8e77-2597c54a4982.png)

## Reference
* [SOBA](https://github.com/cloud-elements/soba/pull/7854)
* [RALLY-#${US2993}](https://rally1.rallydev.com/#/144349237612d/detail/userstory/172615120724)

## Closes
* Closes #[US2993](https://rally1.rallydev.com/#/144349237612d/detail/userstory/172615120724)

  
  