### PR TITLE
added test for mailchimp open-details endpoint

### DIFF
--- a/src/test/elements/mailchimpv3/campaigns.js
+++ b/src/test/elements/mailchimpv3/campaigns.js
@@ -71,6 +71,16 @@ suite.forElement('marketing', 'campaigns', { payload: payload }, (test) => {
       .then((r) => cloud.get(`/hubs/marketing/campaigns/${campaign_id}/email-activities/${email_id}`));
   });
 
+  it('should allow S for since date for campaigns/{id}/open-details', () => {
+    let date = new Date();
+    let campaign_id;
+    return cloud.get(`/hubs/marketing/campaigns`)
+      .then((r) => {
+      campaign_id = r.body[0].id;
+      })
+      .then((r) => cloud.withOptions({ qs: { where: `since = '${date}'` } }).get(`/hubs/marketing/campaigns/${campaign_id}/email-activities`))
+  })
+
   //This test filters for campaigns that have emails that have been opened
   //The first test path uses a hardcoded id set to a campaign with open activity
   //The second test path dynamically looks for a campaignId with open activity
@@ -86,20 +96,20 @@ suite.forElement('marketing', 'campaigns', { payload: payload }, (test) => {
         if(r.body[0]) {
           expect(r.body[0].opens).to.not.be.empty;
         } else {
-          campaign_id;
-          return cloud.withOptions({ qs: { page: 1, pageSize: 400 } }).get(`${test.api}`)
-            .then((r) => {
-              let data = r.body;
-              data.forEach((obj) => {
-              if (obj.report_summary && obj.report_summary.opens) {
-              response.push(obj);
-              }
-            });
-            campaign_id = response[0].id;
-          })
-          .then((r) => cloud.get(`/hubs/marketing/campaigns/${campaign_id}/open-details`))
-          expect(r.body[0].opens).to.not.be.empty;
-        }
-      })
-    }) 
+        campaign_id;
+        return cloud.withOptions({ qs: { page: 1, pageSize: 400 } }).get(`${test.api}`)
+          .then((r) => {
+            let data = r.body;
+            data.forEach((obj) => {
+            if (obj.report_summary && obj.report_summary.opens) {
+            response.push(obj);
+            }
+          });
+          campaign_id = response[0].id;
+        })
+        .then((r) => cloud.get(`/hubs/marketing/campaigns/${campaign_id}/open-details`))
+        expect(r.body[0].opens).to.not.be.empty;
+      }
+    })
+  });
 });

--- a/src/test/elements/mailchimpv3/campaigns.js
+++ b/src/test/elements/mailchimpv3/campaigns.js
@@ -70,26 +70,26 @@ suite.forElement('marketing', 'campaigns', { payload: payload }, (test) => {
       })
       .then((r) => cloud.get(`/hubs/marketing/campaigns/${campaign_id}/email-activities/${email_id}`));
   });
-  
+
   //This test filters for campaigns that have emails that have been opened
   //PageSize is set to 400 because there were no opened emails available on the first page of campaigns
   it('should allow R for campaigns/{id}/open-details', () => {
     let response = [];
-    let email_id, campaign_id;
+    let campaign_id;
     return cloud.withOptions({qs: { page: 1, pageSize: 400 } }).get(`${test.api}`)
       .then((r) => {
         let data = r.body;
         expect(r.body).to.not.be.empty;
         data.forEach((obj) => {
           if (obj.report_summary && obj.report_summary['opens']) {
-            response.push(obj)
+            response.push(obj);
           }
-        })
+        });
         campaign_id = response[0].id;
       })
       .then((r) => cloud.get(`/hubs/marketing/campaigns/${campaign_id}/open-details`))
       .then((r) => {
         expect(r.body).to.not.be.empty;
-      })
+      });
   }); 
 });

--- a/src/test/elements/mailchimpv3/campaigns.js
+++ b/src/test/elements/mailchimpv3/campaigns.js
@@ -110,8 +110,8 @@ suite.forElement('marketing', 'campaigns', { payload: payload }, (test) => {
         .then((r) => cloud.get(`/hubs/marketing/campaigns/${campaign_id}/open-details`))
         .then((r) => {
           expect(r.body[0].opens).to.not.be.empty;
-        })
-      }
+        });
+      };
     });
   });
 });

--- a/src/test/elements/mailchimpv3/campaigns.js
+++ b/src/test/elements/mailchimpv3/campaigns.js
@@ -3,6 +3,7 @@
 const suite = require('core/suite');
 const payload = require('core/tools').requirePayload(`${__dirname}/assets/campaigns.json`);
 const cloud = require('core/cloud');
+const expect = require('chakram').expect;
 
 const updatePayload = () => ({
   "recipients": {
@@ -45,8 +46,50 @@ suite.forElement('marketing', 'campaigns', { payload: payload }, (test) => {
       .then(r => cloud.get(`${test.api}/${campaignId}/comments/${commentId}`))
       .then(r => cloud.patch(`${test.api}/${campaignId}/comments/${commentId}`, commentsUpdate()))
       .then(r => cloud.post(`${test.api}/${campaignId}/comments`, commentsPayload()))
-      .then(r => cloud.withOptions({ qs: { page: 1, pageSize: 1 } }).get(`${test.api}/${campaignId}/comments`))
+      .then(r => cloud.withOptions({qs: { page: 1, pageSize: 1 } }).get(`${test.api}/${campaignId}/comments`))
       .then(r => cloud.delete(`${test.api}/${campaignId}/comments/${commentId}`))
       .then(r => cloud.delete(`${test.api}/${campaignId}`));
   });
+//This test assures that there is some campaign activity on the campaign we pull for
+//GET campaigns/id/emailActivity
+  it('should allow R for campaigns/{id}/email-activities', () => {
+    let response, email_id, campaign_id;
+    return cloud.get(`/hubs/marketing/campaigns`)
+      .then((r) => {
+        let data = r.body;
+        expect(r.body).to.not.be.empty;
+        response = data.filter((obj) => {
+          return obj.report_summary;
+        });
+        campaign_id = response[0].id;
+      })
+      .then((r) => cloud.get(`/hubs/marketing/campaigns/${campaign_id}/email-activities`))
+      .then((r) => {
+        expect(r.body).to.not.be.empty;
+        email_id = r.body[0].email_id;
+      })
+      .then((r) => cloud.get(`/hubs/marketing/campaigns/${campaign_id}/email-activities/${email_id}`));
+  });
+  
+  //This test filters for campaigns that have emails that have been opened
+  //PageSize is set to 400 because there were no opened emails available on the first page of campaigns
+  it('should allow R for campaigns/{id}/open-details', () => {
+    let response = [];
+    let email_id, campaign_id;
+    return cloud.withOptions({qs: { page: 1, pageSize: 400 } }).get(`${test.api}`)
+      .then((r) => {
+        let data = r.body;
+        expect(r.body).to.not.be.empty;
+        data.forEach((obj) => {
+          if (obj.report_summary && obj.report_summary['opens']) {
+            response.push(obj)
+          }
+        })
+        campaign_id = response[0].id;
+      })
+      .then((r) => cloud.get(`/hubs/marketing/campaigns/${campaign_id}/open-details`))
+      .then((r) => {
+        expect(r.body).to.not.be.empty;
+      })
+  }); 
 });

--- a/src/test/elements/mailchimpv3/campaigns.js
+++ b/src/test/elements/mailchimpv3/campaigns.js
@@ -81,7 +81,7 @@ suite.forElement('marketing', 'campaigns', { payload: payload }, (test) => {
         let data = r.body;
         expect(r.body).to.not.be.empty;
         data.forEach((obj) => {
-          if (obj.report_summary && obj.report_summary['opens']) {
+          if (obj.report_summary && obj.report_summary.opens) {
             response.push(obj);
           }
         });

--- a/src/test/elements/mailchimpv3/campaigns.js
+++ b/src/test/elements/mailchimpv3/campaigns.js
@@ -78,8 +78,8 @@ suite.forElement('marketing', 'campaigns', { payload: payload }, (test) => {
       .then((r) => {
       campaign_id = r.body[0].id;
       })
-      .then((r) => cloud.withOptions({ qs: { where: `since = '${date}'` } }).get(`/hubs/marketing/campaigns/${campaign_id}/email-activities`))
-  })
+      .then((r) => cloud.withOptions({ qs: { where: `since = '${date}'` } }).get(`/hubs/marketing/campaigns/${campaign_id}/email-activities`));
+  });
 
   //This test filters for campaigns that have emails that have been opened
   //The first test path uses a hardcoded id set to a campaign with open activity
@@ -111,7 +111,7 @@ suite.forElement('marketing', 'campaigns', { payload: payload }, (test) => {
         .then((r) => {
           expect(r.body[0].opens).to.not.be.empty;
         });
-      };
+      }
     });
   });
 });

--- a/src/test/elements/mailchimpv3/campaigns.js
+++ b/src/test/elements/mailchimpv3/campaigns.js
@@ -76,7 +76,7 @@ suite.forElement('marketing', 'campaigns', { payload: payload }, (test) => {
   it('should allow R for campaigns/{id}/open-details', () => {
     let response = [];
     let campaign_id;
-    return cloud.withOptions({qs: { page: 1, pageSize: 400 } }).get(`${test.api}`)
+    return cloud.withOptions({ qs: { page: 1, pageSize: 400 } }).get(`${test.api}`)
       .then((r) => {
         let data = r.body;
         expect(r.body).to.not.be.empty;

--- a/src/test/elements/mailchimpv3/campaigns.js
+++ b/src/test/elements/mailchimpv3/campaigns.js
@@ -108,8 +108,10 @@ suite.forElement('marketing', 'campaigns', { payload: payload }, (test) => {
           campaign_id = response[0].id;
         })
         .then((r) => cloud.get(`/hubs/marketing/campaigns/${campaign_id}/open-details`))
-        expect(r.body[0].opens).to.not.be.empty;
+        .then((r) => {
+          expect(r.body[0].opens).to.not.be.empty;
+        })
       }
-    })
+    });
   });
 });


### PR DESCRIPTION
## Highlights
* Enhanced  Mailchimp API's with open-detail functionality
Users can now get detailed information about any campaign emails that were opened by a list member.
`GET /campaigns/{id}/open-details `

## Screenshot
![image 2018-02-02 at 3 51 09 pm](https://user-images.githubusercontent.com/5354852/35758397-158cc34a-0831-11e8-9106-dec8f63ffd3b.png)


## Reference
* [SOBA](https://github.com/cloud-elements/soba/pull/8006)
* [RALLY-#${US7644}](https://rally1.rallydev.com/#/144349237612d/detail/userstory/194852630868)

## Closes
* Closes [Rally US7644](https://rally1.rallydev.com/#/144349237612d/detail/userstory/194852630868)
