### PR TITLE
Onedrivev2 : Added testcase for /me API

### DIFF
--- a/src/test/elements/onedrivev2/me.js
+++ b/src/test/elements/onedrivev2/me.js
@@ -1,0 +1,7 @@
+'use strict';
+
+const suite = require('core/suite');
+
+suite.forElement('documents', 'me', null, (test) => {
+  test.should.return200OnGet();
+});


### PR DESCRIPTION
## Highlights
* Added churros for `GET /me` for `onedrivev2`

## Screenshot
![churros](https://user-images.githubusercontent.com/20634723/37290031-3c331d78-2631-11e8-8026-44405957f462.PNG)
![churros1](https://user-images.githubusercontent.com/20634723/37290040-41602052-2631-11e8-8f6d-a5428798f16d.PNG)
![churros2](https://user-images.githubusercontent.com/20634723/37290047-455e9d8c-2631-11e8-9c70-3117e8f327ba.PNG)

## Reference
* [SOBA](https://github.com/cloud-elements/soba/pull/8245)
* [US9352](https://rally1.rallydev.com/#/144349237612ud/detail/userstory/201677249100)

## Closes
* [US9352](https://rally1.rallydev.com/#/144349237612ud/detail/userstory/201677249100)
