### PR TITLE
Shopify : Fixed failing metafields API tests

### DIFF
--- a/src/test/elements/shopify/metafields.js
+++ b/src/test/elements/shopify/metafields.js
@@ -22,7 +22,7 @@ const order = () => ({
   }]
 });
 suite.forElement('ecommerce', 'metafields', { payload: payload, skip: false }, (test) => {
-  const objectName = 'orders';
+  const objectName = 'order';
   let orderId;
   before(() => cloud.post(`/hubs/ecommerce/orders`, order())
     .then(r => orderId = r.body.id)
@@ -37,16 +37,16 @@ suite.forElement('ecommerce', 'metafields', { payload: payload, skip: false }, (
   });
   it(`should allow GET for /hubs/ecommerce/{objectName}/{orderId}/metafields/{metafieldId}`, () => {
     let metafieldId;
-    return cloud.post(`/hubs/ecommerce/${objectName}/${orderId}/metafields`,payload())
+    return cloud.post(`/hubs/ecommerce/orders/${orderId}/metafields`,payload())
     .then(r => metafieldId = r.body.id)
     .then(r => cloud.get(`/hubs/ecommerce/${objectName}/${orderId}/metafields/${metafieldId}`))
     .then(r => cloud.delete(`/hubs/ecommerce/${objectName}/${orderId}/metafields/${metafieldId}`));
   });
   it(`should allow PATCH for /hubs/ecommerce/{objectName}/{orderId}/metafields/{metafieldId}`, () => {
     let metafieldId;
-    return cloud.post(`/hubs/ecommerce/${objectName}/${orderId}/metafields`,payload())
+    return cloud.post(`/hubs/ecommerce/orders/${orderId}/metafields`,payload())
     .then(r => metafieldId = r.body.id)
-    .then(r => cloud.patch(`/hubs/ecommerce/${objectName}/${orderId}/metafields/${metafieldId}`, updatePayload(metafieldId)))
+    .then(r => cloud.patch(`/hubs/ecommerce/orders/${orderId}/metafields/${metafieldId}`, updatePayload(metafieldId)))
     .then(r => cloud.delete(`/hubs/ecommerce/${objectName}/${orderId}/metafields/${metafieldId}`));
   });
   it(`should allow DELETE for /hubs/ecommerce/orders/{orderId}`, () => {


### PR DESCRIPTION
## Highlights
* Fixed churros tests for metafields APIs

## Screenshot
![img_07032018_154203_0](https://user-images.githubusercontent.com/22442264/37086894-b9a66af6-221e-11e8-9c8d-6f516348053a.png)
![img_07032018_154223_0](https://user-images.githubusercontent.com/22442264/37086895-b9ffb6ba-221e-11e8-822f-6232f11ddb90.png)


## Reference
* [SOBA](https://github.com/cloud-elements/soba/pull/8161)
* [RALLY-DE846](https://rally1.rallydev.com/#/144349237612d/detail/defect/195599813620)

## Closes
* [DE846](https://rally1.rallydev.com/#/144349237612d/detail/defect/195599813620)
