### PR TITLE
Readytalk record registration test cases added

### DIFF
--- a/src/test/elements/readytalk/recordings.js
+++ b/src/test/elements/readytalk/recordings.js
@@ -1,8 +1,20 @@
 'use strict';
 
 const suite = require('core/suite');
+const cloud = require('core/cloud');
+const expect = require('chakram').expect;
 
 suite.forElement('marketing', 'recordings', null, (test) => {
   test.should.supportSr();
   test.withOptions({ qs: { page: 1, pageSize: 5}}).should.return200OnGet();
+  it('should get all meetings and then get recording by Id, registrations', () => {
+    let recordingId;
+    return cloud.get(test.api)
+      .then(r => {
+        expect(r.body.length).to.be.above(0);
+        recordingId = r.body[0].id;
+      })
+      .then(r => cloud.get(`${test.api}/${recordingId}`))
+      .then(r => cloud.get(`${test.api}/${recordingId}/registrations`));
+  });    
 });

--- a/src/test/elements/readytalk/recordings.js
+++ b/src/test/elements/readytalk/recordings.js
@@ -6,7 +6,7 @@ const expect = require('chakram').expect;
 
 suite.forElement('marketing', 'recordings', null, (test) => {
   test.should.supportSr();
-  test.withOptions({ qs: { page: 1, pageSize: 5}}).should.return200OnGet();
+  test.withOptions({ qs: { page: 1, pageSize: 5}}).should.supportPagination();
   it('should get all meetings and then get recording by Id, registrations', () => {
     let recordingId;
     return cloud.get(test.api)


### PR DESCRIPTION
## Highlights
* Added new Test cases for API getByID for Recordings 

## Screenshot
![churros](https://user-images.githubusercontent.com/34128818/34984824-29e98ad2-fad8-11e7-838f-c02566a7c714.PNG)


## Reference
* [SOBA](https://github.com/cloud-elements/soba/tree/US6873)
* [RALLY- US6873](https://rally1.rallydev.com/#/144349237612d/detail/userstory/190656993420)

## Closes
*  [RALLY- US6873](https://rally1.rallydev.com/#/144349237612d/detail/userstory/190656993420)
