### PR TITLE
Box updates for webhooks and file comment APIS

### DIFF
--- a/src/test/elements/assets/basics.js
+++ b/src/test/elements/assets/basics.js
@@ -41,6 +41,10 @@
 
     it('metadata', () => cloud.get(`elements/${props.getForKey(element, 'elementId')}/metadata`).then(r => expect(r.body).to.not.be.empty && expect(r).to.have.statusCode(200)));
     it('transformations', function() {
+      if (props.get('hub') === 'documents') {
+        logger.debug('Skipping test as documents hub does not support transformations');
+        return Promise.resolve(null);
+      }
       argv.transform ? this.skip() : null; //no need to do this twice
       let isSync = argv.sync || ['netsuite', 'quickbooksonprem'].filter(e => element.includes(e)).length > 0;
       let error;

--- a/src/test/elements/box/assets/comment.json
+++ b/src/test/elements/box/assets/comment.json
@@ -1,0 +1,3 @@
+{
+  "comment": "<<lorem.words>>"
+}

--- a/src/test/elements/box/files.js
+++ b/src/test/elements/box/files.js
@@ -7,54 +7,42 @@ const faker = require('faker');
 const tools = require('core/tools');
 const payload = tools.requirePayload(`${__dirname}/assets/customFields.json`);
 const temPayload = tools.requirePayload(`${__dirname}/assets/template.json`);
-const lock = () => ({
+const commentPayload1 = tools.requirePayload(`${__dirname}/assets/comment.json`);
+const commentPayload2 = tools.requirePayload(`${__dirname}/assets/comment.json`);
+const lock = {
   "is_download_prevented": false,
   "expires_at": "2030-12-12T10:55:30-08:00"
-});
+};
 
-
-
-suite.forElement('documents', 'files', null, (test) => {
+suite.forElement('documents', 'files', (test) => {
+  let id, path;
+  before(done => {
+    return cloud.withOptions({ qs: { path: `/brady-${faker.address.zipCode()}.jpg` } }).postFile(test.api, `${__dirname}/../assets/brady.jpg`)
+      .then(r => {
+        id = r.body.id;
+        path = r.body.path;
+      })
+      .then(r => done());
+  });
+  after(() => cloud.delete(`${test.api}/${id}`));
   afterEach(done => {
     //We were getting a 429 before this
     setTimeout(done, 2500);
   });
 
   it('should allow PUT /files/:id/lock and DELETE /files/:id/lock', () => {
-    let fileId;
-    let path = __dirname + '/../assets/brady.jpg';
-    let query = { path: `/brady-${faker.address.zipCode()}.jpg` };
-    return cloud.withOptions({ qs: query }).postFile('/hubs/documents/files', path)
-      .then(r => fileId = r.body.id)
-      .then(r => cloud.put('/hubs/documents/files/' + fileId + '/lock', null, null, lock))
-      .then(r => cloud.delete('/hubs/documents/files/' + fileId + '/lock'))
-      .then(r => cloud.delete(test.api + '/' + fileId));
+    return cloud.put(`${test.api}/${id}/lock`, null, null, lock)
+      .then(r => cloud.delete(`${test.api}/${id}/lock`));
   });
 
-  it('should support links for files/:id/links without raw payload', () => {
-    let fileId;
-    let path = __dirname + '/../assets/brady.jpg';
-    let query = { path: `/brady-${faker.address.zipCode()}.jpg` };
-    return cloud.withOptions({ qs: query }).postFile('/hubs/documents/files', path)
-      .then(r => fileId = r.body.id)
-      .then(r => cloud.get("/hubs/documents/files/" + fileId + "/links"))
-      .then(r => expect(r.body).to.not.contain.key('raw'))
-      .then(r => cloud.delete('/hubs/documents/files/' + fileId));
+  it('should allow links for files/:id/links without raw payload', () => {
+    return cloud.get(`${test.api}/${id}/links`)
+      .then(r => expect(r.body).to.not.contain.key('raw'));
   });
 
-  it('should support links for files/links with raw payload', () => {
-    let fileId;
-    let filePath;
-    let path = __dirname + '/../assets/brady.jpg';
-    let query = { path: `/brady-${faker.address.zipCode()}.jpg` };
-    return cloud.withOptions({ qs: query }).postFile('/hubs/documents/files', path)
-      .then(r => {
-        fileId = r.body.id;
-        filePath = r.body.path;
-      })
-      .then(r => cloud.withOptions({ qs: { path: filePath, raw: true } }).get("/hubs/documents/files/links"))
-      .then(r => expect(r.body).to.contain.key('raw'))
-      .then(r => cloud.delete('/hubs/documents/files/' + fileId));
+  it('should allow links for files/links with raw payload', () => {
+    return cloud.withOptions({ qs: { path: path, raw: true } }).get(`${test.api}/links`)
+      .then(r => expect(r.body).to.contain.key('raw'));
   });
 
   it('should fail when copying file with existing file name', () => {
@@ -63,26 +51,26 @@ suite.forElement('documents', 'files', null, (test) => {
     let query1 = { path: `/brady-${faker.address.zipCode()}.jpg` };
     let query2 = { path: `/brady-${faker.address.zipCode()}.jpg` };
 
-    return cloud.withOptions({ qs: query1 }).postFile('/hubs/documents/files', path)
+    return cloud.withOptions({ qs: query1 }).postFile(test.api, path)
       .then(r => {
         fileId1 = r.body.id;
         filePath1 = r.body.path;
       })
-      .then(r => cloud.withOptions({ qs: query2 }).postFile('/hubs/documents/files', path))
+      .then(r => cloud.withOptions({ qs: query2 }).postFile(test.api, path))
       .then(r => {
         fileId2 = r.body.id;
         filePath2 = r.body.path;
       })
       .then(r => cloud.withOptions({ qs: { path: filePath1, overwrite: false } }).post('/hubs/documents/files/copy', { path: filePath2 }, r => { expect(r).to.have.statusCode(409); }))
       .then(r => cloud.get(`/hubs/documents/files/${fileId2}/metadata`))
-      .then(r => { expect(r).to.have.statusCode(200) && expect(r.body.id).to.equal(fileId2); })
+      .then(r => { expect(r).to.have.statusCode(200) && expect(r.body.id).to.equal(fileId2) })
       .then(r => cloud.delete('/hubs/documents/files/' + fileId1))
       .then(r => cloud.delete('/hubs/documents/files/' + fileId2));
   });
 
 
-  it('should support CRUDS for /files/:id/custom-fields', () => {
-    let fileId1, tempKey;
+  it('should allow CRUDS for /files/:id/custom-fields', () => {
+    let tempKey;
     let updatePayload = {
       "template": "customer",
       "path": "/" + temPayload.fields[0].key,
@@ -97,48 +85,82 @@ suite.forElement('documents', 'files', null, (test) => {
 
     let path = __dirname + '/../assets/brady.jpg';
     let query1 = { path: `/brady-${faker.address.zipCode()}.jpg` };
-    return cloud.withOptions({ qs: query1 }).postFile('/hubs/documents/files', path)
-      .then(r => fileId1 = r.body.id)
-      .then(r => cloud.post('/hubs/documents/custom-fields/templates', temPayload))
+    return cloud.post('/hubs/documents/custom-fields/templates', temPayload)
       .then(r => {
         tempKey = r.body.templateKey;
         updatePayload.template = r.body.templateKey;
-		payload.template = r.body.templateKey;	
+        payload.template = r.body.templateKey;
       })
-      .then(r => cloud.get(`/hubs/documents/files/${fileId1}/custom-fields`))
-      .then(r => cloud.post(`/hubs/documents/files/${fileId1}/custom-fields`, payload))
-      .then(r => cloud.put(`/hubs/documents/files/${fileId1}/custom-fields`, updatePayload))
-      .then(r => cloud.patch(`/hubs/documents/files/${fileId1}/custom-fields`, updatePayload))
-      .then(r => cloud.withOptions({ qs: { scope: "enterprise" } }).get(`/hubs/documents/files/${fileId1}/custom-fields/${tempKey}`))
-      .then(r => cloud.patch(`/hubs/documents/files/${fileId1}/custom-fields/${tempKey}`, templateKeyPayload))
-      .then(r => cloud.withOptions({ qs: { scope: "enterprise" } }).delete(`/hubs/documents/files/${fileId1}/custom-fields/${tempKey}`))
-      .then(r => cloud.delete('/hubs/documents/files/' + fileId1));
+      .then(r => cloud.get(`/hubs/documents/files/${id}/custom-fields`))
+      .then(r => cloud.post(`/hubs/documents/files/${id}/custom-fields`, payload))
+      .then(r => cloud.put(`/hubs/documents/files/${id}/custom-fields`, updatePayload))
+      .then(r => cloud.patch(`/hubs/documents/files/${id}/custom-fields`, updatePayload))
+      .then(r => cloud.withOptions({ qs: { scope: "enterprise" } }).get(`/hubs/documents/files/${id}/custom-fields/${tempKey}`))
+      .then(r => cloud.patch(`/hubs/documents/files/${id}/custom-fields/${tempKey}`, templateKeyPayload))
+      .then(r => cloud.withOptions({ qs: { scope: "enterprise" } }).delete(`/hubs/documents/files/${id}/custom-fields/${tempKey}`));
 
   });
 
   /**
-  * /files/revisions endpoint doesn't return current revision. 
-  * While we don't offer the POST /revisions endpoint we'll need to hardcode the file data
-  */
-  it('it should allow RS for documents/files/:id/revisions', () => {
+   * /files/revisions endpoint doesn't return current revision.
+   * While we don't offer the POST /revisions endpoint we'll need to hardcode the file data
+   */
+  it('should allow RS for documents/files/:id/revisions', () => {
     const fileId = 158316363797;
     let revisionId;
     return cloud.get(`${test.api}/${fileId}/revisions`)
       .then(r => {
-          expect(r.body[0]).to.contain.key('id');
-          revisionId = r.body[0].id;
+        expect(r.body[0]).to.contain.key('id');
+        revisionId = r.body[0].id;
       })
       .then(() => cloud.get(`${test.api}/${fileId}/revisions/${revisionId}`));
   });
 
-  it('it should allow RS for documents/files/revisions by path', () => {
-    let options = {qs:{path: '/TestFolderDoNoDelete/Sample WordDoc.docx'}};
+  it('should allow RS for documents/files/revisions by path', () => {
+    let options = { qs: { path: '/TestFolderDoNoDelete/Sample WordDoc.docx' } };
     let revisionId;
-      return cloud.withOptions(options).get(`${test.api}/revisions`)
-        .then(r => {
-            expect(r.body[0]).to.contain.key('id');
-            revisionId = r.body[0].id;
-        })
-        .then(() => cloud.withOptions(options).get(`${test.api}/revisions/${revisionId}`));
-  }); 
+    return cloud.withOptions(options).get(`${test.api}/revisions`)
+      .then(r => {
+        expect(r.body[0]).to.contain.key('id');
+        revisionId = r.body[0].id;
+      })
+      .then(() => cloud.withOptions(options).get(`${test.api}/revisions/${revisionId}`));
+  });
+
+  it(`should allow CRUDS for ${test.api}/:id/comments`, () => cloud.cruds(`${test.api}/${id}/comments`, commentPayload1));
+
+  it(`should allow CRUDS for ${test.api}/comments by path`, () => cloud.withOptions({ qs: { path } }).cruds(`${test.api}/comments`, commentPayload1));
+
+  it(`should allow paginating for ${test.api}/:id/comments`, () => {
+    let commentId1, commentId2;
+    return cloud.post(`${test.api}/${id}/comments`, commentPayload1)
+      .then(r => commentId1 = r.body.id)
+      .then(r => cloud.post(`${test.api}/${id}/comments`, commentPayload2))
+      .then(r => commentId2 = r.body.id)
+      .then(r => cloud.withOptions({ qs: { pageSize: 1, page: 1 } }).get(`${test.api}/${id}/comments`))
+      .then(r => expect(r.body).to.have.lengthOf(1))
+      .then(r => cloud.withOptions({ qs: { pageSize: 1, page: 2 } }).get(`${test.api}/${id}/comments`))
+      .then(r => expect(r.body).to.have.lengthOf(1))
+      .then(r => cloud.withOptions({ qs: { pageSize: 1, page: 3 } }).get(`${test.api}/${id}/comments`))
+      .then(r => expect(r.body).to.be.empty)
+      .then(r => cloud.delete(`${test.api}/${id}/comments/${commentId1}`))
+      .then(r => cloud.delete(`${test.api}/${id}/comments/${commentId2}`));
+  });
+
+  it(`should allow paginating for ${test.api}/comments by path`, () => {
+    let commentId1, commentId2;
+    return cloud.withOptions({ qs: { path } }).post(`${test.api}/comments`, commentPayload1)
+      .then(r => commentId1 = r.body.id)
+      .then(r => cloud.withOptions({ qs: { path } }).post(`${test.api}/comments`, commentPayload2))
+      .then(r => commentId2 = r.body.id)
+      .then(r => cloud.withOptions({ qs: { pageSize: 1, page: 1, path } }).get(`${test.api}/comments`))
+      .then(r => expect(r.body).to.have.lengthOf(1))
+      .then(r => cloud.withOptions({ qs: { pageSize: 1, page: 2, path } }).get(`${test.api}/comments`))
+      .then(r => expect(r.body).to.have.lengthOf(1))
+      .then(r => cloud.withOptions({ qs: { pageSize: 1, page: 3, path } }).get(`${test.api}/comments`))
+      .then(r => expect(r.body).to.be.empty)
+      .then(r => cloud.withOptions({ qs: { path } }).delete(`${test.api}/comments/${commentId1}`))
+      .then(r => cloud.withOptions({ qs: { path } }).delete(`${test.api}/comments/${commentId2}`));
+  });
+
 });

--- a/src/test/elements/box/webhooks.js
+++ b/src/test/elements/box/webhooks.js
@@ -2,21 +2,22 @@
 
 const suite = require('core/suite');
 const cloud = require('core/cloud');
+const props = require('core/props');
 const faker = require('faker');
 const chakram = require('chakram');
+const webhookTemplate = (fileId) => ({ "target": { "id": fileId, "type": "file" }, "triggers": ["METADATA_INSTANCE.CREATED", "METADATA_INSTANCE.UPDATED", "METADATA_INSTANCE.DELETED"] });
+// Box doesn't allow localhost callback
+const getWebhookPayload = (fileId, url) => url && url.includes('localhost') ? Object.assign({}, webhookTemplate(fileId), { address: props.getOptional('event.callback.url') }) : webhookTemplate(fileId);
 
-const webhookPayload = (fileId) => ({"target":{"id":fileId,"type":"file"},"triggers":["METADATA_INSTANCE.CREATED","METADATA_INSTANCE.UPDATED","METADATA_INSTANCE.DELETED"]});
-suite.forElement('documents', 'webhooks', null, (test) => {
-  let fileId,path = __dirname + '/../assets/brady.jpg';
+suite.forElement('documents', 'webhooks', (test) => {
+  let fileId, path = `${__dirname}/../assets/brady.jpg`;
   let query = { path: `/brady-${faker.random.number()}.jpg` };
+
   before(() => cloud.withOptions({ qs: query }).postFile('/hubs/documents/files', path)
-  .then(r => fileId = r.body.id)
+    .then(r => fileId = r.body.id)
   );
   it('should support CRUDS for webhooks', () => {
-    return cloud.cruds(test.api,webhookPayload(fileId),null,chakram.put);
+    return cloud.cruds(test.api, getWebhookPayload(fileId, props.getOptional('url')), null, chakram.put);
   });
-  after(() => cloud.delete('/hubs/documents/files/' + fileId));
+  after(() => cloud.delete(`/hubs/documents/files/${fileId}`));
 });
-
-
-


### PR DESCRIPTION
## Highlights
* Fixed `webhooks` test for running locally
* Added skip transformations tests for Documents hub 
* Cleaned up `files` test and added `.../comments` tests

## Screenshot
```
churros test elements/box


info: Using url: http://localhost:8080
info: Using user: system
info: Using oauth username: developer@cloud-elements.com
info: Using api key: 0zltudvqp2mlbqbctahxhndis0p630hm
info: Running tests for element: box
info: Provisioned with instance id of 955
  Basic tests
    ✓ should provision
    ✓ should GET /objects (2313ms)
    - docs
    ✓ metadata (144ms)
    ✓ transformations
    - should not allow provisioning with bad credentials

  custom-fields
    - should support CRUS for /custom-fields/templates

  files
    ✓ should allow PUT /files/:id/lock and DELETE /files/:id/lock (4777ms)
    ✓ should allow links for files/:id/links without raw payload (3723ms)
    ✓ should allow links for files/links with raw payload (6123ms)
    ✓ should fail when copying file with existing file name (30109ms)
    ✓ should allow CRUDS for /files/:id/custom-fields (10814ms)
    ✓ should allow RS for documents/files/:id/revisions (6536ms)
    ✓ should allow RS for documents/files/revisions by path (11311ms)
    ✓ should allow CRUDS for /hubs/documents/files/:id/comments (17658ms)
    ✓ should allow CRUDS for /hubs/documents/files/comments by path (26967ms)
    ✓ should allow paginating for /hubs/documents/files/:id/comments (23955ms)
    ✓ should allow paginating for /hubs/documents/files/comments by path (37262ms)

  folders
    ✓ should allow CD for /hubs/documents/folders and GET collaborations (12100ms)
    ✓ should include bookmarks in GET /folders/contents results (5083ms)

  folders
    ✓ should allow CD for /hubs/documents/folders and GET links (16180ms)

  groups
    ✓ should allow CUDS for /hubs/documents/groups (3729ms)

  files
    ✓ should allow CRD /files and RD /files/:id (41470ms)
    ✓ should allow GET /files/links and /files/:id/links (21974ms)
    ✓ should allow RU /files/metadata and RU /files/:id/metadata (27943ms)
    ✓ should allow POST /files/copy and POST /files/:id/copy (37291ms)

  folders
    ✓ should allow CD /folders and DELETE /folders/:id (22395ms)
    ✓ should allow GET /folders/contents and GET /folders/:id/contents (21775ms)
    ✓ should allow RU /folders/metadata and RU /folders/:id/metadata (28685ms)
    ✓ should allow POST /folders/copy and POST /folders/:id/copy (33751ms)

  storage
    ✓ should allow GET for /hubs/documents/storage (3584ms)

  search
    ✓ should allow GET for /hubs/documents/search (28405ms)

  search
    ✓ should support template filtering for GET /search (13024ms)

  users
    ✓ should allow CRUDS for /hubs/documents/users (5303ms)
    ✓ should allow paginating with page and pageSize for /hubs/documents/users (3394ms)
    ✓ should allow GET for /hubs/documents/users (848ms)

  webhooks
    ✓ should support CRUDS for webhooks (19800ms)


  34 passing (10m)
  3 pending

```

## Reference
* [SOBA](Link to SOBA or Other PR for which tests were written, when applicable)
* [churros-sauce](Link to Associated Churros-sauce PR, when applicable)
* [DE474](https://rally1.rallydev.com/#/144349237612d/detail/defect/175378236948)
* [TA5276](https://rally1.rallydev.com/#/144349237612d/detail/task/189647333384)

## Closes
* [DE474](https://rally1.rallydev.com/#/144349237612d/detail/defect/175378236948)