### PR TITLE
Added polling testcase for Deals in Hubspot Marketing

### DIFF
--- a/src/test/elements/hubspot/polling.js
+++ b/src/test/elements/hubspot/polling.js
@@ -9,5 +9,5 @@ const dealsPayload = tools.requirePayload(`${__dirname}/assets/deals.json`);
 suite.forElement('marketing', 'polling', null, (test) => {
   test.withApi('/hubs/marketing/accounts').should.supportPolling(accountsPayload, 'accounts');
   test.withApi('/hubs/marketing/contacts').should.supportPolling(contactsPayload, 'contacts');
-  test.withApi('/hubs/marketing/deals').should.supportPolling(contactsPayload, 'deals');
+  test.withApi('/hubs/marketing/deals').should.supportPolling(dealsPayload, 'deals');
 });

--- a/src/test/elements/hubspot/polling.js
+++ b/src/test/elements/hubspot/polling.js
@@ -4,8 +4,10 @@ const suite = require('core/suite');
 const tools = require('core/tools');
 const accountsPayload = tools.requirePayload(`${__dirname}/assets/accounts.json`);
 const contactsPayload = tools.requirePayload(`${__dirname}/assets/contacts.json`);
+const dealsPayload = tools.requirePayload(`${__dirname}/assets/deals.json`);
 
 suite.forElement('marketing', 'polling', null, (test) => {
   test.withApi('/hubs/marketing/accounts').should.supportPolling(accountsPayload, 'accounts');
   test.withApi('/hubs/marketing/contacts').should.supportPolling(contactsPayload, 'contacts');
+  test.withApi('/hubs/marketing/deals').should.supportPolling(contactsPayload, 'deals');
 });


### PR DESCRIPTION
## Highlights
* Added polling testcase for `Deals` object which was newly added in `Hubspot Marketing`

## Screenshot
![pollinghubspot](https://user-images.githubusercontent.com/20634723/37204263-381b747e-23b6-11e8-8fd3-4bf919196bc4.PNG)

## Reference
* [SOBA](https://github.com/cloud-elements/soba/pull/8232)
* [TA10178](https://rally1.rallydev.com/#/144349237612ud/detail/task/203957758960) ([DE1027](https://rally1.rallydev.com/#/144349237612ud/detail/defect/202696714648/tasks))

## Closes
* [TA10178](https://rally1.rallydev.com/#/144349237612ud/detail/task/203957758960) ([DE1027](https://rally1.rallydev.com/#/144349237612ud/detail/defect/202696714648/tasks))
