### PR TITLE
Added ability to provision Ecwid element using an Oauth2

### DIFF
--- a/src/core/oauth.js
+++ b/src/core/oauth.js
@@ -650,6 +650,17 @@ const manipulateDom = (element, browser, r, username, password, config) => {
       browser.findElement(webdriver.By.id('action'))
         .then((element) => element.click(), (err) => {}); // ignore this
       return browser.getCurrentUrl();
+      case 'ecwid':
+        browser.get(r.body.oauthUrl);
+        browser.findElement(webdriver.By.name('email')).sendKeys(username);
+        browser.findElement(webdriver.By.name('password')).sendKeys(password);
+        browser.findElement(webdriver.By.xpath('/html/body/div[7]/div/div[2]/div[2]/div/div[1]/div/div[1]/form/div/button')).click();
+        return browser.wait(() => browser.isElementPresent(webdriver.By.id('menu-toggler')), 5000)
+          .then(r => browser.findElement(webdriver.By.xpath('/html/body/div/p[1]/button[2]')))
+          .then(r => r.click())
+          .then(r => browser.getCurrentUrl())
+          .catch(r => browser.getCurrentUrl());
+
     default:
       throw 'No OAuth function found for element ' + element + '.  Please implement function in core/oauth so ' + element + ' can be provisioned';
   }


### PR DESCRIPTION
## Highlights
* Added ability to provision Ecwid element using an Oauth2
* Added selenium script for provisioning Ecwid instance using  Oauth2

## Screenshot
![image](https://user-images.githubusercontent.com/34128818/35675808-67d9afcc-076f-11e8-8edc-9e9ae71032e0.png)

* Note: 
            1) Basic tests transformations were failing before my implementation as well.
            2) The churros testcases will be executed with new OAuth2 flow and not with existing custom flow.


## Reference
* [SOBA](https://github.com/cloud-elements/soba/pull/8004)
* [churros-sauce](https://github.com/cloud-elements/churros-sauce/pull/154)
* [RALLY-#${US2755}](https://rally1.rallydev.com/#/144349237612d/detail/userstory/168523636680)

## Closes
* Closes [US2755](https://rally1.rallydev.com/#/144349237612d/detail/userstory/168523636680)
