### PR TITLE
Googledrive and Box added tests for posting a file by folderid

### DIFF
--- a/src/test/elements/box/index.js
+++ b/src/test/elements/box/index.js
@@ -14,7 +14,7 @@ documents.override('folders', () => {
   suite.forElement('documents', 'folders', (test) => {
     afterEach(done => {
       //We were getting a 429 before this
-      setTimeout(done, 3000);
+      setTimeout(done, 4000);
     });
 
     let folder;

--- a/src/test/elements/googledrive/files.js
+++ b/src/test/elements/googledrive/files.js
@@ -6,6 +6,11 @@ const tools = require('core/tools');
 const payload = require('./assets/files');
 const expect = require('chakram').expect;
 const faker = require('faker');
+const folderPayload = require('./assets/folders');
+
+const randomInt = tools.randomInt();
+folderPayload.path += randomInt;
+folderPayload.name += randomInt;
 
 payload.path = `/${faker.random.number()}`;
 
@@ -23,7 +28,7 @@ const propertiesPayload = {
 suite.forElement('documents', 'files', { payload: payload }, (test) => {
   let jpgFileBody,revisionId,jpgFile = __dirname + '/assets/Penguins.jpg';
   let query = { path: `/Penguins-${tools.randomStr('abcdefghijklmnopqrstuvwxyz1234567890', 10)}.jpg` };
-  
+
   before(() => cloud.withOptions({ qs : query }).postFile(test.api, jpgFile)
   .then(r => jpgFileBody = r.body));
 
@@ -48,6 +53,19 @@ suite.forElement('documents', 'files', { payload: payload }, (test) => {
       .then(r => cloud.withOptions({ qs: { path: `${srcPath}` } }).patch(`${test.api}/metadata/properties`, propertiesPayload))
       .then(r => cloud.withOptions({ qs: { path: `${srcPath}` } }).delete(`${test.api}`))
       .then(r => cloud.withOptions({ qs: { path: `${destPath}` } }).delete(`${test.api}`));
+  });
+
+  it('should allow POST /files by providing folder id', () => {
+    let folderId, fileId;
+    return cloud.post('/folders', folderPayload)
+      .then(r => folderId = r.body.id)
+      .then(r => cloud.withOptions({ qs: {
+          path: `/churros/brady-${faker.address.zipCode()}.jpg`,
+          folderId,
+          calculateFolderPath: false} }).postFile(test.api, `${__dirname}/../assets/brady.jpg`))
+      .then(r => fileId = r.body.id)
+      .then(() => cloud.delete(`${test.api}/${fileId}`))
+      .then(() => cloud.delete(`/folders/${folderId}`));
   });
 
   it('should allow CRD for hubs/documents/files and RU for hubs/documents/files/metadata by id', () => {


### PR DESCRIPTION
## Highlights
* Googledrive and Box added tests for posting a file by folderid


## Screenshot
```
elemnts-mac49:churros ramana$ churros test elements/box
sleep: using busy loop fallback


info: Using url: http://localhost:5050
info: Using user: churros@ce.com
info: Using oauth username: developer@cloud-elements.com
info: Using api key: 0zltudvqp2mlbqbctahxhndis0p630hm
info: Running tests for element: box
error: Failed to retrieve or validate: /instances
info: Provisioned with instance id of 6379
  Basic tests
    ✓ should provision
    ✓ should GET /objects (1359ms)
    - docs
    ✓ metadata (185ms)
    ✓ transformations
    - should not allow provisioning with bad credentials

  custom-fields
    - should support CRUS for /custom-fields/templates

  files
    ✓ should allow POST /files by providing folder id (9182ms)
    ✓ should allow PUT /files/:id/lock and DELETE /files/:id/lock (2132ms)
    ✓ should allow links for files/:id/links without raw payload (1893ms)
    ✓ should allow links for files/links with raw payload (2620ms)
    ✓ should fail when copying file with existing file name (14563ms)
    ✓ should allow CRUDS for /files/:id/custom-fields (8386ms)
    ✓ should allow RS for documents/files/:id/revisions (2200ms)
    ✓ should allow RS for documents/files/revisions by path (5815ms)
    ✓ should allow CRUDS for /hubs/documents/files/:id/comments (7027ms)
    ✓ should allow CRUDS for /hubs/documents/files/comments by path (12203ms)
    ✓ should allow paginating for /hubs/documents/files/:id/comments (9801ms)
    ✓ should allow paginating for /hubs/documents/files/comments by path (16837ms)
    ✓ should handle raw parameter for /hubs/documents/files/comments (5984ms)

  folders
    ✓ should allow CD for /hubs/documents/folders and GET collaborations (7095ms)
    ✓ should include bookmarks in GET /folders/contents results (2061ms)

  folders
    ✓ should allow CD for /hubs/documents/folders and GET links (6832ms)

  groups
    ✓ should allow CUDS for /hubs/documents/groups (3390ms)

  files
    ✓ should allow CRD /files and RD /files/:id (9605ms)
    ✓ should allow GET /files/links and /files/:id/links (2691ms)
    ✓ should allow RU /files/metadata and RU /files/:id/metadata (5513ms)
    ✓ should allow POST /files/copy and POST /files/:id/copy (11064ms)

  folders
    ✓ should allow CD /folders and DELETE /folders/:id (10118ms)
    ✓ should allow GET /folders/contents and GET /folders/:id/contents (3627ms)
    ✓ should allow RU /folders/metadata and RU /folders/:id/metadata (6562ms)
    ✓ should allow POST /folders/copy and POST /folders/:id/copy (10060ms)

  storage
    ✓ should allow GET for /hubs/documents/storage (926ms)

  search
    ✓ should allow GET for /hubs/documents/search (29078ms)

  search
    ✓ should support template filtering for GET /search (4712ms)

  users
    ✓ should allow CRUDS for /hubs/documents/users (4560ms)
    ✓ should allow paginating with page and pageSize for /hubs/documents/users (1996ms)
    ✓ should allow GET for /hubs/documents/users (667ms)

  webhooks
    ✓ should support CRUDS for webhooks (6230ms)


  36 passing (5m)
  3 pending
```

## Reference
* [SOBA](Link to SOBA or Other PR for which tests were written, when applicable)
* [US7409](https://rally1.rallydev.com/#/144349237612d/detail/userstory/193391666284)

## Closes
* Closes #[US7409](https://rally1.rallydev.com/#/144349237612d/detail/userstory/193391666284)