### PR TITLE
Test Cases for Dropbox, Dropbox Business, Box, GoogleDrive enhanced with /ping API

### DIFF
--- a/src/test/elements/box/ping.js
+++ b/src/test/elements/box/ping.js
@@ -3,9 +3,13 @@
 const suite = require('core/suite');
 const expect = require('chakram').expect;
 
-suite.forElement('documents', 'ping', null, (test) => {
+suite.forElement('documents', 'ping', (test) => {
   test.withApi(test.api)
     .withName(`should allow GET /ping for system health`)
-    .withValidation(r => expect(r.body.endpoint).to.equal('box'))
+    .withValidation(r => {
+      expect(r).to.have.statusCode(200);
+      expect(r.body.endpoint).to.equal('box');
+      expect(r.body.valid).to.equal(true);
+    })
     .should.return200OnGet();
 });

--- a/src/test/elements/box/ping.js
+++ b/src/test/elements/box/ping.js
@@ -6,6 +6,6 @@ const expect = require('chakram').expect;
 suite.forElement('documents', 'ping', null, (test) => {
   test.withApi(test.api)
     .withName(`should allow GET /ping for system health`)
-    .withValidation(r => expect(r.body.endpoint).to.equal('dropbox'))
+    .withValidation(r => expect(r.body.endpoint).to.equal('box'))
     .should.return200OnGet();
 });

--- a/src/test/elements/dropbox/ping.js
+++ b/src/test/elements/dropbox/ping.js
@@ -3,9 +3,13 @@
 const suite = require('core/suite');
 const expect = require('chakram').expect;
 
-suite.forElement('documents', 'ping', null, (test) => {
+suite.forElement('documents', 'ping', (test) => {
   test.withApi(test.api)
     .withName(`should allow GET /ping for system health`)
-    .withValidation(r => expect(r.body.endpoint).to.equal('dropbox'))
+    .withValidation(r => {
+      expect(r).to.have.statusCode(200);
+      expect(r.body.endpoint).to.equal('dropbox');
+      expect(r.body.valid).to.equal(true);
+    })
     .should.return200OnGet();
 });

--- a/src/test/elements/dropboxbusiness/ping.js
+++ b/src/test/elements/dropboxbusiness/ping.js
@@ -3,9 +3,13 @@
 const suite = require('core/suite');
 const expect = require('chakram').expect;
 
-suite.forElement('documents', 'ping', null, (test) => {
+suite.forElement('documents', 'ping', (test) => {
   test.withApi(test.api)
     .withName(`should allow GET /ping for system health`)
-    .withValidation(r => expect(r.body.endpoint).to.equal('dropboxbusiness'))
+    .withValidation(r => {
+      expect(r).to.have.statusCode(200);
+      expect(r.body.endpoint).to.equal('dropboxbusiness');
+      expect(r.body.valid).to.equal(true);
+    })
     .should.return200OnGet();
 });

--- a/src/test/elements/dropboxbusiness/ping.js
+++ b/src/test/elements/dropboxbusiness/ping.js
@@ -6,6 +6,6 @@ const expect = require('chakram').expect;
 suite.forElement('documents', 'ping', null, (test) => {
   test.withApi(test.api)
     .withName(`should allow GET /ping for system health`)
-    .withValidation(r => expect(r.body.endpoint).to.equal('dropbox'))
+    .withValidation(r => expect(r.body.endpoint).to.equal('dropboxbusiness'))
     .should.return200OnGet();
 });

--- a/src/test/elements/googledrive/ping.js
+++ b/src/test/elements/googledrive/ping.js
@@ -3,9 +3,13 @@
 const suite = require('core/suite');
 const expect = require('chakram').expect;
 
-suite.forElement('documents', 'ping', null, (test) => {
+suite.forElement('documents', 'ping', (test) => {
   test.withApi(test.api)
     .withName(`should allow GET /ping for system health`)
-    .withValidation(r => expect(r.body.endpoint).to.equal('googledrive'))
+    .withValidation(r => {
+      expect(r).to.have.statusCode(200);
+      expect(r.body.endpoint).to.equal('googledrive');
+      expect(r.body.valid).to.equal(true);
+    })
     .should.return200OnGet();
 });

--- a/src/test/elements/googledrive/ping.js
+++ b/src/test/elements/googledrive/ping.js
@@ -6,6 +6,6 @@ const expect = require('chakram').expect;
 suite.forElement('documents', 'ping', null, (test) => {
   test.withApi(test.api)
     .withName(`should allow GET /ping for system health`)
-    .withValidation(r => expect(r.body.endpoint).to.equal('dropbox'))
+    .withValidation(r => expect(r.body.endpoint).to.equal('googledrive'))
     .should.return200OnGet();
 });


### PR DESCRIPTION
## Highlights
* `/Ping` API enhanced for GoogleDrive, Dropbox, Dropbox Business and Box 

## Non-customer Highlights
* `/ping`  tells you, vendorConnection is Success or not.

## Checklist
* [x] applicable churros tests are still passing
* [ ] includes a dbdeploy script that is backward-incompatible with one previous Soba minor version

## Screen shot
<img width="764" alt="screen shot 2018-02-14 at 12 51 50 am" src="https://user-images.githubusercontent.com/26943831/36191826-9ef0f5ec-1124-11e8-8ad7-b178ea34178e.png">
<img width="813" alt="screen shot 2018-02-14 at 12 54 54 am" src="https://user-images.githubusercontent.com/26943831/36191827-a0e0e952-1124-11e8-8709-7bf452b52904.png">
<img width="915" alt="screen shot 2018-02-14 at 1 15 10 am" src="https://user-images.githubusercontent.com/26943831/36191832-a2b2c598-1124-11e8-936a-27a3be3740b5.png">


## Related PRs
[Soba](https://github.com/cloud-elements/soba/pull/8057)

## Closes
[Rally](https://rally1.rallydev.com/#/144349237612d/detail/userstory/195164477496)
[Rally](https://rally1.rallydev.com/#/144349237612d/detail/userstory/197540739048)
[Rally](https://rally1.rallydev.com/#/144349237612d/detail/userstory/197540737828)
[Rally](https://rally1.rallydev.com/#/144349237612d/detail/userstory/197540737160)