### PR TITLE
Docusign: Added Envelope Recipients GET API #8018

### DIFF
--- a/src/test/elements/docusign/envelopes.js
+++ b/src/test/elements/docusign/envelopes.js
@@ -66,7 +66,9 @@ suite.forElement('esignature', 'envelopes', (test) => {
     return cloud.withOptions(opts).postFile(test.api, path)
       .then(r => envelopeId = r.body.envelopeId)
       .then(r => cloud.post(`${test.api}/${envelopeId}/recipients`, recipient))
-      .then(r => cloud.post(`${test.api}/${envelopeId}/recipients/${recipient.agents[0].recipientId}/tabs`, tab));
+      .then(r => cloud.post(`${test.api}/${envelopeId}/recipients/${recipient.agents[0].recipientId}/tabs`, tab))
+      .then(r => cloud.get(`${test.api}/${envelopeId}/recipients`))
+      .then(r => cloud.withOptions({ qs: { where: 'include_tabs=\'true\'' } }).get(`${test.api}/${envelopeId}/recipients`));
   });
 
   test.withValidation(envelopesSchema)

--- a/src/test/elements/docusign/envelopes.js
+++ b/src/test/elements/docusign/envelopes.js
@@ -68,7 +68,12 @@ suite.forElement('esignature', 'envelopes', (test) => {
       .then(r => cloud.post(`${test.api}/${envelopeId}/recipients`, recipient))
       .then(r => cloud.post(`${test.api}/${envelopeId}/recipients/${recipient.agents[0].recipientId}/tabs`, tab))
       .then(r => cloud.get(`${test.api}/${envelopeId}/recipients`))
-      .then(r => cloud.withOptions({ qs: { where: 'include_tabs=\'true\'' } }).get(`${test.api}/${envelopeId}/recipients`));
+      .then(r => cloud.withOptions({ qs: { where: 'include_tabs=\'true\'' } }).get(`${test.api}/${envelopeId}/recipients`))
+	  .then(r => {
+        expect(r).to.have.statusCode(200);
+        expect(r.body).to.not.be.undefined;
+        expect(r.body.tabs).to.not.be.null;
+      });
   });
 
   test.withValidation(envelopesSchema)

--- a/src/test/elements/docusign/envelopes.js
+++ b/src/test/elements/docusign/envelopes.js
@@ -58,7 +58,7 @@ suite.forElement('esignature', 'envelopes', (test) => {
       .then(r => cloud.get(`${test.api}/${envelopeId}/documents/certificates`));
   });
 
-  it(`should support create on ${test.api}/:id/recipients and ${test.api}/:id/recipients/:id/tabs`, () => {
+  it(`should support CR on ${test.api}/:id/recipients and ${test.api}/:id/recipients/:id/tabs`, () => {
     let envelopeId = "-1";
     let path = __dirname + '/assets/MrRobotPdf.pdf';
     const opts = { formData: { envelope: JSON.stringify(createPayload) } };


### PR DESCRIPTION
## Highlights
* Added Envelopes Recipients GET API: GET /envelopes/{id}/recipients

## Screenshot
![img_07022018_154748_0](https://user-images.githubusercontent.com/34128818/35910960-5fcf16e2-0c1e-11e8-9c9c-432f5a1500cd.png)

## Reference
* [SOBA](https://github.com/cloud-elements/soba/pull/8018)
* [US7344](https://rally1.rallydev.com/#/144349237612d/detail/userstory/193151748320)
## Closes
* [US7344](https://rally1.rallydev.com/#/144349237612d/detail/userstory/193151748320)