### PR TITLE
Added tests for currencies object Netsuite Finance

### DIFF
--- a/src/test/elements/netsuitefinancev2/assets/currencies.json
+++ b/src/test/elements/netsuitefinancev2/assets/currencies.json
@@ -1,0 +1,8 @@
+{
+ "symbol": "INR",
+ "exchangeRate": 0.481683,
+ "name":"<<address.country>>",
+ "locale": {
+    "value": "_indiaMarathi"
+  }
+}

--- a/src/test/elements/netsuitefinancev2/assets/transformations.json
+++ b/src/test/elements/netsuitefinancev2/assets/transformations.json
@@ -1,4 +1,11 @@
 {
+  "currencies": {
+    "vendorName": "Currency",
+    "fields": [{
+      "path": "id",
+      "vendorPath": "internalId"
+    }]
+  },
   "customers": {
     "vendorName": "Customer",
     "fields": [{

--- a/src/test/elements/netsuitefinancev2/currencies.js
+++ b/src/test/elements/netsuitefinancev2/currencies.js
@@ -1,0 +1,11 @@
+'use strict';
+
+const suite = require('core/suite');
+const tools = require('core/tools');
+const payload = tools.requirePayload(`${__dirname}/assets/currencies.json`);
+payload.symbol = tools.randomStr("AMNBGHJOPEIOU", 3);
+
+suite.forElement('finance', 'currencies', { payload: payload }, (test) => {
+  test.should.supportCruds();
+  test.withOptions({ qs: { page: 1, pageSize: 5 } }).should.supportPagination();
+});


### PR DESCRIPTION
## Highlights
* Added CRUD tests for currencies object Netsuite Finance
* For GET /currencies, no CEQL query test is added as it's a limitation from vendor.

## Screenshot
Churros Report- [NS finance churros.txt](https://github.com/cloud-elements/churros/files/1792511/NS.finance.churros.txt)
  Some of the churros are failing, raised bug [DE1049](https://rally1.rallydev.com/#/144349237612ud/detail/defect/203650294104?fdp=true) for that.

## Reference
* [SOBA](https://github.com/cloud-elements/soba/pull/8224)
* [RALLY-US9389](https://rally1.rallydev.com/#/144349237612ud/detail/userstory/202236832756)
