### PR TITLE
Added the custom-template-fields APIs in Dropbox

### DIFF
--- a/src/test/elements/dropbox/assets/UpdateCustomFields.json
+++ b/src/test/elements/dropbox/assets/UpdateCustomFields.json
@@ -1,0 +1,8 @@
+{
+ "add_or_update_fields": [
+                 {
+                     "name": "Security Policy",
+                     "value": "Confidential"
+                 }
+   ]
+}

--- a/src/test/elements/dropbox/assets/UpdateTemplate.json
+++ b/src/test/elements/dropbox/assets/UpdateTemplate.json
@@ -1,0 +1,9 @@
+{
+  "add_fields": [
+    {
+        "name": "Security Policy",
+        "description": "This is the security policy of the file or folder described.\nPolicies can be Confidential, Public or Internal.",
+        "type": "string"
+    }
+  ]
+}

--- a/src/test/elements/dropbox/assets/customFields.json
+++ b/src/test/elements/dropbox/assets/customFields.json
@@ -1,0 +1,8 @@
+{
+     "fields": [
+               {
+                   "name": "Security Policy",
+                   "value": "Confidential"
+               }
+           ]
+}

--- a/src/test/elements/dropbox/assets/template.json
+++ b/src/test/elements/dropbox/assets/template.json
@@ -1,0 +1,11 @@
+{
+    "name": "c<<random.alphaNumeric##10>>",
+    "description": "These properties describe how confidential this file or folder is.",
+    "fields": [
+        {
+            "name": "Security Policy",
+            "description": "This is the security policy of the file or folder described.\nPolicies can be Confidential, Public or Internal.",
+            "type": "string"
+        }
+    ]
+}

--- a/src/test/elements/dropbox/custom-fields-templates.js
+++ b/src/test/elements/dropbox/custom-fields-templates.js
@@ -4,22 +4,14 @@ const suite = require('core/suite');
 const cloud = require('core/cloud');
 const tools = require('core/tools');
 const temPayload = tools.requirePayload(`${__dirname}/assets/template.json`);
+const updateTemPayload = tools.requirePayload(`${__dirname}/assets/UpdateTemplate.json`);
 
 suite.forElement('documents', 'custom-fields-templates', (test) => {
  let tempKey;
   it('should support CRUS for /custom-fields-templates/templates', () => {
-    let updatePayload = {
-      "add_fields": [
-        {
-            "name": "Security Policy",
-            "description": "This is the security policy of the file or folder described.\nPolicies can be Confidential, Public or Internal.",
-            "type": "string"
-        }
-      ]
-    };
     return cloud.post(`${test.api}`, temPayload)
       .then(r => tempKey = r.body.template_id)
-      .then(r => cloud.put(`${test.api}/${tempKey}`, updatePayload))
+      .then(r => cloud.put(`${test.api}/${tempKey}`, updateTemPayload))
       .then(r => cloud.get(`${test.api}/${tempKey}`))
       .then(r => cloud.get(`${test.api}`))
       .then(r => cloud.delete(`${test.api}/${tempKey}`));

--- a/src/test/elements/dropbox/custom-fields-templates.js
+++ b/src/test/elements/dropbox/custom-fields-templates.js
@@ -7,8 +7,8 @@ const temPayload = tools.requirePayload(`${__dirname}/assets/template.json`);
 const updateTemPayload = tools.requirePayload(`${__dirname}/assets/UpdateTemplate.json`);
 
 suite.forElement('documents', 'custom-fields-templates', (test) => {
- let tempKey;
   it('should support CRUS for /custom-fields-templates/templates', () => {
+    let tempKey;
     return cloud.post(`${test.api}`, temPayload)
       .then(r => tempKey = r.body.template_id)
       .then(r => cloud.put(`${test.api}/${tempKey}`, updateTemPayload))

--- a/src/test/elements/dropbox/custom-template-fields.js
+++ b/src/test/elements/dropbox/custom-template-fields.js
@@ -1,0 +1,27 @@
+'use strict';
+
+const suite = require('core/suite');
+const cloud = require('core/cloud');
+const tools = require('core/tools');
+const temPayload = tools.requirePayload(`${__dirname}/assets/template.json`);
+
+suite.forElement('documents', 'custom-fields-templates', (test) => {
+ let tempKey;
+  it('should support CRUS for /custom-fields-templates/templates', () => {
+    let updatePayload = {
+      "add_fields": [
+        {
+            "name": "Security Policy",
+            "description": "This is the security policy of the file or folder described.\nPolicies can be Confidential, Public or Internal.",
+            "type": "string"
+        }
+      ]
+    };
+    return cloud.post(`${test.api}`, temPayload)
+      .then(r => tempKey = r.body.template_id)
+      .then(r => cloud.put(`${test.api}/${tempKey}`, updatePayload))
+      .then(r => cloud.get(`${test.api}/${tempKey}`))
+      .then(r => cloud.get(`${test.api}`))
+      .then(r => cloud.delete(`${test.api}/${tempKey}`));
+  });
+});

--- a/src/test/elements/dropbox/files.js
+++ b/src/test/elements/dropbox/files.js
@@ -3,6 +3,8 @@
 const cloud = require('core/cloud');
 const suite = require('core/suite');
 const tools = require('core/tools');
+const temPayload = tools.requirePayload(`${__dirname}/assets/template.json`);
+const payload=tools.requirePayload(`${__dirname}/assets/customFields.json`);
 
 suite.forElement('documents','files',(test) => {
 
@@ -26,5 +28,29 @@ suite.forElement('documents','files',(test) => {
       .then(r => revisionId = r.body[0].id)
       .then(() => cloud.withOptions({ qs: query }).get(`${test.api}/revisions/${revisionId}`));
   });
+
+  it(' it should allow RS for /files/{id}/custom-fields-templates/{templateKeyId}/custom-fields', () => {
+    let tempKey;
+    let updatePayload = {
+      "add_or_update_fields": [
+                      {
+                          "name": "Security Policy",
+                          "value": "Confidential"
+                      }
+        ]
+    };
+    return cloud.post('/hubs/documents/custom-fields-templates', temPayload)
+        .then(r => {
+          tempKey = r.body.template_id;
+          updatePayload.add_or_update_fields[0].name = temPayload.fields[0].name;
+          payload.fields[0].name = temPayload.fields[0].name;
+        })
+        .then(r => cloud.post(`/files/${jpgFileBody.refId}/custom-fields-templates/${tempKey}/custom-fields`, payload))
+        .then(r => cloud.put(`/hubs/documents/files/${jpgFileBody.refId}/custom-fields-templates/${tempKey}/custom-fields`, updatePayload))
+        .then(r => cloud.delete(`/hubs/documents/files/${jpgFileBody.refId}/custom-fields-templates/${tempKey}/custom-fields`))
+        .then(r => cloud.delete(`/hubs/documents/custom-fields-templates/${tempKey}`));
+
+  });
+
 
 });

--- a/src/test/elements/dropbox/files.js
+++ b/src/test/elements/dropbox/files.js
@@ -3,19 +3,33 @@
 const cloud = require('core/cloud');
 const suite = require('core/suite');
 const tools = require('core/tools');
-const temPayload = tools.requirePayload(`${__dirname}/assets/template.json`);
 const payload=tools.requirePayload(`${__dirname}/assets/customFields.json`);
+const updatePayload=tools.requirePayload(`${__dirname}/assets/UpdateCustomFields.json`);
+const temPayload = tools.requirePayload(`${__dirname}/assets/template.json`);
 
 suite.forElement('documents','files',(test) => {
 
   let jpgFile = __dirname + '/assets/brady.jpg';
+  let tempKey;
+  let customBody;
   var jpgFileBody,revisionId;
   let query = { path: `/brady-${tools.randomStr('abcdefghijklmnopqrstuvwxyz1234567890', 10)}.jpg` };
 
-  before(() => cloud.withOptions({ qs : query }).postFile(test.api, jpgFile)
-  .then(r => jpgFileBody = r.body));
 
-  after(() => cloud.delete(`${test.api}/${jpgFileBody.id}`));
+
+  before(() => cloud.withOptions({ qs : query }).postFile(test.api, jpgFile)
+  .then(r => jpgFileBody = r.body)
+  .then(r => cloud.post('/hubs/documents/custom-fields-templates', temPayload))
+      .then(r => {
+        customBody= r.body;
+        tempKey = r.body.template_id;
+        updatePayload.add_or_update_fields[0].name = temPayload.fields[0].name;
+        payload.fields[0].name = temPayload.fields[0].name;
+      }));
+
+  after(() => cloud.delete(`${test.api}/${jpgFileBody.id}`)
+  .then(r => cloud.delete(`/hubs/documents/custom-fields-templates/${tempKey}`))
+);
 
   it('it should allow RS for documents/files/:id/revisions', () => {
       return cloud.get(`${test.api}/${jpgFileBody.id}/revisions`)
@@ -30,15 +44,7 @@ suite.forElement('documents','files',(test) => {
   });
 
   it(' it should allow RS for /files/{id}/custom-fields-templates/{templateKeyId}/custom-fields', () => {
-    let tempKey;
-    let updatePayload = {
-      "add_or_update_fields": [
-                      {
-                          "name": "Security Policy",
-                          "value": "Confidential"
-                      }
-        ]
-    };
+
     return cloud.post('/hubs/documents/custom-fields-templates', temPayload)
         .then(r => {
           tempKey = r.body.template_id;
@@ -47,9 +53,7 @@ suite.forElement('documents','files',(test) => {
         })
         .then(r => cloud.post(`/files/${jpgFileBody.refId}/custom-fields-templates/${tempKey}/custom-fields`, payload))
         .then(r => cloud.put(`/hubs/documents/files/${jpgFileBody.refId}/custom-fields-templates/${tempKey}/custom-fields`, updatePayload))
-        .then(r => cloud.delete(`/hubs/documents/files/${jpgFileBody.refId}/custom-fields-templates/${tempKey}/custom-fields`))
-        .then(r => cloud.delete(`/hubs/documents/custom-fields-templates/${tempKey}`));
-
+        .then(r => cloud.delete(`/hubs/documents/files/${jpgFileBody.refId}/custom-fields-templates/${tempKey}/custom-fields`));
   });
 
 


### PR DESCRIPTION
## Highlights
* Added the churros test CRUDS for /custom-fields-templates/templates
* Added the churros test CUD for /files/{id}/custom-fields-templates/{templateKeyId}/custom-fields'
## Screenshot
![dropbchr](https://user-images.githubusercontent.com/22440353/35566819-caaf024c-05e8-11e8-98a7-3ba1fac46856.JPG)
![dropboxch2](https://user-images.githubusercontent.com/22440353/35566825-d00af994-05e8-11e8-95ed-edb51a0fa10f.JPG)
![dropboxch3](https://user-images.githubusercontent.com/22440353/35566841-dd59f758-05e8-11e8-8ff2-b343ce4dacf7.JPG)

- Raised the DE for failing APIs [DE872](https://rally1.rallydev.com/#/144349237612d/detail/defect/194400963348?fdp=true)
## Reference
* [SOBA](https://github.com/cloud-elements/soba/pull/7994)
* [churros-sauce](Link to Associated Churros-sauce PR, when applicable)
* [RALLY-#${TA5987}](https://rally1.rallydev.com/#/144349237612d/detail/task/192341621964)

## Closes
* Closes #$[US7271](https://rally1.rallydev.com/#/144349237612d/detail/userstory/192209559176)
