### PR TITLE
Servicemax : Fixed test cases for search by id

### DIFF
--- a/src/test/elements/servicemax/installed-products.js
+++ b/src/test/elements/servicemax/installed-products.js
@@ -4,6 +4,8 @@ const suite = require('core/suite');
 const payload = require('./assets/installed-products');
 const tools = require('core/tools');
 const cloud = require('core/cloud');
+const chakram = require('chakram');
+const expect = chakram.expect;
 const build = (overrides) => Object.assign({}, payload, overrides);
 const productsPayload = build({ Name: tools.random() });
 
@@ -18,10 +20,16 @@ suite.forElement('fsa', 'installed-products', { payload: productsPayload }, (tes
   test.withOptions(options).should.supportCruds();
   test.should.supportPagination();
   it('should test "where" search for installed-products', () => {
-      let id;
-      return cloud.post(test.api, productsPayload)
-        .then(r => id = r.body.id)
-        .then(r => cloud.get(test.api), { qs: {  where:  `Id =\'${id}\'` } })
-        .then(r => cloud.delete(`${test.api}/${id}`));
-    });
+    let id;
+    return cloud.post(test.api, productsPayload)
+      .then(r => {
+        id = r.body.id;
+        const myOptions = {qs: { where:  `Id =\'${id}\'`}};
+        return cloud.withOptions(myOptions).get(test.api, (r) => {
+          expect(r).to.have.statusCode(200);
+          expect(r.body.filter(obj => obj.Id === id).length).to.equal(r.body.length);
+        });
+       })
+      .then(r => cloud.delete(`${test.api}/${id}`));
+  });
 });

--- a/src/test/elements/servicemax/installed-products.js
+++ b/src/test/elements/servicemax/installed-products.js
@@ -3,6 +3,7 @@
 const suite = require('core/suite');
 const payload = require('./assets/installed-products');
 const tools = require('core/tools');
+const cloud = require('core/cloud');
 const build = (overrides) => Object.assign({}, payload, overrides);
 const productsPayload = build({ Name: tools.random() });
 
@@ -16,5 +17,11 @@ suite.forElement('fsa', 'installed-products', { payload: productsPayload }, (tes
   };
   test.withOptions(options).should.supportCruds();
   test.should.supportPagination();
-  test.should.supportCeqlSearch('id');
+  it('should test "where" search for installed-products', () => {
+      let id;
+      return cloud.post(test.api, productsPayload)
+        .then(r => id = r.body.id)
+        .then(r => cloud.get(test.api), { qs: {  where:  `Id =\'${id}\'` } })
+        .then(r => cloud.delete(`${test.api}/${id}`));
+    });
 });

--- a/src/test/elements/servicemax/order-parts.js
+++ b/src/test/elements/servicemax/order-parts.js
@@ -2,6 +2,7 @@
 
 const suite = require('core/suite');
 const payload = require('./assets/order-parts');
+const cloud = require('core/cloud');
 const build = (overrides) => Object.assign({}, payload, overrides);
 const productsPayload = build({ SVMXC__On_Hold__c: true });
 
@@ -15,6 +16,12 @@ suite.forElement('fsa', 'order-parts', { payload: productsPayload }, (test) => {
   };
   test.withOptions(options).should.supportCruds();
   test.should.supportPagination();
-  test.should.supportCeqlSearch('id');
+  it('should test "where" search for order-parts', () => {
+      let id;
+      return cloud.post(test.api, productsPayload)
+        .then(r => id = r.body.id)
+        .then(r => cloud.get(test.api), { qs: {  where:  `Id =\'${id}\'` } })
+        .then(r => cloud.delete(`${test.api}/${id}`));
+    });
 
 });

--- a/src/test/elements/servicemax/order-parts.js
+++ b/src/test/elements/servicemax/order-parts.js
@@ -3,6 +3,8 @@
 const suite = require('core/suite');
 const payload = require('./assets/order-parts');
 const cloud = require('core/cloud');
+const chakram = require('chakram');
+const expect = chakram.expect;
 const build = (overrides) => Object.assign({}, payload, overrides);
 const productsPayload = build({ SVMXC__On_Hold__c: true });
 
@@ -17,11 +19,16 @@ suite.forElement('fsa', 'order-parts', { payload: productsPayload }, (test) => {
   test.withOptions(options).should.supportCruds();
   test.should.supportPagination();
   it('should test "where" search for order-parts', () => {
-      let id;
-      return cloud.post(test.api, productsPayload)
-        .then(r => id = r.body.id)
-        .then(r => cloud.get(test.api), { qs: {  where:  `Id =\'${id}\'` } })
-        .then(r => cloud.delete(`${test.api}/${id}`));
-    });
-
+    let id;
+    return cloud.post(test.api, productsPayload)
+      .then(r => {
+        id = r.body.id;
+        const myOptions = {qs: { where:  `Id =\'${id}\'`}};
+        return cloud.withOptions(myOptions).get(test.api, (r) => {
+          expect(r).to.have.statusCode(200);
+          expect(r.body.filter(obj => obj.Id === id).length).to.equal(r.body.length);
+        });
+       })
+      .then(r => cloud.delete(`${test.api}/${id}`));
+  });
 });

--- a/src/test/elements/servicemax/service-contracts.js
+++ b/src/test/elements/servicemax/service-contracts.js
@@ -4,6 +4,8 @@ const suite = require('core/suite');
 const payload = require('./assets/service-contracts');
 const tools = require('core/tools');
 const cloud = require('core/cloud');
+const chakram = require('chakram');
+const expect = chakram.expect;
 const build = (overrides) => Object.assign({}, payload, overrides);
 const productsPayload = build({ Name: tools.random() });
 
@@ -21,8 +23,14 @@ suite.forElement('fsa', 'service-contracts', { payload: productsPayload }, (test
   it('should test "where" search for service-contracts', () => {
       let id;
       return cloud.post(test.api, productsPayload)
-        .then(r => id = r.body.id)
-        .then(r => cloud.get(test.api), { qs: {  where:  `Id =\'${id}\'` } })
+        .then(r => {
+          id = r.body.id;
+          const myOptions = {qs: { where:  `Id =\'${id}\'`}};
+          return cloud.withOptions(myOptions).get(test.api, (r) => {
+            expect(r).to.have.statusCode(200);
+            expect(r.body.filter(obj => obj.Id === id).length).to.equal(r.body.length);
+          });
+         })
         .then(r => cloud.delete(`${test.api}/${id}`));
     });
 

--- a/src/test/elements/servicemax/service-contracts.js
+++ b/src/test/elements/servicemax/service-contracts.js
@@ -3,6 +3,7 @@
 const suite = require('core/suite');
 const payload = require('./assets/service-contracts');
 const tools = require('core/tools');
+const cloud = require('core/cloud');
 const build = (overrides) => Object.assign({}, payload, overrides);
 const productsPayload = build({ Name: tools.random() });
 
@@ -17,6 +18,12 @@ suite.forElement('fsa', 'service-contracts', { payload: productsPayload }, (test
   };
   test.withOptions(options).should.supportCruds();
   test.should.supportPagination();
-  test.should.supportCeqlSearch('id');
+  it('should test "where" search for service-contracts', () => {
+      let id;
+      return cloud.post(test.api, productsPayload)
+        .then(r => id = r.body.id)
+        .then(r => cloud.get(test.api), { qs: {  where:  `Id =\'${id}\'` } })
+        .then(r => cloud.delete(`${test.api}/${id}`));
+    });
 
 });

--- a/src/test/elements/servicemax/work-orders.js
+++ b/src/test/elements/servicemax/work-orders.js
@@ -2,6 +2,8 @@
 
 const suite = require('core/suite');
 const cloud = require('core/cloud');
+const chakram = require('chakram');
+const expect = chakram.expect;
 const payload = require('./assets/work-orders');
 
 suite.forElement('fsa', 'work-orders', { payload: payload }, (test) => {
@@ -9,10 +11,16 @@ suite.forElement('fsa', 'work-orders', { payload: payload }, (test) => {
   test.should.supportCruds();
   test.should.supportPagination();
   it('should test "where" search for work-orders', () => {
-      let id;
-      return cloud.post(test.api, payload)
-        .then(r => id = r.body.id)
-        .then(r => cloud.get(test.api), { qs: {  where:  `Id =\'${id}\'` } })
-        .then(r => cloud.delete(`${test.api}/${id}`));
-    });
+    let id;
+    return cloud.post(test.api, payload)
+      .then(r => {
+        id = r.body.id;
+        const myOptions = {qs: { where:  `Id =\'${id}\'`}};
+        return cloud.withOptions(myOptions).get(test.api, (r) => {
+          expect(r).to.have.statusCode(200);
+          expect(r.body.filter(obj => obj.Id === id).length).to.equal(r.body.length);
+        });
+      })
+      .then(r => cloud.delete(`${test.api}/${id}`));
+  });
 });

--- a/src/test/elements/servicemax/work-orders.js
+++ b/src/test/elements/servicemax/work-orders.js
@@ -1,11 +1,18 @@
 'use strict';
 
 const suite = require('core/suite');
+const cloud = require('core/cloud');
 const payload = require('./assets/work-orders');
 
 suite.forElement('fsa', 'work-orders', { payload: payload }, (test) => {
 
   test.should.supportCruds();
   test.should.supportPagination();
-  test.should.supportCeqlSearch('id');
+  it('should test "where" search for work-orders', () => {
+      let id;
+      return cloud.post(test.api, payload)
+        .then(r => id = r.body.id)
+        .then(r => cloud.get(test.api), { qs: {  where:  `Id =\'${id}\'` } })
+        .then(r => cloud.delete(`${test.api}/${id}`));
+    });
 });


### PR DESCRIPTION
## Highlights
* Fixed search by id test cases for following resources 
   
1.  installed-products
2.   order-parts
3.   service-contracts
4.   work-orders

For these resources the Post API response has "id" field  but the Get API model has "Id" field ,hence the existing search by id test cases were failing.

## Screenshot
![churros result](https://user-images.githubusercontent.com/30625203/36784454-6fb44bd0-1ca5-11e8-94f5-20262fbc7298.PNG)


## Reference
* [SOBA](https://github.com/cloud-elements/soba/pull/8170)
* #[Rally DE1013](https://rally1.rallydev.com/#/144349237612d/detail/defect/201813342260)


## Closes
* #[DE1013](https://rally1.rallydev.com/#/144349237612d/detail/defect/201813342260)

