### PR TITLE
Added checks for content types in SFDC Documents and Libraries

### DIFF
--- a/src/test/elements/sfdcdocuments/files.js
+++ b/src/test/elements/sfdcdocuments/files.js
@@ -3,6 +3,7 @@
 const suite = require('core/suite');
 const cloud = require('core/cloud');
 const tools = require('core/tools');
+const expect = require('chakram').expect;
 const upload = require('./assets/metadata');
 
 suite.forElement('documents', 'files', null, (test) => {
@@ -13,9 +14,10 @@ suite.forElement('documents', 'files', null, (test) => {
   it('should allow CRD for hubs/documents/files and UR for hubs/documents/files/metadata by path', () => {
     let UploadFile = __dirname + '/assets/Penguins.jpg',
       srcPath;
-    return cloud.withOptions({ qs: { path: `/${tools.random()}` } }).postFile(test.api, UploadFile)
+    return cloud.withOptions({ qs: { path: `/${tools.random()}.jpg` } }).postFile(test.api, UploadFile)
       .then(r => srcPath = r.body.path)
       .then(r => cloud.withOptions({ qs: { path: `${srcPath}` } }).get(test.api))
+      .then(r => expect(r.response.headers['content-type']).to.contain('image/jpeg'))
       .then(r => cloud.withOptions({ qs: { path: `${srcPath}` } }).get(`${test.api}/metadata`))
       .then(r => cloud.withOptions({ qs: { path: `${srcPath}` } }).patch(`${test.api}/metadata`, upload))
       .then(r => cloud.withOptions({ qs: { path: `${srcPath}` } }).delete(test.api));
@@ -24,9 +26,10 @@ suite.forElement('documents', 'files', null, (test) => {
   it('should allow CRD for hubs/documents/files and UR for hubs/documents/files/metadata by id', () => {
     let UploadFile = __dirname + '/assets/Penguins.jpg',
       fileId;
-    return cloud.withOptions({ qs: { path: `/${tools.random()}` } }).postFile(test.api, UploadFile)
+    return cloud.withOptions({ qs: { path: `/${tools.random()}.jpg` } }).postFile(test.api, UploadFile)
       .then(r => fileId = r.body.id)
       .then(r => cloud.get(`${test.api}/${fileId}`))
+      .then(r => expect(r.response.headers['content-type']).to.contain('image/jpeg'))
       .then(r => cloud.get(`${test.api}/${fileId}/metadata`))
       .then(r => cloud.patch(`${test.api}/${fileId}/metadata`, upload))
       .then(r => cloud.delete(`${test.api}/${fileId}`));

--- a/src/test/elements/sfdclibraries/files.js
+++ b/src/test/elements/sfdclibraries/files.js
@@ -19,7 +19,7 @@ suite.forElement('documents', 'files', (test) => {
     let fileId = -1;
     return cloud.withOptions({ qs: query }).postFile(test.api, path)
       .then(r => fileId = r.body.id)
-      .then(r => cloud.get(test.api + '/' + fileId, (r) => expect(r).to.have.statusCode(200)))
+      .then(r => cloud.get(`${test.api}/${fileId}`, (r) => expect(r).to.have.statusCode(200) && expect(r.response.headers['content-type']).to.equal('image/png')))
       .then(r => cloud.get(`${test.api}/${fileId}/links`))
       .then(r => cloud.get(`${test.api}/${fileId}/metadata`))
       .then(r => cloud.patch(`${test.api}/${fileId}/metadata`, pathUpdate()))
@@ -32,7 +32,7 @@ suite.forElement('documents', 'files', (test) => {
       .then(r => fileId = r.body.id)
       .then(r => cloud.withOptions({ qs: query }).get(`${test.api}/links`))
       .then(r => cloud.withOptions({ qs: query }).get(`${test.api}/metadata`))
-      .then(r => cloud.withOptions({ qs: query }).get(test.api, (r) => expect(r).to.have.statusCode(200)))
+      .then(r => cloud.withOptions({ qs: query }).get(test.api, (r) => expect(r).to.have.statusCode(200) && expect(r.response.headers['content-type']).to.equal('image/png')))
       .then(r => cloud.withOptions({ qs: query }).patch(`${test.api}/metadata`, pathUpdate()))
       .then(r => cloud.withOptions({ qs: { path: `/churros${pathUpdateString}` } }).delete(test.api));
   });


### PR DESCRIPTION
## Highlights
* ☝️ 

## Reference
* [SOBA #8141](https://github.com/cloud-elements/soba/pull/8141)
* [TA-8730](https://rally1.rallydev.com/#/144349237612d/detail/task/200484827380)

## Closes
* [TA-8730](https://rally1.rallydev.com/#/144349237612d/detail/task/200484827380)