### PR TITLE
Add churros test for branding API properties for feature management

### DIFF
--- a/src/test/platform/organizations/branding.js
+++ b/src/test/platform/organizations/branding.js
@@ -46,6 +46,16 @@ suite.forPlatform('organizations/branding', test => {
     tableHeaderForeground: '#ffffff',
     tableBodyBackground: '#ffffff',
     tableBodyForeground: '#ffffff',
+    pendoEnabled: true,
+    documentationUrl: 'https://developers.cloud-elements.com/docs/home',
+    elementsEnabled: true,
+    instanceEnabled: true,
+    formulasEnabled: true,
+    virtualDataEnabled: true,
+    reportsEnabled: true,
+    navigationIconPosition: 'top',
+    navigationIconSize: '20px',
+    navigationLabelSize: '9px',
   };
 
   it('should support upserting, retrieving and deleting branding for a company', () => {

--- a/src/test/platform/organizations/rbac.js
+++ b/src/test/platform/organizations/rbac.js
@@ -487,6 +487,17 @@ suite.forPlatform('Tests privileges restrict API access as expected', test => {
       tableHeaderForeground: '#ffffff',
       tableBodyBackground: '#ffffff',
       tableBodyForeground: '#ffffff',
+      intercomEnabled: true,
+      pendoEnabled: true,
+      documentationUrl: 'https://developers.cloud-elements.com/docs/home',
+      elementsEnabled: true,
+      instanceEnabled: true,
+      formulasEnabled: true,
+      virtualDataEnabled: true,
+      reportsEnabled: true,
+      navigationIconPosition: 'top',
+      navigationIconSize: '20px',
+      navigationLabelSize: '9px',
     };
 
     it('should restrict access to updating the organization branding information but not retrieving it with the proper privilege', () => {


### PR DESCRIPTION
## Highlights
* Add churros test for new branding API properties

## Screenshot
one test failing because missing AWS setup
<img width="940" alt="image 2018-02-28 at 1 27 44 pm" src="https://user-images.githubusercontent.com/2327802/36808731-8cb0b030-1c8b-11e8-966c-cc01817c399a.png">


## Reference
* [SOBA](https://github.com/cloud-elements/soba/pull/8174)
* [RALLY-#${US9036}](https://rally1.rallydev.com/#/detail/userstory/199663045848?fdp=true)

