### PR TITLE
Sharepoint Gliffy enhancements - updated test cases

### DIFF
--- a/src/test/elements/sharepoint/files.js
+++ b/src/test/elements/sharepoint/files.js
@@ -3,6 +3,7 @@
 const suite = require('core/suite');
 const cloud = require('core/cloud');
 const tools = require('core/tools');
+const expect = require('chakram').expect;
 const payload = tools.requirePayload(`${__dirname}/assets/files.json`);
 
 suite.forElement('documents', 'files', { payload: payload }, (test) => {
@@ -14,7 +15,10 @@ suite.forElement('documents', 'files', { payload: payload }, (test) => {
     let UploadFile = __dirname + '/assets/Penguins.jpg',
       srcPath;
     return cloud.withOptions({ qs: { path: `/${tools.random()}`, overwrite: 'true', size: '777835' } }).postFile(test.api, UploadFile)
-      .then(r => srcPath = r.body.path)
+      .then(r => {
+        srcPath = r.body.path;
+        expect(r.body.parentFolderId).to.not.be.null;
+      })
       .then(r => cloud.withOptions({ qs: { path: `${srcPath}` } }).get(test.api))
       .then(r => cloud.withOptions({ qs: { path: `${srcPath}` } }).post(`${test.api}/copy`, payload))
       .then(r => cloud.withOptions({ qs: { path: `${srcPath}` } }).get(`${test.api}/links`))
@@ -28,7 +32,10 @@ suite.forElement('documents', 'files', { payload: payload }, (test) => {
     let UploadFile = __dirname + '/assets/Penguins.jpg',
       fileId;
     return cloud.withOptions({ qs: { path: `/${tools.random()}`, overwrite: 'true', size: '777835' } }).postFile(test.api, UploadFile)
-      .then(r => fileId = r.body.id)
+      .then(r => {
+        fileId = r.body.id;
+        expect(r.body.parentFolderId).to.not.be.null;
+      })
       .then(r => cloud.get(`${test.api}/${fileId}`))
       .then(r => cloud.post(`${test.api}/${fileId}/copy`, payload))
       .then(r => cloud.get(`${test.api}/${fileId}/links`))

--- a/src/test/elements/sharepoint/folders.js
+++ b/src/test/elements/sharepoint/folders.js
@@ -3,13 +3,17 @@
 const suite = require('core/suite');
 const cloud = require('core/cloud');
 const tools = require('core/tools');
+const expect = require('chakram').expect;
 const payload = tools.requirePayload(`${__dirname}/assets/folders.json`);
 
 suite.forElement('documents', 'folders', { payload: payload }, (test) => {
   it('should allow CRD for hubs/documents/folders and GET for hubs/documents/folders/metadata by path', () => {
     let srcPath;
     return cloud.post(test.api, payload)
-      .then(r => srcPath = r.body.path)
+      .then(r => {
+        srcPath = r.body.path;
+        expect(r.body.parentFolderId).to.not.be.null;
+      })
       .then(r => cloud.withOptions({ qs: { path: `${srcPath}` } }).get(`${test.api}/contents`))
       .then(r => cloud.withOptions({ qs: { path: `${srcPath}`, page: 1, pageSize: 1 } }).get(`${test.api}/contents`))
       .then(r => cloud.withOptions({ qs: { path: `${srcPath}` } }).get(`${test.api}/metadata`))
@@ -19,7 +23,10 @@ suite.forElement('documents', 'folders', { payload: payload }, (test) => {
   it('should allow CRD for hubs/documents/folders and GET for hubs/documents/folders/metadata by id', () => {
     let folderId;
     return cloud.post(test.api, payload)
-      .then(r => folderId = r.body.id)
+      .then(r => {
+        folderId = r.body.id;
+        expect(r.body.parentFolderId).to.not.be.null;
+      })
       .then(r => cloud.get(`${test.api}/${folderId}/contents`))
       .then(r => cloud.withOptions({ qs: { page: 1, pageSize: 1 } }).get(`${test.api}/${folderId}/contents`))
       .then(r => cloud.get(`${test.api}/${folderId}/metadata`))


### PR DESCRIPTION
## Highlights
* Added Test case to Validate return parentFolderId - Gliffy Enhancements

## Checklist
* [x] applicable churros tests are still passing
* [ ] includes a dbdeploy script that is backward-incompatible with one previous Soba minor version

## Screenshot
![screen shot 2018-03-12 at 1 37 05 pm](https://user-images.githubusercontent.com/26943831/37306445-c1e5f8ea-2605-11e8-9b7a-46fa749bfc14.png)


## Related PRs
[Soba](https://github.com/cloud-elements/soba/pull/8249)

## Closes
[Rally](https://rally1.rallydev.com/#/144349237612d/detail/userstory/202233376020)