### PR TITLE
Adding the right ID for customrecords API

### DIFF
--- a/src/test/elements/netsuiteerpv2/customrecords.js
+++ b/src/test/elements/netsuiteerpv2/customrecords.js
@@ -11,7 +11,7 @@ suite.forElement('erp', 'custom-record-types', (test) => {
       let customRecordTypeId = 478;
       let customRecordId;
       return cloud.post(`${test.api}/${customRecordTypeId}/custom-records`, customRecordsPayload)
-      .then(r => customRecordId = r.body.internalId)
+      .then(r => customRecordId = r.body.id)
       .then(r => cloud.get(`${test.api}/${customRecordTypeId}/custom-records`))
       .then(r => cloud.get(`${test.api}/${customRecordTypeId}/custom-records/${customRecordId}`))
       .then(r => cloud.patch(`${test.api}/${customRecordTypeId}/custom-records/${customRecordId}`,customRecordsPayload))


### PR DESCRIPTION
## Highlights
* Considering we have transformation, calling GET on internalId failing. It should be GET by 'id'.

## Screenshot
Please include a screenshot of the tests running successfully
![image](https://user-images.githubusercontent.com/20945381/36703162-f81a6c8e-1b1f-11e8-8ebe-512c38fae30c.png)


## Closes
* Closes #${DE737}
