### PR TITLE
JIRA - Fixed Issue of LIKE Operator and Custom Field Search

### DIFF
--- a/src/test/elements/jira/incidents.js
+++ b/src/test/elements/jira/incidents.js
@@ -80,7 +80,7 @@ suite.forElement('helpdesk', 'incidents', { payload: payload }, (test) => {
     }));
 
 
-  it(`should allow GET /incidents with option defultfields LIKE`, () => {
+  it(`should allow GET /incidents with option defaultFields LIKE`, () => {
     return cloud.withOptions({ qs: { where: `summary LIKE '${summary}'` } }).get(test.api)
       .then(r => expect(r.body[0].fields.summary).to.contains(`${summary}`));
   });

--- a/src/test/elements/jira/incidents.js
+++ b/src/test/elements/jira/incidents.js
@@ -75,19 +75,19 @@ suite.forElement('helpdesk', 'incidents', { payload: payload }, (test) => {
 
   before(() => cloud.get(test.api)
     .then(r => {
-      customField = r.body[0].fields['customfield_10100'];
+      customField = r.body[0].fields.customfield_10100;
       summary = r.body[0].fields.summary;
     }));
 
 
   it(`should allow GET /incidents with option defultfields LIKE`, () => {
     return cloud.withOptions({ qs: { where: `summary LIKE '${summary}'` } }).get(test.api)
-      .then(r => expect(r.body[0].fields.summary).to.contains(`${summary}`))
+      .then(r => expect(r.body[0].fields.summary).to.contains(`${summary}`));
   });
 
   it(`should allow GET /incidents with option customfields`, () => {
     return cloud.withOptions({ qs: { where: `customfield_10100 = '${customField}'` } }).get(test.api)
-      .then(r => expect(r.body[0].fields['customfield_10100']).to.be.equal(`${customField}`))
+      .then(r => expect(r.body[0].fields.customfield_10100).to.be.equal(`${customField}`));
   });
 
 });


### PR DESCRIPTION
## Highlights
* `GET  /incidents where : summary LIKE 'QBO%'`
* `GET  /incidents where : customfield_10100 = '1|hzzvw7:'`
* `GET  /incidents where : customfield_12201 like 'testing new field blah blah'`


## Non-customer Highlights
* As Per JIRA Documentation Only `summary, description and comment`  fields supports 
   LIKE (CE) / ~ (JIRA)
* Business Logic added to handle special characters in search values
 `GET  /incidents where : creator = 'byron@cloud-elements.com'` 
`GET  /incidents where : reporter = 'Atul Barve'` 
`GET  /incidents where : created<='2015-09-17'` 
* Business Logic added to handle custom fields search of JQL using custom_field_Id
* Note : Custom Field Id's for any Custom Field are identified using `/fields API`


## Checklist
* [x] applicable churros tests are still passing
* [ ] includes a dbdeploy script that is backward-incompatible with one previous Soba minor version

## Screen Shot
<img width="885" alt="screen shot 2018-01-24 at 10 56 49 pm" src="https://user-images.githubusercontent.com/26943831/35371833-2e0ddc96-015c-11e8-881c-016cb80f5029.png">

## Related PRs
[Soba](https://github.com/cloud-elements/soba/pull/7933)

## Closes
[Rally](https://rally1.rallydev.com/#/144349237612d/detail/defect/190835070184)
[Rally](https://rally1.rallydev.com/#/144349237612d/detail/defect/190273192680)