### PR TITLE
added search tests for marketo channels and programs

### DIFF
--- a/src/test/elements/marketo/channels.js
+++ b/src/test/elements/marketo/channels.js
@@ -1,7 +1,17 @@
 'use strict';
 
 const suite = require('core/suite');
+const cloud = require('core/cloud');
+
+
+var channelName;
 
 suite.forElement('marketing', 'channels', (test) => {
-  test.should.supportSr();
+  it('should allow SR for /channels', () => {
+    return cloud.get(test.api)
+    .then(r => channelName = r.body[0].name);
+  });
+
+  test.withApi(test.api)
+  .withOptions({ qs: { where: `name='${channelName}'` } })
 });

--- a/src/test/elements/marketo/channels.js
+++ b/src/test/elements/marketo/channels.js
@@ -13,5 +13,6 @@ suite.forElement('marketing', 'channels', (test) => {
   });
 
   test.withApi(test.api)
-  .withOptions({ qs: { where: `name='${channelName}'` } })
+    .withOptions({ qs: { where: `name='${channelName}'` } 
+  });
 });

--- a/src/test/elements/marketo/programs.js
+++ b/src/test/elements/marketo/programs.js
@@ -18,11 +18,14 @@ const updatePayload = {
 suite.forElement('marketing', 'programs', { payload: payload }, (test) => {
   payload.name += tools.random();
   let id;
-  it('should allow CRUD for /programs', () => {
+  it('should allow CRUDS for /programs', () => {
     return cloud.post(test.api, payload)
     .then(r => id = r.body.id)
     .then(r => cloud.get(`${test.api}/${id}`))
     .then(r => cloud.patch(`${test.api}/${id}`, updatePayload))
     .then(r => cloud.delete(`${test.api}/${id}`));
   });
+
+  test.withApi(test.api)
+      .withOptions({ qs: { where: `name='${payload.name}'` } })
 });

--- a/src/test/elements/marketo/programs.js
+++ b/src/test/elements/marketo/programs.js
@@ -27,5 +27,6 @@ suite.forElement('marketing', 'programs', { payload: payload }, (test) => {
   });
 
   test.withApi(test.api)
-      .withOptions({ qs: { where: `name='${payload.name}'` } })
+    .withOptions({ qs: { where: `name='${payload.name}'` } 
+  });
 });


### PR DESCRIPTION
## Highlights
* Added test coverage for
   User can search for Marketo programs by name via query field
   User can search for Marketo channels by name via query field

## Screenshot
<img width="618" alt="screen shot 2018-03-06 at 5 37 13 pm" src="https://user-images.githubusercontent.com/5354852/37066995-1234bd86-2165-11e8-9db2-06d391c2c962.png">

<img width="649" alt="screen shot 2018-03-06 at 5 38 09 pm" src="https://user-images.githubusercontent.com/5354852/37067012-2deddd00-2165-11e8-9ffe-d1e7d653ecac.png">

## Reference
* [SOBA - 8208](https://github.com/cloud-elements/soba/pull/8208)
* [RALLY - DE398](https://rally1.rallydev.com/#/144349237612d/detail/defect/170907163336?fdp=true)

## Closes
* Closes [DE398](https://rally1.rallydev.com/#/144349237612d/detail/defect/170907163336?fdp=true)
