### PR TITLE
TwilioV2: Added Testcases for accounts and addresses api

### DIFF
--- a/src/test/elements/twiliov2/accounts.js
+++ b/src/test/elements/twiliov2/accounts.js
@@ -1,0 +1,23 @@
+'use strict';
+
+const suite = require('core/suite');
+const cloud = require('core/cloud');
+const payload = require('./assets/addresses');
+var chakram = require('chakram'),
+    expect = chakram.expect;
+
+suite.forElement('messaging', 'accounts', {payload: payload}, (test) => {
+  test.should.return200OnGet();
+  test.should.supportPagination();
+
+  it('should allow RUS', () => {
+    let AccountSID;
+	let query = { where: "FriendlyName='Jack' AND Status='suspended'"};
+    return cloud.get('/hubs/messaging/accounts')
+    .then(r => AccountSID = r.body[0].sid)
+    .then(r => cloud.get('/hubs/messaging/accounts/' + AccountSID))
+	.then(r => cloud.put('/hubs/messaging/accounts/' + AccountSID, payload))
+    .then(r => cloud.withOptions({ qs: query }).get('/hubs/messaging/accounts'))
+	.then(r => expect(r).to.have.statusCode(200));
+	});
+});

--- a/src/test/elements/twiliov2/accounts.js
+++ b/src/test/elements/twiliov2/accounts.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const suite = require('core/suite');
-const cloud = require('core/cloud');
 const payload = require('./assets/addresses');
 var chakram = require('chakram'),
     expect = chakram.expect;

--- a/src/test/elements/twiliov2/accounts.js
+++ b/src/test/elements/twiliov2/accounts.js
@@ -7,17 +7,14 @@ var chakram = require('chakram'),
     expect = chakram.expect;
 
 suite.forElement('messaging', 'accounts', {payload: payload}, (test) => {
-  test.should.return200OnGet();
-  test.should.supportPagination();
-
-  it('should allow RUS', () => {
-    let AccountSID;
-	let query = { where: "FriendlyName='Jack' AND Status='suspended'"};
-    return cloud.get('/hubs/messaging/accounts')
-    .then(r => AccountSID = r.body[0].sid)
-    .then(r => cloud.get('/hubs/messaging/accounts/' + AccountSID))
-	.then(r => cloud.put('/hubs/messaging/accounts/' + AccountSID, payload))
-    .then(r => cloud.withOptions({ qs: query }).get('/hubs/messaging/accounts'))
-	.then(r => expect(r).to.have.statusCode(200));
-	});
+  test.should.supportSr();
+  test
+     .withOptions({ qs: { where: `FriendlyName = 'Jack' AND Status='suspended'` } })
+     .withName('should support Ceql FriendlyName search')
+     .withValidation(r => {
+       expect(r).to.statusCode(200);
+       const validValues = r.body.filter(obj => obj.FriendlyName = 'Jack');
+       expect(validValues.length).to.equal(r.body.length);
+     })
+     .should.return200OnGet();
 });

--- a/src/test/elements/twiliov2/accounts.js
+++ b/src/test/elements/twiliov2/accounts.js
@@ -1,18 +1,17 @@
 'use strict';
 
 const suite = require('core/suite');
-const payload = require('./assets/addresses');
-var chakram = require('chakram'),
-    expect = chakram.expect;
+const expect = require('chakram').expect;
 
-suite.forElement('messaging', 'accounts', {payload: payload}, (test) => {
+suite.forElement('messaging', 'accounts', (test) => {
   test.should.supportSr();
+  test.should.supportPagination();
   test
      .withOptions({ qs: { where: `FriendlyName = 'Jack' AND Status='suspended'` } })
      .withName('should support Ceql FriendlyName search')
      .withValidation(r => {
        expect(r).to.statusCode(200);
-       const validValues = r.body.filter(obj => obj.FriendlyName = 'Jack');
+       const validValues = r.body.filter(obj => obj.friendly_name = 'Jack' && obj.status === 'suspended');
        expect(validValues.length).to.equal(r.body.length);
      })
      .should.return200OnGet();

--- a/src/test/elements/twiliov2/addresses.js
+++ b/src/test/elements/twiliov2/addresses.js
@@ -1,0 +1,28 @@
+'use strict';
+
+const suite = require('core/suite');
+const cloud = require('core/cloud');
+const payload = require('./assets/addresses');
+var chakram = require('chakram'),
+    expect = chakram.expect;
+
+suite.forElement('messaging', 'addresses', {payload: payload}, (test) => {
+  test.should.return200OnGet();
+  test.should.supportPagination();
+
+  it('should allow CRUDS', () => {
+  let AddressSID;
+	let query1 = { where: "FriendlyName='Jack'"};
+    let query2 = { page: 1, pageSize: 1 };
+    return cloud.post('/hubs/messaging/addresses', payload)
+    .then(r => AddressSID = r.body.sid)
+    .then(r => cloud.get('/hubs/messaging/addresses/' + AddressSID))
+	.then(r => cloud.patch('/hubs/messaging/addresses/' +AddressSID, payload))
+	.then(r => cloud.get('/hubs/messaging/addresses'))
+    .then(r => cloud.withOptions({ qs: query1 }).get('/hubs/messaging/addresses'))
+    .then(r => expect(r).to.have.statusCode(200))
+	.then(r => cloud.withOptions({query2}).get('/hubs/messaging/addresses/'+AddressSID+'/dependent-phone-numbers'))
+	.then(r => expect(r).to.have.statusCode(200))
+	.then(r => cloud.delete('/hubs/messaging/addresses/'+AddressSID));
+  });
+});

--- a/src/test/elements/twiliov2/addresses.js
+++ b/src/test/elements/twiliov2/addresses.js
@@ -7,12 +7,13 @@ const payload = require('./assets/addresses');
 
 suite.forElement('messaging', 'addresses', {payload: payload}, (test) => {
   test.should.supportCruds();
+  test.should.supportPagination();
   test
      .withOptions({ qs: { where: `FriendlyName = 'Jack' ` } })
      .withName('should support Ceql FriendlyName search')
      .withValidation(r => {
        expect(r).to.statusCode(200);
-       const validValues = r.body.filter(obj => obj.FriendlyName = 'Jack');
+       const validValues = r.body.filter(obj => obj.friendly_name = 'Jack');
        expect(validValues.length).to.equal(r.body.length);
      })
      .should.return200OnGet();

--- a/src/test/elements/twiliov2/addresses.js
+++ b/src/test/elements/twiliov2/addresses.js
@@ -1,28 +1,19 @@
 'use strict';
 
 const suite = require('core/suite');
-const cloud = require('core/cloud');
+const expect = require('chakram').expect;
 const payload = require('./assets/addresses');
-var chakram = require('chakram'),
-    expect = chakram.expect;
+
 
 suite.forElement('messaging', 'addresses', {payload: payload}, (test) => {
-  test.should.return200OnGet();
-  test.should.supportPagination();
-
-  it('should allow CRUDS', () => {
-  let AddressSID;
-	let query1 = { where: "FriendlyName='Jack'"};
-    let query2 = { page: 1, pageSize: 1 };
-    return cloud.post('/hubs/messaging/addresses', payload)
-    .then(r => AddressSID = r.body.sid)
-    .then(r => cloud.get('/hubs/messaging/addresses/' + AddressSID))
-	.then(r => cloud.patch('/hubs/messaging/addresses/' +AddressSID, payload))
-	.then(r => cloud.get('/hubs/messaging/addresses'))
-    .then(r => cloud.withOptions({ qs: query1 }).get('/hubs/messaging/addresses'))
-    .then(r => expect(r).to.have.statusCode(200))
-	.then(r => cloud.withOptions({query2}).get('/hubs/messaging/addresses/'+AddressSID+'/dependent-phone-numbers'))
-	.then(r => expect(r).to.have.statusCode(200))
-	.then(r => cloud.delete('/hubs/messaging/addresses/'+AddressSID));
-  });
+  test.should.supportCruds();
+  test
+     .withOptions({ qs: { where: `FriendlyName = 'Jack' ` } })
+     .withName('should support Ceql FriendlyName search')
+     .withValidation(r => {
+       expect(r).to.statusCode(200);
+       const validValues = r.body.filter(obj => obj.FriendlyName = 'Jack');
+       expect(validValues.length).to.equal(r.body.length);
+     })
+     .should.return200OnGet();
 });

--- a/src/test/elements/twiliov2/assets/accounts.json
+++ b/src/test/elements/twiliov2/assets/accounts.json
@@ -1,0 +1,4 @@
+{
+  "FriendlyName": "string",
+  "Status": "suspended"
+}

--- a/src/test/elements/twiliov2/assets/addresses.json
+++ b/src/test/elements/twiliov2/assets/addresses.json
@@ -1,0 +1,10 @@
+{
+  "AutoCorrectAddress": true,
+  "City": "Mumbai",
+  "CustomerName": "Mr. Jack",
+  "FriendlyName": "Jack",
+  "IsoCountry": "IN",
+  "PostalCode": "400021",
+  "Region": "Mumbai",
+  "Street": "New cross"
+}

--- a/src/test/elements/twiliov2/assets/transformations.json
+++ b/src/test/elements/twiliov2/assets/transformations.json
@@ -7,5 +7,23 @@
         "vendorPath": "sid"
       }
     ]
+  },
+  "addresses": {
+    "vendorName": "addresses",
+    "fields": [
+      {
+        "path": "id",
+        "vendorPath": "sid"
+      }
+    ]
+  },
+  "accounts": {
+    "vendorName": "accounts",
+    "fields": [
+      {
+        "path": "id",
+        "vendorPath": "sid"
+      }
+    ]
   }
 }


### PR DESCRIPTION
## Highlights
* Added testcases for `/addresses` resource.
* Added testcases for `/accounts` resource.

## Screenshot

![image](https://user-images.githubusercontent.com/34128818/37070191-5cf61f0a-21dc-11e8-95b6-ddfec0374ad2.png)

## Reference
* [SOBA](https://github.com/cloud-elements/soba/pull/8131)
* [Rally](https://rally1.rallydev.com/#/144349237612d/detail/userstory/198554042924)
* [Rally](https://rally1.rallydev.com/#/144349237612d/detail/userstory/198554042592)

## Closes
* [US8506](https://rally1.rallydev.com/#/144349237612d/detail/userstory/198554042924)
* [US8505](https://rally1.rallydev.com/#/144349237612d/detail/userstory/198554042592)
