### PR TITLE
Test Cases for Implemented Box file and folder tags

### DIFF
--- a/src/test/elements/box/assets/folderTags.json
+++ b/src/test/elements/box/assets/folderTags.json
@@ -1,0 +1,6 @@
+{
+  "directory": true,
+  "name": "folderTagsTest",
+  "path": "/folderTagsTest",
+  "tags": ["folderTags"]
+}

--- a/src/test/elements/box/files.js
+++ b/src/test/elements/box/files.js
@@ -21,12 +21,14 @@ const lock = {
 };
 
 suite.forElement('documents', 'files', (test) => {
-  let id, path;
+  let id, path, fileTagPayload, fileUpdateTagPayload;
   before(done => {
     return cloud.withOptions({ qs: { path: `/brady-${faker.address.zipCode()}.jpg` } }).postFile(test.api, `${__dirname}/../assets/brady.jpg`)
       .then(r => {
         id = r.body.id;
         path = r.body.path;
+        fileTagPayload = r.body;
+        fileTagPayload.tags = ["fileTag1", "fileTag2"];
       })
       .then(r => done());
   });
@@ -40,10 +42,13 @@ suite.forElement('documents', 'files', (test) => {
     let folderId, fileId;
     return cloud.post('/folders', folderPayload)
       .then(r => folderId = r.body.id)
-      .then(r => cloud.withOptions({ qs: {
+      .then(r => cloud.withOptions({
+        qs: {
           path: `/churros/brady-${faker.address.zipCode()}.jpg`,
           folderId,
-          calculateFolderPath: false} }).postFile(test.api, `${__dirname}/../assets/brady.jpg`))
+          calculateFolderPath: false
+        }
+      }).postFile(test.api, `${__dirname}/../assets/brady.jpg`))
       .then(r => fileId = r.body.id)
       .then(() => cloud.delete(`${test.api}/${fileId}`))
       .then(() => cloud.delete(`/folders/${folderId}`));
@@ -182,10 +187,38 @@ suite.forElement('documents', 'files', (test) => {
     let commentId;
     return cloud.post(`${test.api}/${id}/comments`, commentPayload1)
       .then(r => commentId = r.body.id)
-      .then(r => cloud.withOptions({ qs: { raw: true }}).get(`${test.api}/${id}/comments`))
+      .then(r => cloud.withOptions({ qs: { raw: true } }).get(`${test.api}/${id}/comments`))
       .then(r => expect(r.body.filter(obj => obj.raw)).to.not.be.empty)
       .then(r => cloud.get(`${test.api}/${id}/comments`))
       .then(r => expect(r.body.filter(obj => obj.raw)).to.be.empty)
       .then(r => cloud.delete(`${test.api}/${id}/comments/${commentId}`));
+  });
+
+  it('should allow UR tags /files/metadata', () => {
+    return cloud.withOptions({ qs: { path: fileTagPayload.path } }).patch(`${test.api}/metadata`, fileTagPayload)
+      .then(r => {
+        expect(r).to.have.statusCode(200);
+        expect(r.body.tags[0]).to.equal(`${fileTagPayload.tags[0]}`);
+        fileUpdateTagPayload = r.body;
+        fileUpdateTagPayload.tags = ["fileTag1Updated", "fileTag2Updated"];
+      })
+      .then(() => cloud.withOptions({ qs: { path: fileTagPayload.path } }).get(`${test.api}/metadata`))
+      .then(r => {
+        expect(r).to.have.statusCode(200);
+        expect(r.body.tags[0]).to.equal(`${fileTagPayload.tags[0]}`);
+      });
+  });
+
+  it('should allow UR tags /folders/:id/metadata', () => {
+    return cloud.patch(`${test.api}/${fileUpdateTagPayload.id}/metadata`, fileUpdateTagPayload)
+      .then(r => {
+        expect(r).to.have.statusCode(200);
+        expect(r.body.tags[0]).to.equal(`${fileUpdateTagPayload.tags[0]}`);
+      })
+      .then(() => cloud.get(`${test.api}/${fileUpdateTagPayload.id}/metadata`))
+      .then(r => {
+        expect(r).to.have.statusCode(200);
+        expect(r.body.tags[0]).to.equal(`${fileUpdateTagPayload.tags[0]}`);
+      });
   });
 });

--- a/src/test/elements/box/files.js
+++ b/src/test/elements/box/files.js
@@ -194,17 +194,15 @@ suite.forElement('documents', 'files', (test) => {
       .then(r => cloud.delete(`${test.api}/${id}/comments/${commentId}`));
   });
 
-  it('should allow UR tags /files/metadata', () => {
+  it('should allow UR tags /files/metadata by path', () => {
     return cloud.withOptions({ qs: { path: fileTagPayload.path } }).patch(`${test.api}/metadata`, fileTagPayload)
       .then(r => {
-        expect(r).to.have.statusCode(200);
         expect(r.body.tags[0]).to.equal(`${fileTagPayload.tags[0]}`);
         fileUpdateTagPayload = r.body;
         fileUpdateTagPayload.tags = ["fileTag1Updated", "fileTag2Updated"];
       })
       .then(() => cloud.withOptions({ qs: { path: fileTagPayload.path } }).get(`${test.api}/metadata`))
       .then(r => {
-        expect(r).to.have.statusCode(200);
         expect(r.body.tags[0]).to.equal(`${fileTagPayload.tags[0]}`);
       });
   });
@@ -212,12 +210,10 @@ suite.forElement('documents', 'files', (test) => {
   it('should allow UR tags /folders/:id/metadata', () => {
     return cloud.patch(`${test.api}/${fileUpdateTagPayload.id}/metadata`, fileUpdateTagPayload)
       .then(r => {
-        expect(r).to.have.statusCode(200);
         expect(r.body.tags[0]).to.equal(`${fileUpdateTagPayload.tags[0]}`);
       })
       .then(() => cloud.get(`${test.api}/${fileUpdateTagPayload.id}/metadata`))
       .then(r => {
-        expect(r).to.have.statusCode(200);
         expect(r.body.tags[0]).to.equal(`${fileUpdateTagPayload.tags[0]}`);
       });
   });

--- a/src/test/elements/box/folders.js
+++ b/src/test/elements/box/folders.js
@@ -13,6 +13,16 @@ folderPayload.name += randomInt;
 
 suite.forElement('documents', 'folders', {}, (test) => {
   let folderTagPayload, folderUpdateTagPayload;
+
+  before(() => cloud.post(test.api, folderTags)
+    .then(r => {
+      expect(r).to.have.statusCode(200);
+      folderTagPayload = r.body;
+      folderTagPayload.tags = ["folderTag1", "folderTag2"];
+    }));
+
+  after(() => cloud.delete(`${test.api}/${folderTagPayload.id}`));
+
   it(`should allow CD for ${test.api} and GET collaborations`, () => {
     let folderId;
     return cloud.post(test.api, folderPayload)
@@ -36,39 +46,26 @@ suite.forElement('documents', 'folders', {}, (test) => {
       .then(r => cloud.withOptions({ qs: { path: folder1.path } }).delete('/hubs/documents/folders'));
   });
 
-  before(() => cloud.post(test.api, folderTags)
-    .then(r => {
-      expect(r).to.have.statusCode(200);
-      folderTagPayload = r.body;
-      folderTagPayload.tags = ["folderTag1", "folderTag2"];
-    }));
-
-  after(() => cloud.delete(`${test.api}/${folderTagPayload.id}`));
-
-  it('should allow UR tags /folders/metadata', () => {
+  it('should allow UR tags /folders/metadata by path', () => {
     return cloud.withOptions({ qs: { path: folderTagPayload.path } }).patch(`${test.api}/metadata`, folderTagPayload)
       .then(r => {
-        expect(r).to.have.statusCode(200);
         expect(r.body.tags[0]).to.equal(`${folderTagPayload.tags[0]}`);
         folderUpdateTagPayload = r.body;
         folderUpdateTagPayload.tags = ["folderTag1Updated", "folderTag2Updated"];
       })
       .then(() => cloud.withOptions({ qs: { path: folderTagPayload.path } }).get(`${test.api}/metadata`))
       .then(r => {
-        expect(r).to.have.statusCode(200);
         expect(r.body.tags[0]).to.equal(`${folderTagPayload.tags[0]}`);
       });
   });
 
-  it('should allow UR tags PATCH /folders/:id/metadata', () => {
+  it('should allow UR tags /folders/:id/metadata', () => {
     return cloud.patch(`${test.api}/${folderUpdateTagPayload.id}/metadata`, folderUpdateTagPayload)
       .then(r => {
-        expect(r).to.have.statusCode(200);
         expect(r.body.tags[0]).to.equal(`${folderUpdateTagPayload.tags[0]}`);
       })
       .then(() => cloud.get(`${test.api}/${folderUpdateTagPayload.id}/metadata`))
       .then(r => {
-        expect(r).to.have.statusCode(200);
         expect(r.body.tags[0]).to.equal(`${folderUpdateTagPayload.tags[0]}`);
       });
   });

--- a/src/test/elements/box/folders.js
+++ b/src/test/elements/box/folders.js
@@ -5,12 +5,14 @@ const tools = require('core/tools');
 const expect = require('chakram').expect;
 const suite = require('core/suite');
 const folderPayload = require('./assets/folders');
+const folderTags = require('./assets/folderTags');
 
 const randomInt = tools.randomInt();
 folderPayload.path += randomInt;
 folderPayload.name += randomInt;
 
 suite.forElement('documents', 'folders', {}, (test) => {
+  let folderTagPayload, folderUpdateTagPayload;
   it(`should allow CD for ${test.api} and GET collaborations`, () => {
     let folderId;
     return cloud.post(test.api, folderPayload)
@@ -20,10 +22,55 @@ suite.forElement('documents', 'folders', {}, (test) => {
   });
 
   it('should include bookmarks in GET /folders/contents results', () => {
-    return cloud.withOptions({qs: { path: "/TestFolderDoNoDelete"}}).get(`${test.api}/contents?raw=true`)
-    .then(r => {
-      let bookmark = r.body.filter(item => item.name === 'SampleBookMark')[0];
-      expect(bookmark.raw.type).to.equal('web_link');
-    });
+    return cloud.withOptions({ qs: { path: "/TestFolderDoNoDelete" } }).get(`${test.api}/contents?raw=true`)
+      .then(r => {
+        let bookmark = r.body.filter(item => item.name === 'SampleBookMark')[0];
+        expect(bookmark.raw.type).to.equal('web_link');
+      });
   });
+
+  it('should allow CD /folders', () => {
+    let folder1;
+    return cloud.post('/hubs/documents/folders', folderPayload)
+      .then(r => folder1 = r.body)
+      .then(r => cloud.withOptions({ qs: { path: folder1.path } }).delete('/hubs/documents/folders'));
+  });
+
+  before(() => cloud.post(test.api, folderTags)
+    .then(r => {
+      expect(r).to.have.statusCode(200);
+      folderTagPayload = r.body;
+      folderTagPayload.tags = ["folderTag1", "folderTag2"];
+    }));
+
+  after(() => cloud.delete(`${test.api}/${folderTagPayload.id}`));
+
+  it('should allow UR tags /folders/metadata', () => {
+    return cloud.withOptions({ qs: { path: folderTagPayload.path } }).patch(`${test.api}/metadata`, folderTagPayload)
+      .then(r => {
+        expect(r).to.have.statusCode(200);
+        expect(r.body.tags[0]).to.equal(`${folderTagPayload.tags[0]}`);
+        folderUpdateTagPayload = r.body;
+        folderUpdateTagPayload.tags = ["folderTag1Updated", "folderTag2Updated"];
+      })
+      .then(() => cloud.withOptions({ qs: { path: folderTagPayload.path } }).get(`${test.api}/metadata`))
+      .then(r => {
+        expect(r).to.have.statusCode(200);
+        expect(r.body.tags[0]).to.equal(`${folderTagPayload.tags[0]}`);
+      });
+  });
+
+  it('should allow UR tags PATCH /folders/:id/metadata', () => {
+    return cloud.patch(`${test.api}/${folderUpdateTagPayload.id}/metadata`, folderUpdateTagPayload)
+      .then(r => {
+        expect(r).to.have.statusCode(200);
+        expect(r.body.tags[0]).to.equal(`${folderUpdateTagPayload.tags[0]}`);
+      })
+      .then(() => cloud.get(`${test.api}/${folderUpdateTagPayload.id}/metadata`))
+      .then(r => {
+        expect(r).to.have.statusCode(200);
+        expect(r.body.tags[0]).to.equal(`${folderUpdateTagPayload.tags[0]}`);
+      });
+  });
+
 });


### PR DESCRIPTION
## Highlights
* Enhanced Test cases for dropbox UR tags information for files and folders.
* Tags Info for 
    `GET folders/metadata`
    `PATCH folders/metadata`
    `GET folders/:id/metadata`
    `PATCH folders/:id/metadata`

## Checklist
* [x] applicable churros tests are still passing
* [ ] includes a dbdeploy script that is backward-incompatible with one previous Soba minor version

## Screenshot
<img width="940" alt="screen shot 2018-02-21 at 1 57 29 am" src="https://user-images.githubusercontent.com/26943831/36468880-c22e901a-16aa-11e8-922a-1d26f0942c29.png">

## Related PRs
[Soba](https://github.com/cloud-elements/soba/pull/8113)
[ClosedPR](https://github.com/cloud-elements/churros/pull/1420)

## Closes
[Rally](https://rally1.rallydev.com/#/144349237612d/detail/userstory/197579323248)