### PR TITLE
Add churros test for branding API properties

### DIFF
--- a/src/test/platform/organizations/branding.js
+++ b/src/test/platform/organizations/branding.js
@@ -31,6 +31,21 @@ suite.forPlatform('organizations/branding', test => {
     topBarBackgroundColor: '#aedce7',
     navigationBackgroundColor: '#aedce7',
     contextBackgroundColor: '#aedce7',
+    cardHeaderColor: '#ffffff',
+    cardBackground: '#ffffff',
+    cardMenuBackground: '#ffffff',
+    cardMenuLinkColor: '#ffffff',
+    navigationLinkBackground: '#ffffff',
+    navigationLinkForeground: '#ffffff',
+    navigationLinkBackgroundHover: '#ffffff',
+    navigationLinkForegroundHover: '#ffffff',
+    navigationLinkBackgroundActive: '#ffffff',
+    navigationLinkForegroundActive: '#ffffff',
+    topBarNavigationColor: '#ffffff',
+    tableHeaderBackground: '#ffffff',
+    tableHeaderForeground: '#ffffff',
+    tableBodyBackground: '#ffffff',
+    tableBodyForeground: '#ffffff',
   };
 
   it('should support upserting, retrieving and deleting branding for a company', () => {

--- a/src/test/platform/organizations/rbac.js
+++ b/src/test/platform/organizations/rbac.js
@@ -472,6 +472,21 @@ suite.forPlatform('Tests privileges restrict API access as expected', test => {
       topBarBackgroundColor: '#aedce7',
       navigationBackgroundColor: '#aedce7',
       contextBackgroundColor: '#aedce7',
+      cardHeaderColor: '#ffffff',
+      cardBackground: '#ffffff',
+      cardMenuBackground: '#ffffff',
+      cardMenuLinkColor: '#ffffff',
+      navigationLinkBackground: '#ffffff',
+      navigationLinkForeground: '#ffffff',
+      navigationLinkBackgroundHover: '#ffffff',
+      navigationLinkForegroundHover: '#ffffff',
+      navigationLinkBackgroundActive: '#ffffff',
+      navigationLinkForegroundActive: '#ffffff',
+      topBarNavigationColor: '#ffffff',
+      tableHeaderBackground: '#ffffff',
+      tableHeaderForeground: '#ffffff',
+      tableBodyBackground: '#ffffff',
+      tableBodyForeground: '#ffffff',
     };
 
     it('should restrict access to updating the organization branding information but not retrieving it with the proper privilege', () => {


### PR DESCRIPTION
## Highlights
* Add churros test for new branding API properties

## Screenshot
one test failing because missing AWS setup
<img width="649" alt="image 2018-02-12 at 9 15 42 pm" src="https://user-images.githubusercontent.com/2327802/36131903-eb3d1886-1039-11e8-80f0-cafe1b7a0c78.png">

## Reference
* [SOBA](https://github.com/cloud-elements/soba/pull/8072)
* [RALLY-#TA7413](https://rally1.rallydev.com/#/detail/task/197326037840?fdp=true)

