### PR TITLE
Fixed G-Drive and added negative test

### DIFF
--- a/src/test/elements/googledrive/files.js
+++ b/src/test/elements/googledrive/files.js
@@ -248,6 +248,13 @@ suite.forElement('documents', 'files', { payload: payload }, (test) => {
       .then(r => cloud.delete(`${test.api}/${jpgFileBody.id}/comments/${commentId}`));
   });
 
+  test
+    .withApi('/files/comments')
+    .withName(`should throw 404 when a junk path has been provided for /files/comments`)
+    .withOptions({ qs: { path : '/whatever/junk/thing/is/possible.txt'}})
+    .withValidation(r => expect(r).to.have.statusCode(404))
+    .should.return200OnGet();
+
   it(`should allow POST /files/:id/thumbnails by providing folder id`, () => {
       const thumbnailFile = {
         "thumbnail": jpgFile

--- a/src/test/elements/googledrive/folders.js
+++ b/src/test/elements/googledrive/folders.js
@@ -89,26 +89,27 @@ suite.forElement('documents', 'folders', { payload: payload }, (test) => {
       .then(r => expect(r.body.length).to.equal(r.body.filter(obj => obj.properties.mimeType === 'text/plain').length));
   });
 
-
   test.withApi(`/folders/contents`)
     .withName(`should allow GET for /folders/contents with orderBy modifiedDate asc`)
     .withOptions({ qs: { path: `/`, pageSize: 5, page: 1, orderBy: `modifiedDate asc`, calculateFolderPath: false } })
     .withValidation(r => {
-      date1 = new Date(r.body[0].createdDate).getTime();
-      date2 = new Date(r.body[1].createdDate).getTime();
+      expect(r).to.have.statusCode(200);
+      date1 = new Date(r.body[0].modifiedDate).getTime();
+      date2 = new Date(r.body[1].modifiedDate).getTime();
       expect(date1 <= date2).to.be.true;
     })
     .should.return200OnGet();
 
-    test.withApi(`${test.api}/root/contents`)
-        .withName(`should allow GET for /folders/contents with orderBy createdDate desc`)
-        .withOptions({ qs: {  pageSize: 5, page: 1, orderBy: `createdDate desc`, calculateFolderPath: false } })
-        .withValidation(r => {
-          date1 = new Date(r.body[0].createdDate).getTime();
-          date2 = new Date(r.body[1].createdDate).getTime();
-          expect(date1 >= date2).to.be.true;
-        })
-        .should.return200OnGet();
+  test.withApi(`${test.api}/root/contents`)
+      .withName(`should allow GET for /folders/contents with orderBy createdDate desc`)
+      .withOptions({ qs: {  pageSize: 5, page: 1, orderBy: `createdDate desc`, calculateFolderPath: false } })
+      .withValidation(r => {
+        expect(r).to.have.statusCode(200);
+        date1 = new Date(r.body[0].createdDate).getTime();
+        date2 = new Date(r.body[1].createdDate).getTime();
+        expect(date1 >= date2).to.be.true;
+      })
+      .should.return200OnGet();
 
   test.withOptions({ qs: { path: '/' } }).withApi('/folders/contents').should.supportPagination('id');
 


### PR DESCRIPTION
## Highlights
* Fixed `should allow GET for /folders/contents with orderBy modifiedDate asc`
* Added test to validate 404 for a bad path in `/files/comments`

## Reference
* [SOBA](https://github.com/cloud-elements/soba/pull/8151)
* [churros-sauce](Link to Associated Churros-sauce PR, when applicable)
* [TA8966](https://rally1.rallydev.com/#/144349237612d/detail/task/201008560348)

## Closes
* [TA8966](https://rally1.rallydev.com/#/144349237612d/detail/task/201008560348)