### PR TITLE
Updated Testcases for the Google Drive fix -  null thumbnail field being returned for folder response items 

### DIFF
--- a/src/test/elements/googledrive/files.js
+++ b/src/test/elements/googledrive/files.js
@@ -262,7 +262,7 @@ suite.forElement('documents', 'files', { payload: payload }, (test) => {
           .then(r => {
             textFileBody = r.body;
           // Since we provided unknown extension, Google Drive not able to generate thumnail. It's time to rock
-            expect(r.body.properties.thumbnailLink).to.be.null;
+            expect(r.body.properties.thumbnailLink).to.be.undefined;
           })
           .then(() => cloud.withOptions({ qs: { path: `/testType2-${tools.randomStr('abcdefghijklmnopqrstuvwxyz1234567890', 10)}.gliffy` } }).postFileMultiple(test.api, files))
           .then(r => {

--- a/src/test/elements/googledrive/folders.js
+++ b/src/test/elements/googledrive/folders.js
@@ -36,7 +36,8 @@ suite.forElement('documents', 'folders', { payload: payload }, (test) => {
       .then(r => {
             srcPath = r.body.path;
             expect(r.body.properties.thumbnailLink).to.be.undefined;
-            expect(r.body.properties.mimeType).to.be.undefined;})
+            expect(r.body.properties.mimeType).to.be.undefined;
+          })
       .then(r => cloud.withOptions({ qs: { path: `${srcPath}` } }).get(`${test.api}/contents`))
       .then(r => cloud.withOptions({ qs: { path: `${srcPath}`, page: 1, pageSize: 1 } }).get(`${test.api}/contents`))
       .then(r => cloud.withOptions({ qs: { path: `${srcPath}` } }).post(`${test.api}/copy`, updatePayload))

--- a/src/test/elements/googledrive/folders.js
+++ b/src/test/elements/googledrive/folders.js
@@ -33,7 +33,10 @@ suite.forElement('documents', 'folders', { payload: payload }, (test) => {
   it('should allow CRD for hubs/documents/folders and RU for hubs/documents/folders/metadata by path', () => {
     let srcPath, destPath;
     return cloud.post(`${test.api}`, payload)
-      .then(r => srcPath = r.body.path)
+      .then(r => {
+            srcPath = r.body.path;
+            expect(r.body.properties.thumbnailLink).to.be.undefined;
+            expect(r.body.properties.mimeType).to.be.undefined;})
       .then(r => cloud.withOptions({ qs: { path: `${srcPath}` } }).get(`${test.api}/contents`))
       .then(r => cloud.withOptions({ qs: { path: `${srcPath}`, page: 1, pageSize: 1 } }).get(`${test.api}/contents`))
       .then(r => cloud.withOptions({ qs: { path: `${srcPath}` } }).post(`${test.api}/copy`, updatePayload))


### PR DESCRIPTION
## Highlights
   >GET /folders/contents 
   >GET /folders/:id/contents
   >GET /search

## Non-customer Highlights
* Updated undefined check for thumbnail and mimeType for folders items

## Checklist
* [x] applicable churros tests are still passing
* [ ] includes a dbdeploy script that is backward-incompatible with one previous Soba minor version

#Screen shot
<img width="853" alt="screen shot 2018-02-23 at 5 17 47 pm" src="https://user-images.githubusercontent.com/26943831/36621894-029c6f66-18c0-11e8-9174-346f6cee1037.png">


## Related PRs
[soba](https://github.com/cloud-elements/soba/pull/8143)

## Closes
[Rally](https://rally1.rallydev.com/#/144349237612d/detail/defect/198774886136)