### PR TITLE
Some Google Drive paging tests n such

### DIFF
--- a/src/core/suite.js
+++ b/src/core/suite.js
@@ -97,6 +97,7 @@ const itPagination = (name, api, options, validationCb, unique) => {
   const pageSize = options ? options.qs ? options.qs.pageSize ? options.qs.pageSize : 2 : 2 : 2;
   const page = options ? options.qs ? options.qs.page ? options.qs.page : 1 : 1 : 1;
   const where = options ? options.qs ? options.qs.where ? options.qs.where : null : null: null;
+  const path = options ? options.qs ? options.qs.path ? options.qs.path : null : null: null;
   const options1 = Object.assign({}, options, { qs: { page: page, pageSize: pageSize } });
   const options2 = Object.assign({}, options, { qs: { page: page + 1, pageSize: pageSize } });
   const options3 = Object.assign({}, options, { qs: { page: page, pageSize: (pageSize * 2) } });
@@ -104,6 +105,7 @@ const itPagination = (name, api, options, validationCb, unique) => {
   const getWithOptions = (option, result) => {
     // Adding the 'where' clause if it exists
     if (where) option.qs.where = where;
+    if (path) option.qs.path = path;
     return cloud.withOptions(option).get(api)
       .then((r) => {
         if (r.body && r.body.length > 0) {

--- a/src/test/elements/googledrive/files.js
+++ b/src/test/elements/googledrive/files.js
@@ -23,7 +23,7 @@ const propertiesPayload = {
 suite.forElement('documents', 'files', { payload: payload }, (test) => {
   let jpgFileBody,revisionId,jpgFile = __dirname + '/assets/Penguins.jpg';
   let query = { path: `/Penguins-${tools.randomStr('abcdefghijklmnopqrstuvwxyz1234567890', 10)}.jpg` };
-  
+
   before(() => cloud.withOptions({ qs : query }).postFile(test.api, jpgFile)
   .then(r => jpgFileBody = r.body));
 
@@ -67,41 +67,41 @@ suite.forElement('documents', 'files', { payload: payload }, (test) => {
       .then(r => cloud.withOptions({ qs: { path: `${destPath}` } }).delete(`${test.api}`));
   });
 
-  it('it should allow RS for documents/files/:id/revisions', () => {
+  it('should allow RS for documents/files/:id/revisions', () => {
       return cloud.get(`${test.api}/${jpgFileBody.id}/revisions`)
       .then(r => revisionId = r.body[0].id)
       .then(() => cloud.get(`${test.api}/${jpgFileBody.id}/revisions/${revisionId}`));
   });
 
-  it('it should allow RS for documents/files/revisions by path', () => {
+  it('should allow RS for documents/files/revisions by path', () => {
       return cloud.withOptions({ qs: query }).get(`${test.api}/revisions`)
       .then(r => revisionId = r.body[0].id)
       .then(() => cloud.withOptions({ qs: query }).get(`${test.api}/revisions/${revisionId}`));
   });
 
   //Test For Export Functionality
-  it('Should allow export of Google Doc to plain text using media type', () => {
+  it('should allow export of Google Doc to plain text using media type', () => {
     let DocFile = '/ChurrosDocDoNotDelete';
     return cloud.withOptions({ qs: { path: DocFile, mediaType: 'text/plain' } }).get(test.api)
       .then(r => {
         expect(r.body).to.contain('Sample Word Doc');
       });
   });
-  it('Should allow export of Google Sheets to csv using media type', () => {
+  it('should allow export of Google Sheets to csv using media type', () => {
     let SSFile = '/ChurrosSSDoNotDelete';
     return cloud.withOptions({ qs: { path: SSFile, mediaType: 'text/csv' } }).get(test.api)
       .then(r => {
         expect(r.body).to.contain('Test1,Test2,Tes3,Test4');
       });
   });
-  it('Should allow export of Google Presentations to text using media type', () => {
+  it('should allow export of Google Presentations to text using media type', () => {
     let PPTFile = '/ChurrosPPTDoNotDelete';
     return cloud.withOptions({ qs: { path: PPTFile, mediaType: 'text/plain' } }).get(test.api)
       .then(r => {
         expect(r.body).to.contain('Churros PPT Test');
       });
   });
-  it('Should allow export of Google Drawing to pdf using media type', () => {
+  it('should allow export of Google Drawing to pdf using media type', () => {
     let PNGFile = '/ChurrosPNGDoNotDelete';
     return cloud.withOptions({ qs: { path: PNGFile, mediaType: 'application/pdf' } }).get(test.api)
       .then(r => {

--- a/src/test/elements/googledrive/folders.js
+++ b/src/test/elements/googledrive/folders.js
@@ -89,6 +89,8 @@ suite.forElement('documents', 'folders', { payload: payload }, (test) => {
       .then(r => expect(r.body.length).to.equal(r.body.filter(obj => obj.properties.mimeType === 'text/plain').length));
   });
 
+  test.withOptions({ qs: { path: '/' } }).withApi('/folders/contents').should.supportPagination('id');
+
   //Skipping as soba PR is on hold
   it.skip('should not return the path for GET /folders/contents?includePath=false', () => {
     return cloud.withOptions({ qs: { includePath: false, path: `/${directoryPath}` } }).get(`${test.api}/contents`)

--- a/src/test/elements/googledrive/search.js
+++ b/src/test/elements/googledrive/search.js
@@ -19,8 +19,10 @@ suite.forElement('documents', 'search', null, (test) => {
     let folder;
     return cloud.post('/folders', folderPayload)
       .then(r => folder = r.body)
-      .then(r => cloud.withOptions({ qs: { calculateFolderPath: false, path: folderPayload.path } }).get(test.api))
+      .then(r => cloud.withOptions({ qs: { calculateFolderPath: true, path: folderPayload.path } }).get(test.api))
       .then(r => expect(r.body).to.have.lengthOf(1) && expect(r.body[0].path).to.equal(folder.path))
+      .then(r => cloud.withOptions({ qs: { calculateFolderPath: false, path: folderPayload.path, text: 'test' } }).get(test.api))
+      .then(r => expect(r.body).to.not.be.empty && expect(r.body.filter(obj => obj.path)).to.be.empty && expect(r.body.filter(obj => obj.name.includes('test'))).to.not.be.empty)
       .then(r => cloud.delete(`/folders/${folder.id}`));
   });
 


### PR DESCRIPTION
## Highlights
* ☝️ 

## Screenshot
```
churros test elements/googledrive
sleep: using busy loop fallback


(node:36856) [DEP0022] DeprecationWarning: os.tmpDir() is deprecated. Use os.tmpdir() instead.
info: Using url: http://localhost:8080
info: Using user: system
info: Using oauth username: churros.sauce@gmail.com
info: Using api key: 232945639549-cj65c4aeacj68nnv0mfpvv7m0v9e0eg2.apps.googleusercontent.com
info: Running tests for element: googledrive
info: Provisioned with instance id of 1076
  Basic tests
(node:36856) [DEP0013] DeprecationWarning: Calling an asynchronous function without callback is deprecated.
    ✓ should provision
    ✓ should GET /objects (285ms)
    - docs
    ✓ metadata (348ms)
    ✓ transformations
    - should not allow provisioning with bad credentials

  files
    ✓ should allow ping for googledrive (156ms)
    ✓ should allow CRD for hubs/documents/files and RU for hubs/documents/files/metadata by path (15071ms)
    ✓ should allow CRD for hubs/documents/files and RU for hubs/documents/files/metadata by id (13846ms)
    ✓ it should allow RS for documents/files/:id/revisions (874ms)
    ✓ it should allow RS for documents/files/revisions by path (920ms)
    ✓ Should allow export of Google Doc to plain text using media type (997ms)
    ✓ Should allow export of Google Sheets to csv using media type (989ms)
    ✓ Should allow export of Google Presentations to text using media type (1131ms)
    ✓ Should allow export of Google Drawing to pdf using media type (1023ms)
    ✓ should fail when copying file to existing file path without overwrite (8487ms)
    ✓ should succeed when copying file with existing file path with overwrite (14896ms)

  folders
    ✓ should allow CRD for hubs/documents/folders and RU for hubs/documents/folders/metadata by path (9989ms)
    ✓ should allow CRD for hubs/documents/folders and RU for hubs/documents/folders/metadata by id (8864ms)
    ✓ should allow GET /folders/contents (1103ms)
    ✓ should allow GET /folders/contents with name like (950ms)
    ✓ should allow GET /folders/contents with name equals (1076ms)
    ✓ should allow GET /folders/contents with name IN (904ms)
    ✓ should allow GET /folders/contents with extension (905ms)
    ✓ should allow GET /folders/contents with mimeType (922ms)
    ✓ should allow paginating with page and pageSize for /folders/contents (2436ms)
    - should not return the path for GET /folders/contents?includePath=false
    - should not return the path for GET /folders/:id/contents?includePath=false

  search
    ✓ should allow GET for /hubs/documents/search (447ms)
    ✓ should not support searching more than 1000 records (587ms)
    ✓ should not return more than my folder on a GET /search (10902ms)
    ✓ should allow paginating with page and pageSize for /hubs/documents/search (4704ms)

  storage
    ✓ should allow GET for /hubs/documents/storage (479ms)


  29 passing (2m)
  4 pending
```

## Reference
* [SOBA](https://github.com/cloud-elements/soba/pull/7965)
* [churros-sauce](Link to Associated Churros-sauce PR, when applicable)
* [DE771](https://rally1.rallydev.com/#/144349237612ud/detail/defect/192224151448)

## Closes
* [TA6176](https://rally1.rallydev.com/#/144349237612d/detail/task/193358649188)
