### PR TITLE
Square /customers API Testcases

### DIFF
--- a/src/test/elements/square/assets/customer.json
+++ b/src/test/elements/square/assets/customer.json
@@ -1,0 +1,3 @@
+{
+  "given_name": "<<random.word>>"
+}

--- a/src/test/elements/square/assets/transformations.json
+++ b/src/test/elements/square/assets/transformations.json
@@ -5,5 +5,12 @@
       "path": "id",
       "vendorPath": "id"
     }]
+  },
+  "customers": {
+    "vendorName": "customers",
+    "fields": [{
+      "path": "id",
+      "vendorPath": "id"
+    }]
   }
 }

--- a/src/test/elements/square/customers.js
+++ b/src/test/elements/square/customers.js
@@ -2,7 +2,6 @@
 
 const suite = require('core/suite');
 const tools = require('core/tools');
-const chakram = require('chakram');
 const customerPayload = tools.requirePayload(`${__dirname}/assets/customer.json`);
 
 suite.forElement('employee', 'customers', { payload : customerPayload }, (test) => {

--- a/src/test/elements/square/customers.js
+++ b/src/test/elements/square/customers.js
@@ -1,0 +1,12 @@
+'use strict';
+
+const suite = require('core/suite');
+const tools = require('core/tools');
+const chakram = require('chakram');
+const customerPayload = tools.requirePayload(`${__dirname}/assets/customer.json`);
+
+suite.forElement('employee', 'customers', { payload : customerPayload }, (test) => {
+  test.should.supportCruds();
+  test.should.supportPagination();
+  test.should.supportNextPagePagination(1);
+});

--- a/src/test/elements/square/customers.js
+++ b/src/test/elements/square/customers.js
@@ -7,5 +7,5 @@ const customerPayload = tools.requirePayload(`${__dirname}/assets/customer.json`
 suite.forElement('employee', 'customers', { payload : customerPayload }, (test) => {
   test.should.supportCruds();
   test.should.supportPagination();
-  test.should.supportNextPagePagination(1);
+  test.should.supportNextPagePagination(3);
 });

--- a/src/test/elements/square/employees.js
+++ b/src/test/elements/square/employees.js
@@ -37,9 +37,7 @@ suite.forElement('employee', 'employees', (test) => {
 
   let empId, roleId;
   before(() => cloud.get(`hubs/employee/roles`)
-    .then(r => roleId = r.body[0].id)
-    .then(r => employeePayload.role_ids = roleId)
-    .then(r => employeeUpdatePayload.role_ids = roleId));
+    .then(r => roleId = r.body[0].id));
 
   it('should allow CRU for /employees', () => {
     return cloud.post(test.api, employeePayload)

--- a/src/test/elements/square/locations.js
+++ b/src/test/elements/square/locations.js
@@ -4,7 +4,7 @@ const suite = require('core/suite');
 const expect = require('chakram').expect;
 
 suite.forElement('employee', 'locations', (test) => {
-  test.should.supportPagination();
+  test.should.supportPagination("id");
   test.withValidation(r => {
         expect(r).to.have.statusCode(200);
         expect(r.body.filter(obj => obj.id !== null)).to.not.be.empty;

--- a/src/test/elements/square/payments.js
+++ b/src/test/elements/square/payments.js
@@ -9,7 +9,7 @@ suite.forElement('employee', 'locations', (test) => {
   let locId, paymentId, business, businessName = 'Cloud Elements';
   before(() => cloud.get(test.api)
     .then(r => {
-      business = r.body.filter(obj => obj['business_name'] && obj['business_name'] === businessName);
+      business = r.body.filter(obj => obj.business_name && obj.business_name === businessName);
       expect(business).to.not.be.empty;
       locId = business[0].id;
     }));

--- a/src/test/elements/square/payments.js
+++ b/src/test/elements/square/payments.js
@@ -8,7 +8,7 @@ suite.forElement('employee', 'locations', (test) => {
 
   let locId, paymentId;
   before(() => cloud.get(test.api)
-    .then(r => locId = r.body[1].id));
+    .then(r => locId = r.body[3].id));
 
   it(`should allow GET with where begin_time for ${test.api}/:id/payments`, () => {
     return cloud.withOptions({ qs: { where: "begin_time='2017-10-03T18:18:45Z'" } }).get(`${test.api}/${locId}/payments`)

--- a/src/test/elements/square/payments.js
+++ b/src/test/elements/square/payments.js
@@ -5,10 +5,14 @@ const cloud = require('core/cloud');
 const expect = require('chakram').expect;
 
 suite.forElement('employee', 'locations', (test) => {
-
-  let locId, paymentId;
+  // Using Cloud Elements business name as that's only one populated with sample payment data
+  let locId, paymentId, business, businessName = 'Cloud Elements';
   before(() => cloud.get(test.api)
-    .then(r => locId = r.body[3].id));
+    .then(r => {
+      business = r.body.filter(obj => obj['business_name'] && obj['business_name'] === businessName);
+      expect(business).to.not.be.empty;
+      locId = business[0].id;
+    }));
 
   it(`should allow GET with where begin_time for ${test.api}/:id/payments`, () => {
     return cloud.withOptions({ qs: { where: "begin_time='2017-10-03T18:18:45Z'" } }).get(`${test.api}/${locId}/payments`)

--- a/src/test/elements/square/timesheets.js
+++ b/src/test/elements/square/timesheets.js
@@ -39,7 +39,7 @@ suite.forElement('employee', 'timesheets', (test) => {
 
   test.withApi(test.api)
     .withOptions({ qs: { where: "end_updated_at='2017-10-04T17:49:02Z'" } })
-    .withValidation(r => expect(r.body.filter(obj => obj.updated_at <= '2017-10-01T17:49:02Z')).to.not.be.empty)
+    .withValidation(r => expect(r.body.filter(obj => obj.updated_at <= '2017-10-04T17:49:02Z')).to.not.be.empty)
     .withName('should allow GET with option end_updated_at')
     .should.return200OnGet();
 


### PR DESCRIPTION
## Highlights
* Square enhancements with `/customers` API

## Non-customer Highlights
* Added Test cases to `/customers`.
* Fixed Churros Issues For Square.

## Checklist
* [x] applicable churros tests are still passing
* [ ] includes a dbdeploy script that is backward-incompatible with one previous Soba minor version

## Screen shot
<img width="897" alt="screen shot 2018-01-11 at 1 37 28 pm" src="https://user-images.githubusercontent.com/26943831/34844155-24c2542c-f6d6-11e7-8760-438ba79ea957.png">


## Related PRs
[Soba](https://github.com/cloud-elements/soba/pull/7898)

## Closes
[Rally](https://rally1.rallydev.com/#/144349237612d/detail/userstory/188402884648)