### PR TITLE
Dropbox tests fixes

### DIFF
--- a/src/test/elements/dropbox/folders.js
+++ b/src/test/elements/dropbox/folders.js
@@ -95,16 +95,6 @@ suite.forElement('documents', 'folders', (test) => {
       .then(r => expect(r.body.length).to.equal(r.body.filter(obj => obj.directory === true || obj.directory === false).length));
   });
 
-  it.skip('should allow GET /folders/contents with name', () => {
-    return cloud.withOptions({ qs: { path: `/`, where: "name='dontdelete.jpg'" } }).get(`${test.api}/contents`)
-      .then(r => expect(r.body[0].name).to.contain('dontdelete'));
-  });
-
-  it.skip('should allow GET /folders/contents with extension', () => {
-    return cloud.withOptions({ qs: { path: `/`, where: "extension='.csv'" } }).get(`${test.api}/contents`)
-      .then(r => expect(r.body[0].name).to.contain('.csv'));
-  });
-
   it('should return parentFolderId for GET /folders/content', ()=> {
     return cloud.withOptions({ qs: { path: `/` } }).get(`${test.api}/contents`)
         .then(r => expect(r.body.parentFolderId).to.not.equal(null));

--- a/src/test/elements/dropbox/ping.js
+++ b/src/test/elements/dropbox/ping.js
@@ -9,7 +9,6 @@ suite.forElement('documents', 'ping', (test) => {
     .withValidation(r => {
       expect(r).to.have.statusCode(200);
       expect(r.body.endpoint).to.equal('dropbox');
-      expect(r.body.valid).to.equal(true);
     })
     .should.return200OnGet();
 });


### PR DESCRIPTION
## Highlights
* Removed Dropbox `GET /folders/contents` `where` clause tests as where clause was never implemented for this endpoint and tests had been merged prematurely. 
* Adjusted `GET /ping` test to not validate a `status` field was returned since status code was used in place of populating a status field. When /ping fails a 4XX status code will be returned. 

## Screenshot
![image](https://user-images.githubusercontent.com/20074506/36650149-77628080-1a67-11e8-89ad-2f8e03319d6f.png)

## Reference
* [RALLY-#DE828](https://rally1.rallydev.com/#/144349237612d/detail/defect/194400963348/discussion)