### PR TITLE
Stripe : Added GET /balances API 

### DIFF
--- a/src/test/elements/stripe/assets/payment-methods.json
+++ b/src/test/elements/stripe/assets/payment-methods.json
@@ -2,7 +2,7 @@
   "card": {
     "number": 4242424242424242,
     "exp_month": 12,
-    "exp_year": 2017,
+    "exp_year": 2018,
     "cvc": 123
   }
 }

--- a/src/test/elements/stripe/assets/payment-methods.json
+++ b/src/test/elements/stripe/assets/payment-methods.json
@@ -2,7 +2,7 @@
   "card": {
     "number": 4242424242424242,
     "exp_month": 12,
-    "exp_year": 2018,
+    "exp_year": 2020,
     "cvc": 123
   }
 }

--- a/src/test/elements/stripe/balances.js
+++ b/src/test/elements/stripe/balances.js
@@ -1,0 +1,7 @@
+'use strict';
+
+const suite = require('core/suite');
+
+suite.forElement('payment', 'balances', (test) => {
+  test.should.return200OnGet();
+});

--- a/src/test/elements/stripe/balances.js
+++ b/src/test/elements/stripe/balances.js
@@ -4,6 +4,9 @@ const expect = require('chakram').expect;
 const suite = require('core/suite');
 
 suite.forElement('payment', 'balances', (test) => {
-  test.withValidation((r) => expect(r).to.have.statusCode(200))
-  .should.return200OnGet();
+  test.withValidation((r) => {
+      expect(r).to.have.statusCode(200);
+      expect(r.body).to.be.an('Array')
+    })
+    .should.return200OnGet();
 });

--- a/src/test/elements/stripe/balances.js
+++ b/src/test/elements/stripe/balances.js
@@ -1,7 +1,9 @@
 'use strict';
 
+const expect = require('chakram').expect;
 const suite = require('core/suite');
 
 suite.forElement('payment', 'balances', (test) => {
-  test.should.return200OnGet();
+  test.withValidation((r) => expect(r).to.have.statusCode(200))
+  .should.return200OnGet();
 });

--- a/src/test/elements/stripe/balances.js
+++ b/src/test/elements/stripe/balances.js
@@ -6,7 +6,7 @@ const suite = require('core/suite');
 suite.forElement('payment', 'balances', (test) => {
   test.withValidation((r) => {
       expect(r).to.have.statusCode(200);
-      expect(r.body).to.be.an('Array')
+      expect(r.body).to.be.an('Array');
     })
     .should.return200OnGet();
 });


### PR DESCRIPTION
## Highlights
* Added GET /balances API 

## Non-Custormer Highlights
* where clause not supported hence not added the test for where clause
## Examples
If applicable, please include any images, GIFs, etc. showing up these changes

## Screenshot

> 
PS C:\Users\GS-1259\CE-4656\churros\finalch\churros-sauce> churros  test elements/stripe


info: Using url: http://localhost:8080
info: Using user: madhuri.kadam@gslab.com
info: Using oauth username: sk_test_HZ6dO9HizZtYuHcO8Up9kmjI
info: Running tests for element: stripe
info: Provisioned with instance id of 689
  Basic tests
    √ should provision
    √ should GET /objects (171ms)
    - docs
    √ metadata (191ms)
error: Failed to retrieve or validate: /hubs/payment/tokens
error: Failed to retrieve or validate: /hubs/payment/payment-methods
    √ transformations (18590ms)
    - should not allow provisioning with bad credentials

  balances
    √ should allow GET for /hubs/payment/balances (953ms)

  charges
    √ should allow CRS for /hubs/payment/charges (11634ms)
    √ should allow CUS for /hubs/payment/charges (3495ms)
    √ should allow paginating with page and pageSize for /hubs/payment/charges (2214ms)
    √ should allow paginating with page and nextPage /hubs/payment/charges (715ms)

  customers
    √ should allow CRUDS for /hubs/payment/customers (7512ms)
    √ should allow GET for /hubs/payment/customers (1874ms)
    √ should allow paginating with page and pageSize for /hubs/payment/customers (1891ms)
    √ should allow paginating with page and nextPage /hubs/payment/customers (641ms)

  events
    √ should allow GET for /hubs/payment/events (4118ms)
    √ should allow paginating with page and pageSize for /hubs/payment/events (1829ms)
    √ should allow paginating with page and nextPage /hubs/payment/events (564ms)

  orders
    √ should allow SR for /hubs/payment/orders (9054ms)
    √ should allow CU for /hubs/payment/orders (11208ms)
    √ should allow paginating with page and nextPage /hubs/payment/orders (649ms)

  payment-methods
    √ should allow GET for /hubs/payment/customers/{customerId}/payment-methods (1330ms)
    √ should allow CRUD for /hubs/payment/customers/{customerId}/payment-methods/{paymentId} (3692ms)

  ping
    √ should allow GET for /hubs/payment/ping (174ms)

  plans
    √ should allow CRUDS for /hubs/payment/plans (3603ms)
    √ should allow GET for /hubs/payment/plans (835ms)
    √ should allow paginating with page and pageSize for /hubs/payment/plans (1684ms)
    √ should allow paginating with page and nextPage /hubs/payment/plans (549ms)

  polling
    - polling /hubs/payment/customers
    - polling /hubs/payment/plans
    - polling /hubs/payment/products

  products
    √ should allow CRUDS for /hubs/payment/products (2956ms)
    √ should allow GET for /hubs/payment/products (595ms)
    √ should allow paginating with page and pageSize for /hubs/payment/products (1713ms)
    √ should allow paginating with page and nextPage /hubs/payment/products (561ms)

  refunds
    √ should allow CRU for /hubs/payment/charges/{chargeId}/refunds (2756ms)
    √ should allow GET for /hubs/payment/refunds (2556ms)
    √ should allow paginating with page and nextPage /hubs/payment/refunds (593ms)

  subscriptions
    √ should allow paginating with page and nextPage /hubs/payment/subscriptions (1237ms)
    √ should allow SR for /hubs/payment/subscriptions (2428ms)
    √ should allow CRUD for /hubs/payment/customers/{customerId}/subscriptions/{subscriptionId} (4077ms)

  tokens
    √ should allow GET for /hubs/payment/tokens/tok_182kUjGdZbyQGmEeaRuzEj4F (580ms)

  transactions
    √ should allow GET for /hubs/payment/transactions (4004ms)
    √ should allow GET for /hubs/payment/transactions/{transactionId} (10219ms)
    √ should allow paginating with page and nextPage /hubs/payment/transactions (568ms)

  transfers
    √ should allow SR for /hubs/payment/transfers (4337ms)
    √ should allow PATCH for /hubs/payment/transfers (6371ms)
    √ should allow paginating with page and nextPage /hubs/payment/transfers (673ms)

  43 passing (3m)
  5 pending

## Reference
* [SOBA](https://github.com/cloud-elements/soba/pull/8274)
* [RALLY-#${US10061}](https://rally1.rallydev.com/#/144349237612d/detail/userstory/203777852140)

## Closes
* Closes #${[US10061](https://rally1.rallydev.com/#/144349237612d/detail/userstory/203777852140)}
