### PR TITLE
Test cases for OneNote files and folders

### DIFF
--- a/src/test/elements/onenote/assets/files.json
+++ b/src/test/elements/onenote/assets/files.json
@@ -1,0 +1,4 @@
+{
+"name":"sample",
+"path":"/123/churros/textFileChurros.txt"
+}

--- a/src/test/elements/onenote/assets/folders.json
+++ b/src/test/elements/onenote/assets/folders.json
@@ -1,0 +1,3 @@
+{
+"path":"/123/ChurrosTest"
+}

--- a/src/test/elements/onenote/assets/textFile.txt
+++ b/src/test/elements/onenote/assets/textFile.txt
@@ -1,0 +1,1 @@
+sampletextfile

--- a/src/test/elements/onenote/files.js
+++ b/src/test/elements/onenote/files.js
@@ -1,0 +1,32 @@
+'use strict';
+
+const suite = require('core/suite');
+const cloud = require('core/cloud');
+const payload = require('./assets/files');
+const tools = require('core/tools');
+
+suite.forElement('documents', 'files', { payload: payload }, (test) => {
+  let txtFileBody, txtFile = __dirname + '/assets/textFile.txt';
+  let query = { path: `/123/churros/textFile-${tools.randomStr('abcdefghijklmnopqrstuvwxyz1234567890', 10)}.txt` };
+
+  before(() => cloud.withOptions({ qs: query }).postFile(test.api, txtFile)
+    .then(r => txtFileBody = r.body));
+
+
+  it('should allow ping for onenote', () => {
+    return cloud.get(`/hubs/documents/ping`);
+  });
+
+  it('should allow CRD for hubs/documents/files and RU for hubs/documents/files/metadata by path', () => {
+    let UploadFile = __dirname + '/assets/textFile.txt',
+      folderId;
+      //Hardcoding the fileName here as we do not get path in the response for futher test cases
+    return cloud.withOptions({ qs: { path: `/123/churros/textFileChurros.txt`, overwrite: 'true' } }).postFile(`${test.api}`, UploadFile)
+      .then(r => cloud.withOptions({ qs: { path: `/123/churros/textFileChurros.txt` } }).get(`${test.api}`))
+      .then(r => cloud.withOptions({ qs: { path: `/123/churros/textFileChurros.txt`, overwrite: true } }).post(`${test.api}/copy`, payload))
+      .then(r => folderId = r.body.id)
+      .then(r => cloud.withOptions({ qs: { path: `/123/churros/textFileChurros.txt` } }).get(`${test.api}/links`))
+      .then(r => cloud.withOptions({ qs: { path: `/123/churros/textFileChurros.txt` } }).get(`${test.api}/metadata`))
+      .then(r => cloud.delete(`${test.api}/${folderId}`));
+  });
+});

--- a/src/test/elements/onenote/folders.js
+++ b/src/test/elements/onenote/folders.js
@@ -8,7 +8,7 @@ const payload = require('./assets/folders');
 payload.path = payload.path + `-${faker.random.number()}`;
 
 //Need to skip as there is no delete API
-suite.forElement('documents', 'folders', { payload: payload }, {skip: true}, (test) => {
+suite.forElement('documents', 'folders', { payload: payload, skip: true}, (test) => {
   let srcPath, folderId;
 
   it('should allow C for hubs/documents/folders and SR for hubs/documents/folders/metadata and hubs/documents/folders/content by path', () => {

--- a/src/test/elements/onenote/folders.js
+++ b/src/test/elements/onenote/folders.js
@@ -1,0 +1,26 @@
+'use strict';
+
+const suite = require('core/suite');
+const cloud = require('core/cloud');
+const faker = require('faker');
+const payload = require('./assets/folders');
+
+payload.path = payload.path + `-${faker.random.number()}`;
+
+//Need to skip as there is no delete API
+suite.forElement('documents', 'folders', { payload: payload }, {skip: true}, (test) => {
+  let srcPath, folderId;
+
+  it('should allow C for hubs/documents/folders and SR for hubs/documents/folders/metadata and hubs/documents/folders/content by path', () => {
+    return cloud.post(`${test.api}`, payload)
+      .then(r => {
+        srcPath = r.body.path;
+        folderId = r.body.id;
+      })
+      .then(r => cloud.withOptions({ qs: { path: `${srcPath}` } }).get(`${test.api}/contents`))
+      .then(r => cloud.withOptions({ qs: { path: `${srcPath}`, page: 1, pageSize: 1 } }).get(`${test.api}/contents`))
+      .then(r => cloud.withOptions({ qs: { path: `${srcPath}` } }).get(`${test.api}/metadata`))
+      .then(r => cloud.withOptions({ qs: { path: `${srcPath}` } }).get(`${test.api}/${folderId}/contents`))
+      .then(r => cloud.withOptions({ qs: { path: `${srcPath}` } }).get(`${test.api}/${folderId}/metadata`));
+  });
+});


### PR DESCRIPTION
## Highlights
* Added testcases for OneNote files and folders.


## Screenshot
![image](https://user-images.githubusercontent.com/22440131/35158160-468502b2-fd5c-11e7-95b4-54a59754ee49.png)


## Reference
* [SOBA](https://github.com/cloud-elements/soba/pull/7923/)
* [RALLY-#${US6660}](https://rally1.rallydev.com/#/144349237612d/detail/userstory/189405848196)

## Closes
* Closes #${US6660}
