### PR TITLE
Enhanced Testcases for sqlserver, mysql and postgresql

### DIFF
--- a/src/test/elements/mysql/ping.js
+++ b/src/test/elements/mysql/ping.js
@@ -8,7 +8,7 @@ suite.forElement('db', 'ping', null, (test) => {
     .withName(`should allow GET /ping for system health`)
     .withValidation(r => {
       expect(r).to.have.statusCode(200);
-      expect(r.body.endpoint).to.equal('postgresql');
+      expect(r.body.endpoint).to.equal('mysql');
       expect(r.body.valid).to.equal(true);
     })
     .should.return200OnGet();

--- a/src/test/elements/sqlserver/ping.js
+++ b/src/test/elements/sqlserver/ping.js
@@ -8,7 +8,7 @@ suite.forElement('db', 'ping', null, (test) => {
     .withName(`should allow GET /ping for system health`)
     .withValidation(r => {
       expect(r).to.have.statusCode(200);
-      expect(r.body.endpoint).to.equal('postgresql');
+      expect(r.body.endpoint).to.equal('sqlserver');
       expect(r.body.valid).to.equal(true);
     })
     .should.return200OnGet();


### PR DESCRIPTION
## Highlights
Enhanced `sqlserver`, `mysql`,  and `pstgresql` with `/ping API`

## Non-customer Highlights
* Added Test cases for /PING API for `sqlserver`, `mysql`,  and `pstgresql`.


## Checklist
* [x] applicable churros tests are still passing
* [ ] includes a dbdeploy script that is backward-incompatible with one previous Soba minor version

## Screen Shot
![screen shot 2018-02-16 at 2 47 11 pm](https://user-images.githubusercontent.com/26943831/36329173-a411b540-132a-11e8-93a5-22bb3fec940c.png)
![screen shot 2018-02-16 at 2 43 35 pm](https://user-images.githubusercontent.com/26943831/36329175-a5586bba-132a-11e8-8958-e0a9a48b22ec.png)


## Related PRs
[Soiba](https://github.com/cloud-elements/soba/pull/8099)

## Closes
[Postgres_Rally](https://rally1.rallydev.com/#/144349237612d/detail/userstory/197540741012)
[sql_Rally](https://rally1.rallydev.com/#/144349237612d/detail/userstory/197540740428)
[mysql_Rally](https://rally1.rallydev.com/#/144349237612d/detail/userstory/197540740752)
