### PR TITLE
Intacct fixes testcases for /bill-payments

### DIFF
--- a/src/test/elements/intacct/assets/transformations.json
+++ b/src/test/elements/intacct/assets/transformations.json
@@ -158,7 +158,8 @@
     "fields": [{
       "path": "id",
       "vendorPath": "RECORDNO"
-    }]},
+    }]
+  },
     "checking-accounts": {
       "vendorName": "",
       "fields": [

--- a/src/test/elements/intacct/bills-payments.js
+++ b/src/test/elements/intacct/bills-payments.js
@@ -7,11 +7,11 @@ const expect = require('chakram').expect;
 suite.forElement('finance', 'bills-payments', (test) => {
   test.should.supportSr();
   test
-    .withOptions({ qs: { where: `WHENMODIFIED > '06/23/2013 14:25:17'` } })
+    .withOptions({ qs: { where: `WHENMODIFIED >= '06/23/2013 14:25:17'` } })
     .withName('should support Ceql date search')
     .withValidation(r => {
       expect(r).to.statusCode(200);
-      const validValues = r.body.filter(obj => obj.WHENMODIFIED >= '06/23/2013 14:25:17');
+      const validValues = r.body.filter(obj => new Date(obj.WHENMODIFIED).getTime() >= 1372015517000); //06/23/2013 14:25:17 is equivalent to 1372015517000
       expect(validValues.length).to.equal(r.body.length);
     })
     .should.return200OnGet();


### PR DESCRIPTION
## Highlights
* Fixes Intacct `/bill-payments` testcases

# Screen Shot
![screen shot 2018-02-09 at 8 48 23 pm](https://user-images.githubusercontent.com/26943831/36057887-ba9dcaa6-0dda-11e8-9d9e-61524f435442.png)
![screen shot 2018-02-09 at 8 48 41 pm](https://user-images.githubusercontent.com/26943831/36057888-bcae5900-0dda-11e8-81cd-0789c8ad72e9.png)
![screen shot 2018-02-09 at 8 48 58 pm](https://user-images.githubusercontent.com/26943831/36057889-be3cdca6-0dda-11e8-9f35-f2189184bd5d.png)

## Reference
* [Soba](https://github.com/cloud-elements/soba/pull/8060)

## Closes
* [Rally](https://rally1.rallydev.com/#/144349237612d/detail/defect/196757925664)