### PR TITLE
Updated folders metadata test cases to update description

### DIFF
--- a/src/test/elements/box/index.js
+++ b/src/test/elements/box/index.js
@@ -46,7 +46,11 @@ documents.override('folders', () => {
 
     it('should allow RU /folders/metadata and RU /folders/:id/metadata', () => {
       let updatedFolder,
-        folderTemp = { path: `/a-${folder.name}` };
+        folderTemp = {
+          path: `/a-${folder.name}`,
+          description: "churros description"
+        };
+        folder.description = "churros update by id";
       return cloud.withOptions({ qs: { path: folder.path } }).get('/hubs/documents/folders/metadata')
         .then(r => cloud.withOptions({ qs: { path: folder.path } }).patch('/hubs/documents/folders/metadata', folderTemp))
         .then(r => updatedFolder = r.body)


### PR DESCRIPTION
## Non-Customer Highlights
* Updated folders metadata test cases to test the newly supported update of description field

## Screenshot
* Churros report: [box_churros.txt](https://github.com/cloud-elements/churros/files/1727435/box_churros.txt)

![image](https://user-images.githubusercontent.com/20282215/36254434-13831096-1271-11e8-97f8-0d0e2bb8dccf.png)

## Reference
* [SOBA](https://github.com/cloud-elements/soba/pull/8091)
* [RALLY-#DE869](https://rally1.rallydev.com/#/144349237612d/detail/defect/196709008204)

## Closes
* [#DE869](https://rally1.rallydev.com/#/144349237612d/detail/defect/196709008204)
