### PR TITLE
Fixed test cases for activitiesEmails on SugarCrm

### DIFF
--- a/src/test/elements/sugarcrmv2/assets/activitiesEmails.json
+++ b/src/test/elements/sugarcrmv2/assets/activitiesEmails.json
@@ -1,5 +1,4 @@
 {
-  "description": "Test",
   "duration_hours": 0,
   "direction": "Inbound",
   "reminder_time": "-1",
@@ -10,6 +9,5 @@
   "_module": "Emails",
   "duration_minutes": 30,
   "parent_id": "d58d4996-e0d1-d59b-258e-5693de8d95da",
-  "name": "Get more information on the proposed deal",
   "status": "Planned"
 }


### PR DESCRIPTION
## Non-customer Highlights
* Fixed test cases for activitiesEmails
* The patch test cases were failing due to no update allowed on the fields `name` and `description`
* Removed the above 2 fields from the payload

## Screenshot
Please include a screenshot of the tests running successfully
![image](https://user-images.githubusercontent.com/20282215/35968899-250ba0c0-0ceb-11e8-9714-c88ba1ffd6f3.png)
* Complete report: 
[SugarCRM_churros.txt](https://github.com/cloud-elements/churros/files/1706671/SugarCRM_churros.txt)

## Reference
* [SOBA](https://github.com/cloud-elements/soba/pull/8044)
* [RALLY-#US7693](https://rally1.rallydev.com/#/144349237612d/detail/userstory/195163540364)

## Closes
* [#US7693](https://rally1.rallydev.com/#/144349237612d/detail/userstory/195163540364)
