### PR TITLE
Enhanced sharepoint element with /revisions API's Testcases

### DIFF
--- a/src/test/elements/sharepoint/files.js
+++ b/src/test/elements/sharepoint/files.js
@@ -6,6 +6,28 @@ const tools = require('core/tools');
 const payload = tools.requirePayload(`${__dirname}/assets/files.json`);
 
 suite.forElement('documents', 'files', { payload: payload }, (test) => {
+  let jpgFile = __dirname + '/assets/Penguins.jpg';
+  var jpgFileBody,revisionId;
+  let query = { path: `/brady-${tools.randomStr('abcdefghijklmnopqrstuvwxyz1234567890', 10)}.jpg` , overwrite: 'true', size: '777835'};
+
+  before(() => cloud.withOptions({ qs : query }).postFile(test.api, jpgFile)
+  .then(() => cloud.withOptions({ qs : query }).postFile(test.api, jpgFile))
+  .then(r => jpgFileBody = r.body));
+
+  after(() => cloud.delete(`${test.api}/${jpgFileBody.id}`));
+
+  it('it should allow RS for documents/files/:id/revisions', () => {
+      return cloud.get(`${test.api}/${jpgFileBody.id}/revisions`)
+      .then(r => revisionId = r.body[0].id)
+      .then(() => cloud.get(`${test.api}/${jpgFileBody.id}/revisions/${revisionId}`));
+  });
+
+  it('it should allow RS for documents/files/revisions by path', () => {
+      return cloud.withOptions({ qs: query }).get(`${test.api}/revisions`)
+      .then(r => revisionId = r.body[0].id)
+      .then(() => cloud.withOptions({ qs: query }).get(`${test.api}/revisions/${revisionId}`));
+  });
+  
   it('should allow ping for sharepoint', () => {
     return cloud.get(`/hubs/documents/ping`);
   });


### PR DESCRIPTION
## Highlights
* Sharepoint enhanced with `/revisions API` by path and id testcases.

## Non-customer Highlights
* Revisions By Path
   `files/revisions`
   `files/revisions/{revisionId}`

* Revisions By Id
   `files/{fileId}/revisions`
  `files/{fileId}/revisions/{revisionId}`

## Checklist
* [x] applicable churros tests are still passing
* [ ] includes a dbdeploy script that is backward-incompatible with one previous Soba minor version

#Screen shot
![screen shot 2018-03-06 at 12 36 34 pm](https://user-images.githubusercontent.com/26943831/37051737-e3bb20f8-213c-11e8-8165-30d4bf357657.png)


## Related PRs
[Soba](https://github.com/cloud-elements/soba/pull/8204)

## Closes
[US9381](https://rally1.rallydev.com/#/144349237612d/detail/userstory/202233375544)