### PR TITLE
Fixes freshdeskv2 churros

### DIFF
--- a/src/test/elements/assets/object.definitions.json
+++ b/src/test/elements/assets/object.definitions.json
@@ -1843,7 +1843,6 @@
      "path": "id",
      "type": "string"
    }]
- }
  },"checking-accounts": {
     "fields": [{
       "path": "idTransformed",

--- a/src/test/elements/freshdeskv2/assets/accounts.json
+++ b/src/test/elements/freshdeskv2/assets/accounts.json
@@ -1,4 +1,6 @@
 {
-  "name": "<<name.firstName>><<name.lastName>>",
-  "description": "<<random.words>>"
+  "customer": {
+      "name": "<<name.firstName>>",
+      "description": "<<random.words>>"
+    }
 }

--- a/src/test/elements/freshdeskv2/assets/transformations.json
+++ b/src/test/elements/freshdeskv2/assets/transformations.json
@@ -3,7 +3,7 @@
     "vendorName": "accounts",
     "fields": [{
       "path": "id",
-      "vendorPath": "id"
+      "vendorPath": "customer.id"
     }]
   },
   "incidents": {


### PR DESCRIPTION
## Highlights
* Fixes freshdeskv2 churros for /accounts

## Examples
```elemnts-mac49:churros ramana$ churros test elements/freshdeskv2
sleep: using busy loop fallback


info: Using url: http://localhost:5050
info: Using user: churros@ce.com
info: Using oauth username: pcTlQRXAg1YWdxDwsxIX
info: Running tests for element: freshdeskv2
error: Failed to retrieve or validate: /instances
info: Provisioned with instance id of 6410
  Basic tests
    ✓ should provision
    ✓ should GET /objects (137ms)
    - docs
    ✓ metadata (155ms)
    ✓ transformations (2447ms)
    - should not allow provisioning with bad credentials

  accounts
    ✓ should allow CRUDS for /hubs/helpdesk/accounts (1428ms)
    ✓ should allow paginating with page and pageSize for /hubs/helpdesk/accounts (847ms)

  agents
    ✓ should allow SR for /hubs/helpdesk/agents (406ms)
    ✓ should allow paginating with page and pageSize for /hubs/helpdesk/agents (599ms)
    ✓ should support searching /hubs/helpdesk/agents by email (222ms)

  contacts
    ✓ should allow CRUDS for /hubs/helpdesk/contacts (1514ms)
    ✓ should allow paginating with page and pageSize for /hubs/helpdesk/contacts (687ms)
    ✓ should not allow malformed bulk query and throw a 400 (132ms)

  incidents
    ✓ should allow CRUDS for /hubs/helpdesk/incidents (1779ms)
    ✓ should allow paginating with page and pageSize for /hubs/helpdesk/incidents (1337ms)
    ✓ should support searching /hubs/helpdesk/incidents by updated_since (944ms)
    ✓ should support GET /hubs/helpdesk/incidents/:id/comments  (1177ms)

  polling
    - polling /hubs/helpdesk/incidents
    - polling /hubs/helpdesk/contacts


  16 passing (17s)
  4 pending
```

## Reference
* [8041](https://github.com/cloud-elements/soba/pull/8041)
* [DE856](https://rally1.rallydev.com/#/144349237612d/detail/defect/196078241424)
