### PR TITLE
Updated the where clause for /expense-reports

### DIFF
--- a/src/test/elements/intacct/expense-reports.js
+++ b/src/test/elements/intacct/expense-reports.js
@@ -20,11 +20,11 @@ suite.forElement('finance', 'expense-reports', { payload: payload }, (test) => {
   });
   test.should.supportPagination();
   test
-     .withOptions({ qs: { where: `status='Draft'` } })
-     .withName('should support Ceql status search')
+     .withOptions({ qs: { where: `batchkey = 187 ` } })
+     .withName('should support Ceql batchKey search')
      .withValidation(r => {
        expect(r).to.statusCode(200);
-       const validValues = r.body.filter(obj => obj.status = 'Draft');
+       const validValues = r.body.filter(obj => obj.batchkey === 187 );
        expect(validValues.length).to.equal(r.body.length);
      })
      .should.return200OnGet();


### PR DESCRIPTION
## Highlights
* Updated the where clause for /expense-reports API 

## Screenshot
`(node:15888) [DEP0022] DeprecationWarning: os.tmpDir() is deprecated. Use os.tmpdir() instead.

info: Using url: http://localhost:8080
info: Using user: mithila.garud@gslab.com
info: Using oauth username: zoho@cloud-elements.com
info: Running tests for element: zohocrm
info: Provisioned with instance id of 158
(node:15888) [DEP0013] DeprecationWarning: Calling an asynchronous function without callback is deprecated.
  Basic tests
    √ should provision
    √ should GET /objects (536ms)
    - docs
    √ metadata (166ms)
    √ transformations (11100ms)
    - should not allow provisioning with bad credentials

  accounts
    √ should allow ping for zohocrm (192ms)
    √ should allow CRUDS for /hubs/crm/accounts (5553ms)
    √ should allow paginating with page and pageSize for /hubs/crm/accounts (1745ms)
    √ should support searching /hubs/crm/accounts by Website (2784ms)
    √ should allow CRUDS for accounts/{id}/notes (6931ms)

  activity-calls
    √ should allow CRUDS for /hubs/crm/activity-calls (4440ms)
    √ should allow paginating with page and pageSize for /hubs/crm/activity-calls (1792ms)

  activity-events
    √ should allow CRUDS for /hubs/crm/activity-events (5746ms)
    √ should allow paginating with page and pageSize for /hubs/crm/activity-events (1783ms)

  campaigns
    √ should allow CRUDS for /hubs/crm/campaigns (5281ms)
    √ should allow paginating with page and pageSize for /hubs/crm/campaigns (1837ms)
    √ should support searching /hubs/crm/campaigns by Description (2762ms)

  contacts-post
    √ should test newly added account resource contacts-post (707ms)

  contacts
    √ should allow CRUDS for /hubs/crm/contacts (8000ms)
    √ should allow paginating with page and pageSize for /hubs/crm/contacts (1854ms)
    √ should support searching /hubs/crm/contacts by email (3025ms)
    √ should allow CRUDS for contacts/{id}/notes (6851ms)

  leads-search
    √ should test newly added account resource leads-search (1059ms)

  leads
    √ should allow CRUDS for /hubs/crm/leads (5454ms)
    √ should allow paginating with page and pageSize for /hubs/crm/leads (1847ms)
    √ should support searching /hubs/crm/leads by firstName (2795ms)
    √ should allow CRUDS for leads/{id}/notes (7139ms)

  opportunities
    √ should allow CRUDS for /hubs/crm/opportunities (7763ms)
    √ should allow paginating with page and pageSize for /hubs/crm/opportunities (1663ms)
    √ should support searching /hubs/crm/opportunities by name (2880ms)
    √ should allow CRUDS for leads/{id}/notes (7796ms)

  polling
    - polling /hubs/crm/accounts
    - polling /hubs/crm/activity-calls
    - polling /hubs/crm/activity-events
    - polling /hubs/crm/campaigns
    - polling /hubs/crm/contacts
    - polling /hubs/crm/leads
    - polling /hubs/crm/opportunities

  products
    √ should allow CRUDS for /hubs/crm/products (6837ms)
    √ should allow paginating with page and pageSize for /hubs/crm/products (1735ms)
    √ should support searching /hubs/crm/products by Modified Time (620ms)
    √ should update product related to account (3759ms)

  tasks
    √ should allow CRUDS for /hubs/crm/tasks (4549ms)
    √ should allow paginating with page and pageSize for /hubs/crm/tasks (1699ms)
    √ should support searching /hubs/crm/tasks by subject (2579ms)

  users
    √ should allow GET for /hubs/crm/users (594ms)


  38 passing (3m)
  9 pending

PS C:\Git\churros> churros test elements/intacct

(node:23516) [DEP0022] DeprecationWarning: os.tmpDir() is deprecated. Use os.tmpdir() instead.

info: Using url: http://localhost:8080
info: Using user: mithila.garud@gslab.com
info: Running tests for element: intacct
info: Provisioned with instance id of 159
(node:23516) [DEP0013] DeprecationWarning: Calling an asynchronous function without callback is deprecated.
  Basic tests
    √ should provision
    √ should GET /objects (385ms)
    - docs
    √ metadata (486ms)
error: Failed to retrieve or validate: /hubs/finance/attachments
    1) transformations
    - should not allow provisioning with bad credentials

  bills-payments
    √ should allow SR for /hubs/finance/bills-payments (3966ms)
    √ should support Ceql date search (3533ms)
    √ should allow paginating with page and nextPage /hubs/finance/bills-payments (5096ms)

  bills
    √ should allow CRDS for /hubs/finance/bills (16512ms)
    √ should allow paginating with page and pageSize for /hubs/finance/bills (4750ms)
    √ should support updated > {date} Ceql search (3871ms)

  chargecard-transactions
    √ should allow SR for /hubs/finance/chargecard-transactions (3186ms)
    √ should allow paginating with page and nextPage /hubs/finance/chargecard-transactions (2947ms)
    √ should support Ceql WHENMODIFIED search (1146ms)

  checking-accounts
    √ should allow SR for /hubs/finance/checking-accounts (3552ms)
    √ should allow paginating with page and nextPage /hubs/finance/checking-accounts (4562ms)
    √ should support Ceql WHENMODIFIED search (2386ms)

  classes
    √ should allow CRUDS for /hubs/finance/classes (8057ms)
    √ should allow paginating with page and pageSize for /hubs/finance/classes (4464ms)
    √ should support updated > {date} Ceql search (2437ms)

  contacts
    √ should allow CRDS for /hubs/finance/contacts (9027ms)
    √ should allow PATCH for /hubs/finance/contacts/{id} (4996ms)
    √ should allow paginating with page and pageSize for /hubs/finance/contacts (4988ms)
    √ should support status Ceql search (3560ms)

  customers
    √ should allow CRUDS for /hubs/finance/customers (11622ms)
    √ should allow paginating with page and pageSize for /hubs/finance/customers (6617ms)
    √ should support updated > {date} Ceql search (3510ms)

  departments
    √ should allow CRUDS for /hubs/finance/departments (10335ms)
    √ should allow paginating with page and pageSize for /hubs/finance/departments (5090ms)
    √ should support updated > {date} Ceql search (2102ms)

  employees
    √ should allow CRDS for /hubs/finance/employees (8890ms)
    √ should allow PATCH for /hubs/finance/employees/{id} (6752ms)
    √ should allow paginating with page and pageSize for /hubs/finance/employees (4580ms)
    √ should support updated > {date} Ceql search (3641ms)

  exchange-rate-entries
    √ should allow SR for /hubs/payment/exchange-rate-entries (3030ms)
    √ should allow paginating with page and nextPage /hubs/payment/exchange-rate-entries (2569ms)

  exchange-rate-types
    √ should allow SR for /hubs/payment/exchange-rate-types (2393ms)
    √ should allow paginating with page and nextPage /hubs/payment/exchange-rate-types (2413ms)

  exchange-rates
    - should allow CRS for /hubs/payment/exchange-rates
    - should allow paginating with page and nextPage /hubs/payment/exchange-rates

  expense-reports
    √ should allow CRDS for /hubs/finance/expense-reports (9696ms)
    √ should allow PATCH for /hubs/finance/expense-reports/{id} (5514ms)
    √ should allow paginating with page and pageSize for /hubs/finance/expense-reports (4659ms)
    √ should support Ceql status search (1324ms)

  folders
    √ should allow CRUDS for /hubs/finance/folders (10515ms)
    √ should allow paginating with page and pageSize for /hubs/finance/folders (7127ms)
    √ should support description = {string} Ceql search (2840ms)
    √ should allow CRUDS for /hubs/finance/folders/8pn2pf8guf/files (10323ms)
    √ should allow paginating with page and pageSize for /hubs/finance/folders/sk8ev5r9lr/files (6070ms)
    √ should support  description = {string} Ceql search (1201ms)

  invoices
error: Failed to delete /hubs/finance/folders/8pn2pf8guf
    √ should allow CRUDS for /hubs/finance/invoices (12685ms)
    √ should allow paginating with page and pageSize for /hubs/finance/invoices (6897ms)
    √ should support updated > {date} Ceql search (4510ms)

  items
    √ should allow CRUDS for /hubs/finance/items (11211ms)
    √ should allow paginating with page and pageSize for /hubs/finance/items (6855ms)
    √ should support updated > {date} Ceql search (3742ms)

  journals
    √ should allow CRUDS for /hubs/finance/journals (10932ms)
    √ should allow paginating with page and pageSize for /hubs/finance/journals (6217ms)
    √ should support updated > {date} Ceql search (2406ms)

  ledger-accounts
    √ should allow CRUDS for /hubs/finance/ledger-accounts (11589ms)
    √ should allow paginating with page and pageSize for /hubs/finance/ledger-accounts (5176ms)
    √ should support updated > {date} Ceql search (2820ms)

  locations
    √ should allow CRUDS for /hubs/finance/locations (11514ms)
    √ should allow paginating with page and pageSize for /hubs/finance/locations (5420ms)
    √ should support updated > {date} Ceql search (1771ms)

  payments
    - should allow CRS for /hubs/finance/payments
    - should allow paginating with page and pageSize for /hubs/finance/payments
    - should support updated > {date} Ceql search
    - should allow C for /hubs/finance/payments/{id}/apply

  ping
    √ should allow GET for /hubs/finance/ping (305ms)

  polling
    - polling /hubs/finance/customers
    - polling /hubs/finance/employees
    - polling /hubs/finance/invoices
    - polling /hubs/finance/items
    - polling /hubs/finance/journals
    - polling /hubs/finance/ledger-accounts
    - polling /hubs/finance/payments
    - polling /hubs/finance/vendors

  projects
    √ should allow CRUDS for /hubs/finance/projects (11206ms)
    √ should allow paginating with page and pageSize for /hubs/finance/projects (6647ms)
    √ should support updated > {date} Ceql search (3095ms)

  purchase-orders
    - should allow CRDS for /hubs/finance/purchase-orders
    - should allow paginating with page and pageSize for /hubs/finance/purchase-orders
    - should support updated > {date} Ceql search

  reporting-periods
    √ should allow GET for /hubs/finance/reporting-periods (2861ms)
    √ should allow paginating with page and pageSize for /hubs/finance/reporting-periods (6282ms)
    √ should support status = {string} Ceql search (3062ms)

  sales-orders
    √ should allow CRUDS for /hubs/finance/sales-orders (16338ms)
    √ should allow paginating with page and pageSize for /hubs/finance/sales-orders (7027ms)
    √ should support updated > {date} Ceql search (4228ms)

  terms
    √ should allow SR for /hubs/finance/terms (4028ms)
    √ should allow CUD for /hubs/finance/terms (4941ms)
    √ should allow paginating with page and pageSize for /hubs/finance/terms (4232ms)
    √ should support updated > {date} Ceql search (2121ms)

  transactions
    - should allow CRDS for /hubs/finance/transactions
    - should allow GET for /hubs/finance/transactions-entries
    - should allow paginating with page and pageSize for /hubs/finance/transactions
    - should support updated > {date} Ceql search

  vendors
    √ should allow CRDS for /hubs/finance/vendors (8364ms)
    √ should allow paginating with page and pageSize for /hubs/finance/vendors (6528ms)
    √ should support updated > {date} Ceql search (3666ms)
    √ should support paginated search and return less than requested (17552ms)

  vouchers
    √ should allow CRDS for /hubs/finance/vouchers (14389ms)
    √ should allow paginating with page and pageSize for /hubs/finance/vouchers (6332ms)
    √ should support updated > {date} Ceql search (2979ms)

  warehouses
    √ should allow SR for /hubs/finance/warehouses (5813ms)
    √ should allow paginating with page and pageSize for /hubs/finance/warehouses (5776ms)
    √ should support updated > {date} Ceql search (2056ms)


  85 passing (9m)
  23 pending
  1 failing

  1) Basic tests transformations:
     Error: AssertionError: expected 57 to equal 0
      at cloud.delete.catch.then.catch.then.then.catch.then (C:\Git\churros\src\test\elements\assets\basics.js:128:17)
      at _fulfilled (C:\Git\churros\node_modules\q\q.js:854:54)
      at self.promiseDispatch.done (C:\Git\churros\node_modules\q\q.js:883:30)
      at Promise.promise.promiseDispatch (C:\Git\churros\node_modules\q\q.js:816:13)
      at C:\Git\churros\node_modules\q\q.js:624:44
      at runSingle (C:\Git\churros\node_modules\q\q.js:137:13)
      at flush (C:\Git\churros\node_modules\q\q.js:125:13)
      at process._tickCallback (internal/process/next_tick.js:150:11)

`
## Reference
* [SOBA](https://github.com/cloud-elements/soba/pull/8167)
* [churros-sauce](Link to Associated Churros-sauce PR, when applicable)
* [RALLY-#${DE789}](https://rally1.rallydev.com/#/144349237612d/detail/defect/192937992328/tasks)

## Closes
* Closes #${issueNumber}
#