### PR TITLE
QuickBooks Online Enhanced with /transfers, /budgets, /deposits and currencies endpoints

### DIFF
--- a/src/test/elements/quickbooks/assets/currencies.json
+++ b/src/test/elements/quickbooks/assets/currencies.json
@@ -1,0 +1,3 @@
+{
+  "code":"<<finance.currencyCode>>"
+}

--- a/src/test/elements/quickbooks/assets/deposits.json
+++ b/src/test/elements/quickbooks/assets/deposits.json
@@ -1,0 +1,16 @@
+{
+  "line": [{
+    "detailType": "DEPOSIT_LINE_DETAIL",
+    "amount": 69.2,
+    "depositLineDetail": {
+      "accountRef": {
+        "name": "Unapplied Cash Payment Income",
+        "value": "122"
+      }
+    }
+  }],
+  "depositToAccountRef": {
+    "name": "10300 Savings",
+    "value": "59"
+  }
+}

--- a/src/test/elements/quickbooks/assets/transfers.json
+++ b/src/test/elements/quickbooks/assets/transfers.json
@@ -1,0 +1,11 @@
+{
+  "amount": "<<random.number>>",
+  "toAccountRef": {
+    "name": "<<random.word>>",
+    "value": "58"
+  },
+  "fromAccountRef": {
+    "name": "<<random.word>>",
+    "value": "59"
+  }
+}

--- a/src/test/elements/quickbooks/budgets.js
+++ b/src/test/elements/quickbooks/budgets.js
@@ -1,9 +1,13 @@
 'use strict';
 
 const suite = require('core/suite');
-
+const expect = require('chakram').expect;
 suite.forElement('finance', 'budgets', (test) => {
   test.should.supportSr();
   test.should.supportPagination();
-  test.should.supportCeqlSearch('active');
+  test.withApi(test.api)
+    .withOptions({ qs: { where: "active='true'" } })
+    .withValidation(r => expect(r.body.filter(obj => obj.active === true)).to.not.be.empty)
+    .withName('should allow GET with option active')
+    .should.return200OnGet();
 });

--- a/src/test/elements/quickbooks/budgets.js
+++ b/src/test/elements/quickbooks/budgets.js
@@ -4,5 +4,6 @@ const suite = require('core/suite');
 
 suite.forElement('finance', 'budgets', (test) => {
   test.should.supportSr();
-  test.withOptions({ qs: { page: 1, pageSize: 5 } }).should.return200OnGet();
+  test.should.supportPagination();
+  test.should.supportCeqlSearch('active');
 });

--- a/src/test/elements/quickbooks/budgets.js
+++ b/src/test/elements/quickbooks/budgets.js
@@ -1,0 +1,9 @@
+'use strict';
+
+const suite = require('core/suite');
+const tools = require('core/tools');
+
+suite.forElement('finance', 'budgets', (test) => {
+  test.should.supportSr();
+  test.withOptions({ qs: { page: 1, pageSize: 5 } }).should.return200OnGet();
+});

--- a/src/test/elements/quickbooks/budgets.js
+++ b/src/test/elements/quickbooks/budgets.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const suite = require('core/suite');
-const tools = require('core/tools');
 
 suite.forElement('finance', 'budgets', (test) => {
   test.should.supportSr();

--- a/src/test/elements/quickbooks/currencies.js
+++ b/src/test/elements/quickbooks/currencies.js
@@ -1,10 +1,10 @@
 'use strict';
 
 const suite = require('core/suite');
-const tools = require('core/tools');
 const payload = tools.requirePayload(`${__dirname}/assets/currencies.json`);
 
 suite.forElement('finance', 'currencies', { payload: payload }, (test) => {
   test.should.supportCruds();
-  test.withOptions({ qs: { page: 1, pageSize: 5 } }).should.return200OnGet();
+  test.should.supportPagination();
+  test.should.supportCeqlSearch('code');
 });

--- a/src/test/elements/quickbooks/currencies.js
+++ b/src/test/elements/quickbooks/currencies.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const suite = require('core/suite');
+const tools = require('core/tools');
 const payload = tools.requirePayload(`${__dirname}/assets/currencies.json`);
 
 suite.forElement('finance', 'currencies', { payload: payload }, (test) => {

--- a/src/test/elements/quickbooks/currencies.js
+++ b/src/test/elements/quickbooks/currencies.js
@@ -1,0 +1,10 @@
+'use strict';
+
+const suite = require('core/suite');
+const tools = require('core/tools');
+const payload = tools.requirePayload(`${__dirname}/assets/currencies.json`);
+
+suite.forElement('finance', 'currencies', { payload: payload }, (test) => {
+  test.should.supportCruds();
+  test.withOptions({ qs: { page: 1, pageSize: 5 } }).should.return200OnGet();
+});

--- a/src/test/elements/quickbooks/deposits.js
+++ b/src/test/elements/quickbooks/deposits.js
@@ -1,10 +1,10 @@
 'use strict';
 
 const suite = require('core/suite');
-const tools = require('core/tools');
 const payload = tools.requirePayload(`${__dirname}/assets/deposits.json`);
 
 suite.forElement('finance', 'deposits', { payload: payload }, (test) => {
   test.should.supportCruds();
-  test.withOptions({ qs: { page: 1, pageSize: 5 } }).should.return200OnGet();
+  test.should.supportPagination();
+  test.should.supportCeqlSearch('txnDate');
 });

--- a/src/test/elements/quickbooks/deposits.js
+++ b/src/test/elements/quickbooks/deposits.js
@@ -1,0 +1,10 @@
+'use strict';
+
+const suite = require('core/suite');
+const tools = require('core/tools');
+const payload = tools.requirePayload(`${__dirname}/assets/deposits.json`);
+
+suite.forElement('finance', 'deposits', { payload: payload }, (test) => {
+  test.should.supportCruds();
+  test.withOptions({ qs: { page: 1, pageSize: 5 } }).should.return200OnGet();
+});

--- a/src/test/elements/quickbooks/deposits.js
+++ b/src/test/elements/quickbooks/deposits.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const suite = require('core/suite');
+const tools = require('core/tools');
 const payload = tools.requirePayload(`${__dirname}/assets/deposits.json`);
 
 suite.forElement('finance', 'deposits', { payload: payload }, (test) => {

--- a/src/test/elements/quickbooks/transfers.js
+++ b/src/test/elements/quickbooks/transfers.js
@@ -2,7 +2,6 @@
 
 const suite = require('core/suite');
 const tools = require('core/tools');
-const cloud = require('core/cloud');
 const payload = tools.requirePayload(`${__dirname}/assets/transfers.json`);
 
 suite.forElement('finance', 'transfers', { payload: payload }, (test) => {

--- a/src/test/elements/quickbooks/transfers.js
+++ b/src/test/elements/quickbooks/transfers.js
@@ -1,0 +1,11 @@
+'use strict';
+
+const suite = require('core/suite');
+const tools = require('core/tools');
+const cloud = require('core/cloud');
+const payload = tools.requirePayload(`${__dirname}/assets/transfers.json`);
+
+suite.forElement('finance', 'transfers', { payload: payload }, (test) => {
+  test.should.supportCruds();
+  test.withOptions({ qs: { page: 1, pageSize: 5 } }).should.return200OnGet();
+});

--- a/src/test/elements/quickbooks/transfers.js
+++ b/src/test/elements/quickbooks/transfers.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const suite = require('core/suite');
+const tools = require('core/tools');
 const payload = tools.requirePayload(`${__dirname}/assets/transfers.json`);
 
 suite.forElement('finance', 'transfers', { payload: payload }, (test) => {

--- a/src/test/elements/quickbooks/transfers.js
+++ b/src/test/elements/quickbooks/transfers.js
@@ -1,10 +1,10 @@
 'use strict';
 
 const suite = require('core/suite');
-const tools = require('core/tools');
 const payload = tools.requirePayload(`${__dirname}/assets/transfers.json`);
 
 suite.forElement('finance', 'transfers', { payload: payload }, (test) => {
   test.should.supportCruds();
-  test.withOptions({ qs: { page: 1, pageSize: 5 } }).should.return200OnGet();
+  test.should.supportPagination();
+  test.should.supportCeqlSearch('txnDate');
 });


### PR DESCRIPTION
## Non-customer Highlights
* QuickBooks Online Enhanced with testcases for /transfers, /budgets, /deposits and currencies endpoints . 

## Checklist
* [x] applicable churros tests are still passing
* [ ] includes a dbdeploy script that is backward-incompatible with one previous Soba minor version

## Screen shot
<img width="823" alt="screen shot 2018-02-05 at 12 20 19 am" src="https://user-images.githubusercontent.com/26943831/35791116-7ee61540-0a0b-11e8-8b4a-31ee603f879b.png">
<img width="841" alt="screen shot 2018-02-05 at 12 20 45 am" src="https://user-images.githubusercontent.com/26943831/35791118-8183e480-0a0b-11e8-9b21-5e942d2faf75.png">
<img width="842" alt="screen shot 2018-02-05 at 12 21 05 am" src="https://user-images.githubusercontent.com/26943831/35791119-83ff1c5c-0a0b-11e8-8aa1-fb54c4543b43.png">


## Related PRs
[Soba](https://github.com/cloud-elements/soba/compare/Quickbooks_US7346?expand=1)

## Closes
[Rally](https://rally1.rallydev.com/#/144349237612d/detail/userstory/193152085556)