### PR TITLE
Enhanced chargify element with /invoices testcases

### DIFF
--- a/src/test/elements/chargify/assets/invoices.json
+++ b/src/test/elements/chargify/assets/invoices.json
@@ -1,0 +1,51 @@
+[
+  {
+    "invoice": {
+      "created_at": "2018-03-06T14:42:51-05:00",
+      "statement_id": 110091125,
+      "line_items": [
+        {
+          "kind": "baseline",
+          "created_at": "2018-03-06T14:42:51-05:00",
+          "memo": "Basic Plan (03/06/2018 - 04/06/2018)",
+          "type": "Charge",
+          "transaction_type": "charge",
+          "starting_balance_in_cents": 0,
+          "subscription_id": 21086339,
+          "amount_in_cents": 1000,
+          "success": true,
+          "product_id": 4468608,
+          "ending_balance_in_cents": 1000,
+          "id": 229975068,
+          "customer_id": 20702475
+        }
+      ],
+      "subscription_id": 21086339,
+      "total_amount_in_cents": 1000,
+      "number": "000002",
+      "payments_and_credits": [],
+      "charges": [
+        {
+          "kind": "baseline",
+          "created_at": "2018-03-06T14:42:51-05:00",
+          "memo": "Basic Plan (03/06/2018 - 04/06/2018)",
+          "type": "Charge",
+          "transaction_type": "charge",
+          "starting_balance_in_cents": 0,
+          "subscription_id": 21086339,
+          "amount_in_cents": 1000,
+          "success": true,
+          "product_id": 4468608,
+          "ending_balance_in_cents": 1000,
+          "id": 229975068,
+          "customer_id": 20702475
+        }
+      ],
+      "updated_at": "2018-03-06T14:42:51-05:00",
+      "amount_due_in_cents": 1000,
+      "site_id": 34752,
+      "id": 1794923,
+      "state": "unpaid"
+    }
+  }
+]

--- a/src/test/elements/chargify/assets/transformations.json
+++ b/src/test/elements/chargify/assets/transformations.json
@@ -43,5 +43,14 @@
         "vendorPath": "subscription.id"
       }
     ]
+  },
+  "invoices": {
+    "vendorName": "invoices",
+    "fields": [
+      {
+        "path": "id",
+        "vendorPath": "invoice.id"
+      }
+    ]
   }
 }

--- a/src/test/elements/chargify/invoices.js
+++ b/src/test/elements/chargify/invoices.js
@@ -1,0 +1,9 @@
+'use strict';
+
+const suite = require('core/suite');
+const tools = require('core/tools');
+
+suite.forElement('payment', 'invoices', (test) => {
+  test.should.supportSr();
+  test.should.supportPagination();
+});

--- a/src/test/elements/chargify/invoices.js
+++ b/src/test/elements/chargify/invoices.js
@@ -1,9 +1,10 @@
 'use strict';
 
 const suite = require('core/suite');
-const tools = require('core/tools');
+const invoicesschema = require('./assets/invoices.json');
 
 suite.forElement('payment', 'invoices', (test) => {
   test.should.supportSr();
+  test.withValidation(invoicesschema).withName('should support Ceql search').withOptions({ qs: { where: 'status=\'unpaid\'' } }).should.return200OnGet();
   test.should.supportPagination();
 });


### PR DESCRIPTION
## Highlights
* Chargify element enhance with `/invoices` API Testcases

## Non-customer Highlights
* Invoices API's
   > `GET /invoices`
   > `GET /invoices/{id}`

## Checklist
* [x] applicable churros tests are still passing
* [ ] includes a dbdeploy script that is backward-incompatible with one previous Soba minor version

#Screen shot
![screen shot 2018-03-06 at 4 15 53 pm](https://user-images.githubusercontent.com/26943831/37063987-f53cb84a-2160-11e8-8b1e-fdaa2def490b.png)


## Related PRs
[Soba](https://github.com/cloud-elements/soba/pull/8211)

## Closes
[US8327](https://rally1.rallydev.com/#/144349237612d/detail/userstory/197894482304)