### PR TITLE
Testing OAuth2 masked API key during provision

### DIFF
--- a/src/core/oauth.js
+++ b/src/core/oauth.js
@@ -40,6 +40,7 @@ const manipulateDom = (element, browser, r, username, password, config) => {
       browser.findElement(webdriver.By.className('btn')).click();
       return browser.getCurrentUrl();
     case 'bullhorn--v1':
+    case 'bullhorn--v2masked':
     case 'bullhorn--v2':
       browser.get(r.body.oauthUrl);
       browser.findElement(webdriver.By.id('un')).sendKeys(username);

--- a/src/test/platform/provisioning/provision.js
+++ b/src/test/platform/provisioning/provision.js
@@ -2,8 +2,8 @@ const provisioner = require('core/provisioner');
 const suite = require('core/suite');
 const expect = require('chakram').expect;
 const cloud = require('core/cloud');
-const config = {
-  "oauth.callback.url":"https://auth.cloudelements.io/oauth",
+let config = {
+  "oauth.callback.url":"https://auth.cloudelements.io/oauth"
 };
 
 suite.forPlatform('provisionv2', (test) => {
@@ -24,6 +24,16 @@ suite.forPlatform('provisionv2', (test) => {
      .then(r => {
        oauth2instanceId = r.body.id;
        return provisioner.updateWithDefault('bullhorn--v2', config, null, r.body.id);
+     })
+    .then(r => expect(r.body.id).to.equal(oauth2instanceId));
+   });
+
+
+   it('should create an instance of Bullhorn in V1 and update with v2 when config is masked', () => {
+     return provisioner.create('bullhorn--v1')
+     .then(r => {
+       oauth2instanceId = r.body.id;
+       return provisioner.updateWithDefault('bullhorn--v2masked', null, null, r.body.id);
      })
     .then(r => expect(r.body.id).to.equal(oauth2instanceId));
    });

--- a/src/test/platform/provisioning/provision.js
+++ b/src/test/platform/provisioning/provision.js
@@ -2,7 +2,7 @@ const provisioner = require('core/provisioner');
 const suite = require('core/suite');
 const expect = require('chakram').expect;
 const cloud = require('core/cloud');
-let config = {
+const config = {
   "oauth.callback.url":"https://auth.cloudelements.io/oauth"
 };
 
@@ -27,11 +27,11 @@ suite.forPlatform('provisionv2', (test) => {
 
    it('should create an instance of Bullhorn in V1 and update with v2', () => {
      return provisioner.create('bullhorn--v1')
-     .then(r => {
-       oauth2instanceId = r.body.id;
-       return provisioner.updateWithDefault('bullhorn--v2', config, null, r.body.id);
-     })
-    .then(r => expect(r.body.id).to.equal(oauth2instanceId));
+      .then(r => {
+        oauth2instanceId = r.body.id;
+        return provisioner.updateWithDefault('bullhorn--v2', null, null, r.body.id);
+      })
+     .then(r => expect(r.body.id).to.equal(oauth2instanceId));
    });
 
 

--- a/src/test/platform/provisioning/provision.js
+++ b/src/test/platform/provisioning/provision.js
@@ -6,6 +6,12 @@ let config = {
   "oauth.callback.url":"https://auth.cloudelements.io/oauth"
 };
 
+const bullhornMaskedConfig = {
+  "oauth.api.key":"********",
+  "provisioning": "oauth2",
+  "oauth.callback.url": "https://auth.cloudelements.io/oauth"
+}
+
 suite.forPlatform('provisionv2', (test) => {
   let oauth2instanceId, oauth2instanceId2, oauth2instanceId3, oauth2instanceId4, oauth1instanceId, oauth1instanceId2;
 
@@ -31,11 +37,10 @@ suite.forPlatform('provisionv2', (test) => {
 
    it('should create an instance of Bullhorn in V1 and update with v2 when config is masked', () => {
      return provisioner.create('bullhorn--v1')
-     .then(r => {
-       oauth2instanceId = r.body.id;
-       return provisioner.updateWithDefault('bullhorn--v2masked', null, null, r.body.id);
-     })
-    .then(r => expect(r.body.id).to.equal(oauth2instanceId));
+     .then(r => oauth2instanceId = r.body.id)
+     .then(r => cloud.get('elements/bullhorn'))
+     .then(r => cloud.withOptions({qs:bullhornMaskedConfig}).get(`/elements/${r.body.id}/oauth/url/default`))
+    .then(r => expect(r.body.oauthUrl).to.not.include("client_id=********"));
    });
 
   it('should provision instance with non default api key/secret', () => {

--- a/src/test/platform/provisioning/provision.js
+++ b/src/test/platform/provisioning/provision.js
@@ -10,7 +10,7 @@ const bullhornMaskedConfig = {
   "oauth.api.key":"********",
   "provisioning": "oauth2",
   "oauth.callback.url": "https://auth.cloudelements.io/oauth"
-}
+};
 
 suite.forPlatform('provisionv2', (test) => {
   let oauth2instanceId, oauth2instanceId2, oauth2instanceId3, oauth2instanceId4, oauth1instanceId, oauth1instanceId2;
@@ -29,7 +29,7 @@ suite.forPlatform('provisionv2', (test) => {
      return provisioner.create('bullhorn--v1')
       .then(r => {
         oauth2instanceId = r.body.id;
-        return provisioner.updateWithDefault('bullhorn--v2', null, null, r.body.id);
+        return provisioner.updateWithDefault('bullhorn--v2', config, null, r.body.id);
       })
      .then(r => expect(r.body.id).to.equal(oauth2instanceId));
    });


### PR DESCRIPTION
## Highlights
* Tests if the OAuth default URL returns a masked API key during provision

## Reference
* [7970](https://github.com/cloud-elements/soba/pull/7970)
