### PR TITLE
Hubspot CRM : Fixed Churros

### DIFF
--- a/src/test/elements/hubspotcrm/owners.js
+++ b/src/test/elements/hubspotcrm/owners.js
@@ -1,12 +1,9 @@
 'use strict';
 
 const suite = require('core/suite');
-const payload = require('./assets/owners');
 
-suite.forElement('crm', 'owners', { payload: payload }, (test) => {
-  test
-  .withOptions({ skip: true })
-  .should.supportCrus();
+suite.forElement('crm', 'owners', (test) => {
+  test.should.supportS();
 
   test.should.supportPagination();
 });

--- a/src/test/elements/hubspotcrm/owners.js
+++ b/src/test/elements/hubspotcrm/owners.js
@@ -1,9 +1,19 @@
 'use strict';
 
 const suite = require('core/suite');
+const expect = require('chakram').expect;
 
 suite.forElement('crm', 'owners', (test) => {
   test.should.supportS();
 
   test.should.supportPagination();
+  test
+    .withOptions({ qs: { where: `email = 'email@address.com'` } })
+    .withName('should support email search')
+    .withValidation(r => {
+      expect(r).to.statusCode(200);
+      const validValues = r.body.filter(obj => obj.email = 'email@address.com');
+      expect(validValues.length).to.equal(r.body.length);
+    })
+    .should.return200OnGet();
 });


### PR DESCRIPTION
## Non-Customer Highlights
* Fixed churros for `owners.js` by removing the test for CRUD operations as the API is not present in the element.

## Screenshot
* Churros run successfully
![image](https://user-images.githubusercontent.com/22442264/35149700-1d7cf09c-fd3d-11e7-9f78-9d8af6ad972b.png)
![image](https://user-images.githubusercontent.com/22442264/35148546-9c3799d2-fd38-11e7-9e28-9b3630976be2.png)


## Reference
* [SOBA](Link to SOBA or Other PR for which tests were written, when applicable)
* [churros-sauce](Link to Associated Churros-sauce PR, when applicable)
* [RALLY-DE635](https://rally1.rallydev.com/#/144349237612d/detail/defect/185383094480)

## Closes
* [DE635](https://rally1.rallydev.com/#/144349237612d/detail/defect/185383094480)
