### PR TITLE
Test cases for Google Drive search, folders/contents and folders/:id/contents with orderBy functionality

### DIFF
--- a/src/test/elements/googledrive/folders.js
+++ b/src/test/elements/googledrive/folders.js
@@ -16,7 +16,7 @@ suite.forElement('documents', 'folders', { payload: payload }, (test) => {
   let jpgFile = __dirname + '/assets/Penguins.jpg';
   let pngFile = __dirname + '/assets/Dice.png';
   let textFile = __dirname + '/assets/textFile.txt';
-  let jpgFileBody, pngFileBody, textFileBody, date1, date2;;
+  let jpgFileBody, pngFileBody, textFileBody, date1, date2;
 
   before(() =>
     cloud.withOptions({ qs: { path: `/${directoryPath}/Penguins.jpg`, overwrite: 'true' } }).postFile(`/hubs/documents/files`, jpgFile)

--- a/src/test/elements/googledrive/folders.js
+++ b/src/test/elements/googledrive/folders.js
@@ -90,8 +90,8 @@ suite.forElement('documents', 'folders', { payload: payload }, (test) => {
   });
 
   test.withApi(`/folders/contents`)
-    .withName(`should allow GET for /folders/contents with use of the orderBy modifiedDate parameter`)
-    .withOptions({ qs: { path: `/`, pageSize: 5, page: 1, orderBy: `modifiedDate asc` } })
+    .withName(`should allow GET for /folders/contents with orderBy modifiedDate asc`)
+    .withOptions({ qs: { path: `/`, pageSize: 5, page: 1, orderBy: `modifiedDate asc`, calculateFolderPath: false } })
     .withValidation(r => {
       date1 = new Date(r.body[0].createdDate).getTime();
       date2 = new Date(r.body[1].createdDate).getTime();
@@ -100,31 +100,14 @@ suite.forElement('documents', 'folders', { payload: payload }, (test) => {
     .should.return200OnGet();
 
     test.withApi(`${test.api}/root/contents`)
-        .withName(`should allow GET for /folders/:id/contents with use of the orderBy createdDate parameter`)
-        .withOptions({ qs: {  pageSize: 5, page: 1, orderBy: `createdDate desc` } })
+        .withName(`should allow GET for /folders/contents with orderBy createdDate desc`)
+        .withOptions({ qs: {  pageSize: 5, page: 1, orderBy: `createdDate desc`, calculateFolderPath: false } })
         .withValidation(r => {
           date1 = new Date(r.body[0].createdDate).getTime();
           date2 = new Date(r.body[1].createdDate).getTime();
           expect(date1 >= date2).to.be.true;
         })
         .should.return200OnGet();
-
-  //Skipping as soba PR is on hold
-  it.skip('should not return the path for GET /folders/contents?includePath=false', () => {
-    return cloud.withOptions({ qs: { includePath: false, path: `/${directoryPath}` } }).get(`${test.api}/contents`)
-      .then(r => {
-        expect(r.body[0].name).to.exist;
-        expect(r.body[0].path).to.be.undefined;
-      });
-  });
-
-  //Skipping as soba PR is on hold
-  it.skip('should not return the path for GET /folders/:id/contents?includePath=false', () => {
-    return cloud.withOptions({ qs: { includePath: false } }).get(`${test.api}/${directoryId}/contents`)
-      .then(r => {
-        expect(r.body[0].name).to.exist;
-        expect(r.body[0].path).to.be.undefined;
-      });
   });
 
 });

--- a/src/test/elements/googledrive/folders.js
+++ b/src/test/elements/googledrive/folders.js
@@ -108,6 +108,4 @@ suite.forElement('documents', 'folders', { payload: payload }, (test) => {
           expect(date1 >= date2).to.be.true;
         })
         .should.return200OnGet();
-  });
-
 });

--- a/src/test/elements/googledrive/folders.js
+++ b/src/test/elements/googledrive/folders.js
@@ -16,7 +16,7 @@ suite.forElement('documents', 'folders', { payload: payload }, (test) => {
   let jpgFile = __dirname + '/assets/Penguins.jpg';
   let pngFile = __dirname + '/assets/Dice.png';
   let textFile = __dirname + '/assets/textFile.txt';
-  let jpgFileBody, pngFileBody, textFileBody;
+  let jpgFileBody, pngFileBody, textFileBody, date1, date2;;
 
   before(() =>
     cloud.withOptions({ qs: { path: `/${directoryPath}/Penguins.jpg`, overwrite: 'true' } }).postFile(`/hubs/documents/files`, jpgFile)
@@ -88,6 +88,26 @@ suite.forElement('documents', 'folders', { payload: payload }, (test) => {
     return cloud.withOptions({ qs: { path: `/${directoryPath}`, where: "mimeType='text/plain'" } }).get(`${test.api}/contents`)
       .then(r => expect(r.body.length).to.equal(r.body.filter(obj => obj.properties.mimeType === 'text/plain').length));
   });
+
+  test.withApi(`/folders/contents`)
+    .withName(`should allow GET for /folders/contents with use of the orderBy modifiedDate parameter`)
+    .withOptions({ qs: { path: `/`, pageSize: 5, page: 1, orderBy: `modifiedDate asc` } })
+    .withValidation(r => {
+      date1 = new Date(r.body[0].createdDate).getTime();
+      date2 = new Date(r.body[1].createdDate).getTime();
+      expect(date1 <= date2).to.be.true;
+    })
+    .should.return200OnGet();
+
+    test.withApi(`${test.api}/root/contents`)
+        .withName(`should allow GET for /folders/:id/contents with use of the orderBy createdDate parameter`)
+        .withOptions({ qs: {  pageSize: 5, page: 1, orderBy: `createdDate desc` } })
+        .withValidation(r => {
+          date1 = new Date(r.body[0].createdDate).getTime();
+          date2 = new Date(r.body[1].createdDate).getTime();
+          expect(date1 >= date2).to.be.true;
+        })
+        .should.return200OnGet();
 
   //Skipping as soba PR is on hold
   it.skip('should not return the path for GET /folders/contents?includePath=false', () => {

--- a/src/test/elements/googledrive/search.js
+++ b/src/test/elements/googledrive/search.js
@@ -27,13 +27,23 @@ suite.forElement('documents', 'search', null, (test) => {
       .then(r => cloud.delete(`/folders/${folder.id}`));
   });
 
-test.withApi(test.api)
+  test.withApi(test.api)
     .withName(`should allow GET for /search with use of the orderBy createdDate parameter`)
     .withOptions({ qs: { pageSize: 5, page: 1, orderBy: `createdDate asc` } })
     .withValidation(r => {
       date1 = new Date(r.body[0].createdDate).getTime();
       date2 = new Date(r.body[1].createdDate).getTime();
       expect(date1 <= date2).to.be.true;
+    })
+    .should.return200OnGet();
+
+  test.withApi(test.api)
+    .withName(`should allow GET for /search with use of the orderBy createdDate parameter`)
+    .withOptions({ qs: { pageSize: 5, page: 1, orderBy: `createdDate desc` } })
+    .withValidation(r => {
+      date1 = new Date(r.body[0].createdDate).getTime();
+      date2 = new Date(r.body[1].createdDate).getTime();
+      expect(date1 >= date2).to.be.true;
     })
     .should.return200OnGet();
 

--- a/src/test/elements/googledrive/search.js
+++ b/src/test/elements/googledrive/search.js
@@ -7,6 +7,9 @@ const expect = require('chakram').expect;
 const folderPayload = { path: '/entirely-new-folder' };
 
 suite.forElement('documents', 'search', null, (test) => {
+
+  let date1, date2;
+
   test.withOptions({ qs: { text: tools.random() } }).should.return200OnGet();
 
   test
@@ -23,6 +26,16 @@ suite.forElement('documents', 'search', null, (test) => {
       .then(r => expect(r.body).to.have.lengthOf(1) && expect(r.body[0].path).to.equal(folder.path))
       .then(r => cloud.delete(`/folders/${folder.id}`));
   });
+
+test.withApi(test.api)
+    .withName(`should allow GET for /search with use of the orderBy createdDate parameter`)
+    .withOptions({ qs: { pageSize: 5, page: 1, orderBy: `createdDate asc` } })
+    .withValidation(r => {
+      date1 = new Date(r.body[0].createdDate).getTime();
+      date2 = new Date(r.body[1].createdDate).getTime();
+      expect(date1 <= date2).to.be.true;
+    })
+    .should.return200OnGet();
 
   // GDrive needs some time to process deleting files in a previous test :[
   test.should.supportPagination('id');

--- a/src/test/elements/googledrive/search.js
+++ b/src/test/elements/googledrive/search.js
@@ -28,8 +28,8 @@ suite.forElement('documents', 'search', null, (test) => {
   });
 
   test.withApi(test.api)
-    .withName(`should allow GET for /search with use of the orderBy createdDate parameter`)
-    .withOptions({ qs: { pageSize: 5, page: 1, orderBy: `createdDate asc` } })
+    .withName(`should allow GET for /search  with orderBy createdDate asc`)
+    .withOptions({ qs: { pageSize: 5, page: 1, orderBy: `createdDate asc`, calculateFolderPath: false } })
     .withValidation(r => {
       date1 = new Date(r.body[0].createdDate).getTime();
       date2 = new Date(r.body[1].createdDate).getTime();
@@ -38,8 +38,8 @@ suite.forElement('documents', 'search', null, (test) => {
     .should.return200OnGet();
 
   test.withApi(test.api)
-    .withName(`should allow GET for /search with use of the orderBy createdDate parameter`)
-    .withOptions({ qs: { pageSize: 5, page: 1, orderBy: `createdDate desc` } })
+    .withName(`should allow GET for /search  with orderBy createdDate desc`)
+    .withOptions({ qs: { pageSize: 5, page: 1, orderBy: `createdDate desc`, calculateFolderPath: false } })
     .withValidation(r => {
       date1 = new Date(r.body[0].createdDate).getTime();
       date2 = new Date(r.body[1].createdDate).getTime();


### PR DESCRIPTION
## Highlights
* Enhanced  Google  Drive API's with orderBy functionality
`GET /search    orderBy  : createdDate asc` 
`GET /folders/contents    orderBy  : name desc,createdDate asc`
`GET /folders/:id/contents  orderBy  : modifiedDate desc`


## Non-customer Highlights
* Enhanced orderBy functionality to Google Drive `search, folders/contents and folders/:id/contents` API's
* Default sorting order is Ascending, as per documentation.

## Checklist
* [x] applicable churros tests are still passing
* [ ] includes a dbdeploy script that is backward-incompatible with one previous Soba minor version

## Unit-test cases:
Sr No. | Test Case | Status
-- | -- | --
1 | Tested GET operations manually | Passed
2 | Tested API's through Churros | Passed
3 | Verify that documentation is loading | Passed
4 | Verify that model structure is exactly the same as actual request and response of the API | Passed

## Churros Screen Shot
![screen shot 2018-01-28 at 5 52 38 pm](https://user-images.githubusercontent.com/26943831/35488837-74ec5c78-0454-11e8-943c-3c310cf3574d.png)


## Related PRs
[Soba](https://github.com/cloud-elements/soba/compare/GoogleDrive_US7091?expand=1)

## Closes
[Rally](https://rally1.rallydev.com/#/144349237612d/detail/userstory/191447507420)