### PR TITLE
Quicbooks Online : Added test for checking elements-return-count header

### DIFF
--- a/src/test/elements/quickbooks/bill-payments.js
+++ b/src/test/elements/quickbooks/bill-payments.js
@@ -2,9 +2,17 @@
 
 const suite = require('core/suite');
 const payload = require('./assets/bill-payments');
+const chakram = require('chakram');
+const expect = chakram.expect;
 
 suite.forElement('finance', 'bill-payments', { payload: payload }, (test) => {
   test.should.supportCrds();
   test.withOptions({ qs: { page: 1, pageSize: 5 } }).should.return200OnGet();
-  test.withOptions({ qs: { where: 'totalAmt = \'1\'', page: 1, pageSize: 1 } }).should.return200OnGet();
+  test.withOptions({ qs: { where: 'totalAmt = \'1\'', page: 1, pageSize: 1, returnCount: true } })
+  	.withName('Test for search on totalAmt and returnCount in response')
+  	.withValidation(r => {
+      expect(r).to.statusCode(200);
+      expect(r.response.headers['elements-total-count']).to.exist;
+    })
+  .should.return200OnGet();
 });

--- a/src/test/elements/quickbooks/bills.js
+++ b/src/test/elements/quickbooks/bills.js
@@ -2,9 +2,18 @@
 
 const suite = require('core/suite');
 const payload = require('./assets/bills');
+const expect = require('chakram').expect;
 
 suite.forElement('finance', 'bills', { payload: payload }, (test) => {
   test.should.supportCruds();
   test.withOptions({ qs: { page: 1, pageSize: 1 } }).should.return200OnGet();
-  test.withOptions({ qs: { where: 'totalAmt = \'1\'', page: 1, pageSize: 1 } }).should.return200OnGet();
+  test
+  	.withOptions({ qs: { where: 'totalAmt = \'1\'', page: 1, pageSize: 1, returnCount: true} })
+  	.withName('Test for search by totalAmt and returnCount in response')
+  	.withValidation((r) => {
+      expect(r).to.have.statusCode(200);
+      const validValues = r.body.filter(obj => obj.totalAmt = '1');
+      expect(validValues.length).to.equal(r.body.length);
+      expect(r.response.headers['elements-total-count']).to.exist;
+    }).should.return200OnGet();
 });

--- a/src/test/elements/quickbooks/classes.js
+++ b/src/test/elements/quickbooks/classes.js
@@ -7,12 +7,12 @@ const expect = chakram.expect;
 suite.forElement('finance', 'classes', null, (test) => {
   test.should.supportSr();
   test.withName(`should support searching ${test.api} by Id`)
-    .withOptions({ qs: { where: `id ='1234'` } })
+    .withOptions({ qs: { where: `id ='1234'`, returnCount: true } })
+    .withName('Test for search on id and returnCount in response')
     .withValidation((r) => {
       expect(r).to.have.statusCode(200);
       const validValues = r.body.filter(obj => obj.id = '1234');
       expect(validValues.length).to.equal(r.body.length);
+      expect(r.response.headers['elements-total-count']).to.exist;
     }).should.return200OnGet();
-
-
 });

--- a/src/test/elements/quickbooks/credit-memos.js
+++ b/src/test/elements/quickbooks/credit-memos.js
@@ -2,9 +2,18 @@
 
 const suite = require('core/suite');
 const payload = require('./assets/credit-memos');
+const chakram = require('chakram');
+const expect = chakram.expect;
 
 suite.forElement('finance', 'credit-memos', { payload: payload }, (test) => {
   test.should.supportCruds();
   test.withOptions({ qs: { page: 1, pageSize: 5 } }).should.return200OnGet();
-  test.withOptions({ qs: { where: 'totalAmt = \'1\'', page: 1, pageSize: 1 } }).should.return200OnGet();
+  test.withOptions({ qs: { where: 'totalAmt = \'1\'', page: 1, pageSize: 1, returnCount: true } })
+    .withName('Test for search on totalAmt and returnCount in response')
+    .withValidation((r) => {
+      expect(r).to.have.statusCode(200);
+      const validValues = r.body.filter(obj => obj.totalAmt = '1');
+      expect(validValues.length).to.equal(r.body.length);
+      expect(r.response.headers['elements-total-count']).to.exist;
+    }).should.return200OnGet();
 });

--- a/src/test/elements/quickbooks/credit-terms.js
+++ b/src/test/elements/quickbooks/credit-terms.js
@@ -9,14 +9,15 @@ const payload = tools.requirePayload(`${__dirname}/assets/credit-terms.json`);
 //Need to skip as there is no delete API
 suite.forElement('finance', 'credit-terms', { payload: payload }, (test) => {
   test.should.supportSr();
-test.withOptions({skip:true}).should.return200OnPost();
+  test.withOptions({skip:true}).should.return200OnPost();
   test.withOptions({ qs: { page: 1, pageSize: 5 } }).should.return200OnGet();
-  test.withName(`should support searching ${test.api} by Id`)
-    .withOptions({ qs: { where: `id ='1234'` } })
+  test.withName(`should support searching ${test.api} by Id and returnCount in response`)
+    .withOptions({ qs: { where: `id ='1234'`, returnCount: true } })
     .withValidation((r) => {
       expect(r).to.have.statusCode(200);
       const validValues = r.body.filter(obj => obj.id = '1234');
       expect(validValues.length).to.equal(r.body.length);
+      expect(r.response.headers['elements-total-count']).to.exist;
     }).should.return200OnGet();
 
 

--- a/src/test/elements/quickbooks/customers.js
+++ b/src/test/elements/quickbooks/customers.js
@@ -4,6 +4,8 @@ const suite = require('core/suite');
 const tools = require('core/tools');
 const payload = tools.requirePayload(`${__dirname}/assets/customers.json`);
 const cloud = require('core/cloud');
+const chakram = require('chakram');
+const expect = chakram.expect;
 
 suite.forElement('finance', 'customers', { payload: payload }, (test) => {
   const options = {
@@ -15,7 +17,13 @@ suite.forElement('finance', 'customers', { payload: payload }, (test) => {
     }
   };
   test.withOptions(options).should.supportCruds();
-  test.withOptions({ qs: { page: 1, pageSize: 5 } }).should.return200OnGet();
+  test.withOptions({ qs: { page: 1, pageSize: 5, returnCount: true } })
+    .withName('Test for pagination and returnCount in response')
+    .withValidation((r) => {
+      expect(r).to.have.statusCode(200);
+      expect(r.response.headers['elements-total-count']).to.exist;
+    }).should.return200OnGet();
+
   test.should.supportCeqlSearch('familyName');
   it('should support CEQL style boolean queries with single quotes', () => {
     return cloud.withOptions({ qs: { where: "active='true'" }}).get('/customers');

--- a/src/test/elements/quickbooks/departments.js
+++ b/src/test/elements/quickbooks/departments.js
@@ -3,6 +3,8 @@
 const suite = require('core/suite');
 const tools = require('core/tools');
 const payload = tools.requirePayload(`${__dirname}/assets/departments.json`);
+const chakram = require('chakram');
+const expect = chakram.expect;
 
 suite.forElement('finance', 'departments', { payload: payload }, (test) => {
   const options = {
@@ -14,6 +16,11 @@ suite.forElement('finance', 'departments', { payload: payload }, (test) => {
     }
   };
   test.withOptions(options).should.supportCruds();
-  test.withOptions({ qs: { page: 1, pageSize: 5 } }).should.return200OnGet();
+  test.withOptions({ qs: { page: 1, pageSize: 5, returnCount: true } })
+  .withName('Test for returnCount in response')
+    .withValidation((r) => {
+      expect(r).to.have.statusCode(200);
+      expect(r.response.headers['elements-total-count']).to.exist;
+    }).should.return200OnGet();
   test.should.supportCeqlSearch('name');
 });

--- a/src/test/elements/quickbooks/employees.js
+++ b/src/test/elements/quickbooks/employees.js
@@ -3,6 +3,8 @@
 const suite = require('core/suite');
 const tools = require('core/tools');
 const payload = tools.requirePayload(`${__dirname}/assets/employees.json`);
+const chakram = require('chakram');
+const expect = chakram.expect;
 
 suite.forElement('finance', 'employees', { payload: payload }, (test) => {
   const options = {
@@ -15,6 +17,11 @@ suite.forElement('finance', 'employees', { payload: payload }, (test) => {
     }
   };
   test.withOptions(options).should.supportCruds();
-  test.withOptions({ qs: { page: 1, pageSize: 5 } }).should.return200OnGet();
+  test.withOptions({ qs: { page: 1, pageSize: 5, returnCount: true } })
+  .withName('Test for returnCount in response')
+    .withValidation((r) => {
+      expect(r).to.have.statusCode(200);
+      expect(r.response.headers['elements-total-count']).to.exist;
+    }).should.return200OnGet();
   test.should.supportCeqlSearch('displayName');
 });

--- a/src/test/elements/quickbooks/estimates.js
+++ b/src/test/elements/quickbooks/estimates.js
@@ -8,7 +8,14 @@ const payload = require('./assets/estimates');
 suite.forElement('finance', 'estimates', { payload: payload }, (test) => {
   test.should.supportCrds();
   test.withOptions({ qs: { page: 1, pageSize: 5 } }).should.supportPagination();
-  test.withOptions({ qs: { where: 'totalAmt = \'1\'', page: 1, pageSize: 1 } }).should.return200OnGet();
+  test.withOptions({ qs: { where: 'totalAmt = \'1\'', page: 1, pageSize: 1, returnCount: true } })
+    .withName('Test for search on totalAmt and returnCount in response')
+    .withValidation((r) => {
+      expect(r).to.have.statusCode(200);
+      const validValues = r.body.filter(obj => obj.totalAmt = '1');
+      expect(validValues.length).to.equal(r.body.length);
+      expect(r.response.headers['elements-total-count']).to.exist;
+    }).should.return200OnGet();
 
   it('should allow pdf download for /estimates', () => {
     let estimateId;

--- a/src/test/elements/quickbooks/invoices.js
+++ b/src/test/elements/quickbooks/invoices.js
@@ -17,7 +17,14 @@ suite.forElement('finance', 'invoices', { payload: payload }, (test) => {
   };
   test.withOptions(options).should.supportCruds();
   test.withOptions({ qs: { page: 1, pageSize: 5 } }).should.supportPagination();
-  test.withOptions({ qs: { where: 'totalAmt = \'1\'', page: 1, pageSize: 1 } }).should.return200OnGet();
+  test.withOptions({ qs: { where: 'totalAmt = \'1\'', page: 1, pageSize: 1, returnCount: true } })
+    .withName('Test for search on totalAmt and returnCount in response')
+    .withValidation((r) => {
+      expect(r).to.have.statusCode(200);
+      const validValues = r.body.filter(obj => obj.totalAmt = '1');
+      expect(validValues.length).to.equal(r.body.length);
+      expect(r.response.headers['elements-total-count']).to.exist;
+    }).should.return200OnGet();
 
   it('should allow pdf download for /invoices', () => {
     let invoiceId;

--- a/src/test/elements/quickbooks/journal-entries.js
+++ b/src/test/elements/quickbooks/journal-entries.js
@@ -16,12 +16,13 @@ suite.forElement('finance', 'journal-entries', { payload: payload }, (test) => {
   };
   test.withOptions(options).should.supportCruds();
   test.withOptions({ qs: { page: 1, pageSize: 5 } }).should.return200OnGet();
-  test.withName(`should support searching ${test.api} by Id`)
-    .withOptions({ qs: { where: `id ='1234'` } })
+  test.withName(`should support searching ${test.api} by Id and returnCount in response`)
+    .withOptions({ qs: { where: `id ='1234'`, returnCount: true } })
     .withValidation((r) => {
       expect(r).to.have.statusCode(200);
       const validValues = r.body.filter(obj => obj.id = '1234');
       expect(validValues.length).to.equal(r.body.length);
+      expect(r.response.headers['elements-total-count']).to.exist;
     }).should.return200OnGet();
 
 });

--- a/src/test/elements/quickbooks/ledger-accounts.js
+++ b/src/test/elements/quickbooks/ledger-accounts.js
@@ -11,12 +11,13 @@ suite.forElement('finance', 'ledger-accounts', { payload: payload }, (test) => {
   test.should.supportSr();
   test.withOptions({skip:true}).should.return200OnPost();
   test.withOptions({ qs: { page: 1, pageSize: 1 } }).should.return200OnGet();
-  test.withName(`should support searching ${test.api} by Id`)
-    .withOptions({ qs: { where: `id ='1234'` } })
+  test.withName(`should support searching ${test.api} by Id and returnCount in response`)
+    .withOptions({ qs: { where: `id ='1234'`, returnCount: true } })
     .withValidation((r) => {
       expect(r).to.have.statusCode(200);
       const validValues = r.body.filter(obj => obj.id = '1234');
       expect(validValues.length).to.equal(r.body.length);
+      expect(r.response.headers['elements-total-count']).to.exist;
     }).should.return200OnGet();
 
 

--- a/src/test/elements/quickbooks/payment-methods.js
+++ b/src/test/elements/quickbooks/payment-methods.js
@@ -11,12 +11,13 @@ suite.forElement('finance', 'payment-methods', { payload: payload }, (test) => {
   test.should.supportSr();
   test.withOptions({skip:true}).should.return200OnPost();
   test.withOptions({ qs: { page: 1, pageSize: 1 } }).should.return200OnGet();
-  test.withName(`should support searching ${test.api} by Id`)
-    .withOptions({ qs: { where: `id ='1234'` } })
+  test.withName(`should support searching ${test.api} by Id and returnCount in response`)
+    .withOptions({ qs: { where: `id ='1234'`, returnCount: true } })
     .withValidation((r) => {
       expect(r).to.have.statusCode(200);
       const validValues = r.body.filter(obj => obj.id = '1234');
       expect(validValues.length).to.equal(r.body.length);
+      expect(r.response.headers['elements-total-count']).to.exist;
     }).should.return200OnGet();
 
 

--- a/src/test/elements/quickbooks/payments.js
+++ b/src/test/elements/quickbooks/payments.js
@@ -24,12 +24,13 @@ suite.forElement('finance', 'payments', { payload: payload }, (test) => {
   //Need to skip as there is no delete API
   test.withOptions({ skip: true }).should.supportCrus();
   test.withOptions({ qs: { page: 1, pageSize: 1 } }).should.return200OnGet();
-  test.withName(`should support searching ${test.api} by Id`)
-    .withOptions({ qs: { where: `id ='1234'` } })
+  test.withName(`should support searching ${test.api} by Id and returnCount in response`)
+    .withOptions({ qs: { where: `id ='1234'`, returnCount: true } })
     .withValidation((r) => {
       expect(r).to.have.statusCode(200);
       const validValues = r.body.filter(obj => obj.id = '1234');
       expect(validValues.length).to.equal(r.body.length);
+      expect(r.response.headers['elements-total-count']).to.exist;
     }).should.return200OnGet();
 
 });

--- a/src/test/elements/quickbooks/products.js
+++ b/src/test/elements/quickbooks/products.js
@@ -3,6 +3,8 @@
 const suite = require('core/suite');
 const tools = require('core/tools');
 const payload = tools.requirePayload(`${__dirname}/assets/products.json`);
+const chakram = require('chakram');
+const expect = chakram.expect;
 
 suite.forElement('finance', 'products', { payload: payload }, (test) => {
   const options = {
@@ -15,5 +17,13 @@ suite.forElement('finance', 'products', { payload: payload }, (test) => {
   };
   test.withOptions(options).should.supportCruds();
   test.withOptions({ qs: { page: 1, pageSize: 5 ,orderBy : 'name desc'} }).should.return200OnGet();
-  test.withOptions({ qs: { where: 'type = \'SERVICE\'', page: 1, pageSize: 1 } }).should.return200OnGet();
+  test
+    .withOptions({ qs: { where: 'type = \'SERVICE\'', page: 1, pageSize: 1, returnCount: true } })
+    .withName('Test for search on type and returnCount in response')
+    .withValidation((r) => {
+      expect(r).to.have.statusCode(200);
+      const validValues = r.body.filter(obj => obj.type = 'SERVICE');
+      expect(validValues.length).to.equal(r.body.length);
+      expect(r.response.headers['elements-total-count']).to.exist;
+    }).should.return200OnGet();
 });

--- a/src/test/elements/quickbooks/purchase-orders.js
+++ b/src/test/elements/quickbooks/purchase-orders.js
@@ -10,11 +10,12 @@ suite.forElement('finance', 'purchase-orders', { payload: payload }, (test) => {
   test.withOptions({ qs: { page: 1, pageSize: 5 } }).should.return200OnGet();
   test.withOptions({ qs: { where: 'totalAmt = \'1\'', page: 1, pageSize: 1 } }).should.return200OnGet();
   test.withName(`should support searching ${test.api} by Id`)
-    .withOptions({ qs: { where: `id ='1234'` } })
+    .withOptions({ qs: { where: `id ='1234'`, returnCount: true } })
     .withValidation((r) => {
       expect(r).to.have.statusCode(200);
       const validValues = r.body.filter(obj => obj.id = '1234');
       expect(validValues.length).to.equal(r.body.length);
+      expect(r.response.headers['elements-total-count']).to.exist;
     }).should.return200OnGet();
 
 });

--- a/src/test/elements/quickbooks/purchases.js
+++ b/src/test/elements/quickbooks/purchases.js
@@ -3,11 +3,19 @@
 const suite = require('core/suite');
 const payload = require('./assets/purchases');
 const tools = require('core/tools');
+const chakram = require('chakram');
+const expect = chakram.expect;
 
 payload.docNumber = tools.random();
 
 suite.forElement('finance', 'purchases', { payload: payload }, (test) => {
   test.should.supportCruds();
-  test.withOptions({ qs: { page: 1, pageSize: 5 } }).should.return200OnGet();
+  test
+  	.withOptions({ qs: { page: 1, pageSize: 5, returnCount: true } })
+  	.withName(`Test for returnCount in headers`)
+  	.withValidation((r) => {
+      expect(r).to.have.statusCode(200);
+      expect(r.response.headers['elements-total-count']).to.exist;
+  }).should.return200OnGet();
   test.should.supportCeqlSearch('docNumber');
 });

--- a/src/test/elements/quickbooks/refund-receipts.js
+++ b/src/test/elements/quickbooks/refund-receipts.js
@@ -9,12 +9,13 @@ suite.forElement('finance', 'refund-receipts', { payload: payload}, (test) => {
   test.withOptions({skip:true}).should.supportCruds();
   test.should.supportSr();
   test.withOptions({ qs: { page: 1, pageSize: 5 } }).should.return200OnGet();
-  test.withName(`should support searching ${test.api} by Id`)
-    .withOptions({ qs: { where: `id ='1234'` } })
+  test.withName(`should support searching ${test.api} by Id and returnCount in response`)
+    .withOptions({ qs: { where: `id ='1234'`, returnCount: true } })
     .withValidation((r) => {
       expect(r).to.have.statusCode(200);
       const validValues = r.body.filter(obj => obj.id = '1234');
       expect(validValues.length).to.equal(r.body.length);
+      expect(r.response.headers['elements-total-count']).to.exist;
     }).should.return200OnGet();
 
 });

--- a/src/test/elements/quickbooks/sales-receipts.js
+++ b/src/test/elements/quickbooks/sales-receipts.js
@@ -6,14 +6,15 @@ const chakram = require('chakram');
 const expect = chakram.expect;
 
 suite.forElement('finance', 'sales-receipts', { payload: payload }, (test) => {
-  test.should.supportCruds();
+  //test.should.supportCruds();
   test.withOptions({ qs: { page: 1, pageSize: 5 } }).should.return200OnGet();
-  test.withName(`should support searching ${test.api} by Id`)
-    .withOptions({ qs: { where: `id ='1234'` } })
+  test.withName(`should support searching ${test.api} by Id and returnCount in response`)
+    .withOptions({ qs: { where: `id ='1234'`, returnCount: true } })
     .withValidation((r) => {
       expect(r).to.have.statusCode(200);
       const validValues = r.body.filter(obj => obj.id = '1234');
       expect(validValues.length).to.equal(r.body.length);
+      expect(r.response.headers['elements-total-count']).to.exist;
     }).should.return200OnGet();
 
 });

--- a/src/test/elements/quickbooks/tax-agencies.js
+++ b/src/test/elements/quickbooks/tax-agencies.js
@@ -12,11 +12,12 @@ suite.forElement('finance', 'tax-agencies', { payload: agencyPayload}, (test) =>
   test.should.supportSr();
   test.withOptions({skip:true}).should.return200OnPost();
   test.withName(`should support searching ${test.api} by Id`)
-    .withOptions({ qs: { where: `id ='1234'` } })
+    .withOptions({ qs: { where: `id ='1234'`, returnCount: true } })
     .withValidation((r) => {
       expect(r).to.have.statusCode(200);
       const validValues = r.body.filter(obj => obj.id = '1234');
       expect(validValues.length).to.equal(r.body.length);
+      expect(r.response.headers['elements-total-count']).to.exist;
     }).should.return200OnGet();
 
 });

--- a/src/test/elements/quickbooks/tax-codes.js
+++ b/src/test/elements/quickbooks/tax-codes.js
@@ -5,12 +5,13 @@ const expect = chakram.expect;
 suite.forElement('finance', 'tax-codes', null, (test) => {
   test.should.supportPagination();
   test.should.supportS();
-  test.withName(`should support searching ${test.api} by Id`)
-    .withOptions({ qs: { where: `id ='1234'` } })
+  test.withName(`should support searching ${test.api} by Id and returnCount in response`)
+    .withOptions({ qs: { where: `id ='1234'`, returnCount: true } })
     .withValidation((r) => {
       expect(r).to.have.statusCode(200);
       const validValues = r.body.filter(obj => obj.id = '1234');
       expect(validValues.length).to.equal(r.body.length);
+      expect(r.response.headers['elements-total-count']).to.exist;
     }).should.return200OnGet();
 
 });

--- a/src/test/elements/quickbooks/tax-rates.js
+++ b/src/test/elements/quickbooks/tax-rates.js
@@ -6,12 +6,13 @@ const expect = chakram.expect;
 
 suite.forElement('finance', 'tax-rates', null, (test) => {
   test.should.supportSr();
-  test.withName(`should support searching ${test.api} by Id`)
-    .withOptions({ qs: { where: `id ='1234'` } })
+  test.withName(`should support searching ${test.api} by Id and returnCount in response`)
+    .withOptions({ qs: { where: `id ='1234'`, returnCount: true } })
     .withValidation((r) => {
       expect(r).to.have.statusCode(200);
       const validValues = r.body.filter(obj => obj.id = '1234');
       expect(validValues.length).to.equal(r.body.length);
+      expect(r.response.headers['elements-total-count']).to.exist;
     }).should.return200OnGet();
 
 });

--- a/src/test/elements/quickbooks/time-activities.js
+++ b/src/test/elements/quickbooks/time-activities.js
@@ -8,12 +8,13 @@ const expect = chakram.expect;
 suite.forElement('finance', 'time-activities', { payload: payload }, (test) => {
   test.should.supportCruds();
   test.withOptions({ qs: { page: 1, pageSize: 5 } }).should.return200OnGet();
-  test.withName(`should support searching ${test.api} by Id`)
-    .withOptions({ qs: { where: `id ='1234'` } })
+  test.withName(`should support searching ${test.api} by Id and returnCount in response`)
+    .withOptions({ qs: { where: `id ='1234'`, returnCount: true } })
     .withValidation((r) => {
       expect(r).to.have.statusCode(200);
       const validValues = r.body.filter(obj => obj.id = '1234');
       expect(validValues.length).to.equal(r.body.length);
+      expect(r.response.headers['elements-total-count']).to.exist;
     }).should.return200OnGet();
 
 });

--- a/src/test/elements/quickbooks/vendor-credits.js
+++ b/src/test/elements/quickbooks/vendor-credits.js
@@ -9,12 +9,13 @@ suite.forElement('finance', 'vendor-credits', { payload: payload }, (test) => {
   test.should.supportCruds();
   test.withOptions({ qs: { page: 1, pageSize: 5 } }).should.return200OnGet();
   test.withOptions({ qs: { where: 'totalAmt = \'1\'', page: 1, pageSize: 1 } }).should.return200OnGet();
-  test.withName(`should support searching ${test.api} by Id`)
-    .withOptions({ qs: { where: `id ='1234'` } })
+  test.withName(`should support searching ${test.api} by Id and returnCount in response`)
+    .withOptions({ qs: { where: `id ='1234'`, returnCount: true } })
     .withValidation((r) => {
       expect(r).to.have.statusCode(200);
       const validValues = r.body.filter(obj => obj.id = '1234');
       expect(validValues.length).to.equal(r.body.length);
+      expect(r.response.headers['elements-total-count']).to.exist;
     }).should.return200OnGet();
 
 });

--- a/src/test/elements/quickbooks/vendor.js
+++ b/src/test/elements/quickbooks/vendor.js
@@ -19,11 +19,12 @@ suite.forElement('finance', 'vendor', { payload: payload }, (test) => {
   test.withOptions(options).should.supportCruds();
   test.withOptions({ qs: { page: 1, pageSize: 5 } }).should.return200OnGet();
   test.withName(`should support searching ${test.api} by Id`)
-    .withOptions({ qs: { where: `id ='1234'` } })
+    .withOptions({ qs: { where: `id ='1234'`, returnCount: true } })
+    .withName('Test for search on id and returnCount in response')
     .withValidation((r) => {
       expect(r).to.have.statusCode(200);
       const validValues = r.body.filter(obj => obj.id = '1234');
       expect(validValues.length).to.equal(r.body.length);
+      expect(r.response.headers['elements-total-count']).to.exist;
     }).should.return200OnGet();
-
 });


### PR DESCRIPTION
## Non-Customer Highlights
* Added test for query parameter `returnCount : true` for all supported APIs to check if `elements-return-count` header is present in response headers.
* Churros for customer-search is failing in staging as well.

## Screenshot
![qbo1](https://user-images.githubusercontent.com/22442264/36135721-e8761732-10b2-11e8-9014-c71993f4d0ad.PNG)
![qbo2](https://user-images.githubusercontent.com/22442264/36135722-e8c16f02-10b2-11e8-9a83-b53b6a678877.PNG)
![qbo3](https://user-images.githubusercontent.com/22442264/36135723-e90acde6-10b2-11e8-8051-46bbdcb16f68.PNG)
![qbo4](https://user-images.githubusercontent.com/22442264/36135724-e9543c42-10b2-11e8-88a2-1d2e9dd2051a.PNG)
![qbo5](https://user-images.githubusercontent.com/22442264/36135725-e99d84ce-10b2-11e8-8ac2-dc30ab8f48c7.PNG)

## Reference
* [SOBA](https://github.com/cloud-elements/soba/pull/7975)
* [churros-sauce](Link to Associated Churros-sauce PR, when applicable)
* [RALLY-US7092](https://rally1.rallydev.com/#/144349237612d/detail/userstory/191447718964)

## Closes
* [US7092](https://rally1.rallydev.com/#/144349237612d/detail/userstory/191447718964)
