### PR TITLE
Added testcases for contracts APIs for Autotask Helpdesk

### DIFF
--- a/src/test/elements/autotaskhelpdesk/assets/contracts.json
+++ b/src/test/elements/autotaskhelpdesk/assets/contracts.json
@@ -1,0 +1,25 @@
+{
+    "serviceLevelAgreementID": 2,
+    "endDate": "2013-05-13T14:30:00+0530",
+    "contractType": 8,
+    "contactName": "Schrage, Gail R",
+    "timeReportingRequiresStartAndStopTimes": 1,
+    "estimatedRevenue": 60000,
+    "estimatedCost": 0,
+    "userDefinedFields": {
+      "userDefinedField": []
+    },
+    "contractPeriodType": "m",
+    "accountID": 29683565,
+    "contractCategory": 15,
+    "billingPreference": 2,
+    "compliance": true,
+    "purchaseOrderNumber": "",
+    "contractName": "Afrin Contract Name",
+    "setupFee": 0,
+    "estimatedHours": 0,
+    "id": 0,
+    "isDefaultContract": true,
+    "startDate": "2012-05-14T14:30:00+0530",
+    "status": 1
+}

--- a/src/test/elements/autotaskhelpdesk/contracts.js
+++ b/src/test/elements/autotaskhelpdesk/contracts.js
@@ -2,9 +2,18 @@
 
 const suite = require('core/suite');
 const contractPayload = require('./assets/contracts');
+const expect = require('chakram').expect;
 
-suite.forElement('helpdesk', 'contracts', { payload: contractPayload }, (test) => {
+suite.forElement('helpdesk', 'contracts', { payload: contractPayload, skip: true }, (test) => {	
 	 test.should.supportCrus();
-	 test.withOptions({ qs: { where: 'contactName=\'Wilson, Carl\'' } }).should.return200OnGet();
-        test.should.supportPagination('id');
+	 test.should.supportPagination('id');
+	 test
+	 .withOptions({ qs: { where: 'contactName=\'Wilson, Carl\'' } })
+	 .withName('should support search by contactName')
+	 .withValidation(r => {
+		 expect(r).to.statusCode(200);
+		 const validValues = r.body.filter(obj => obj.contactName = `Wilson, Carl`);
+		 expect(validValues.length).to.equal(r.body.length);
+    })
+	.should.return200OnGet();
  });

--- a/src/test/elements/autotaskhelpdesk/contracts.js
+++ b/src/test/elements/autotaskhelpdesk/contracts.js
@@ -6,5 +6,5 @@ const contractPayload = require('./assets/contracts');
 suite.forElement('helpdesk', 'contracts', { payload: contractPayload }, (test) => {
 	 test.should.supportCrus();
 	 test.withOptions({ qs: { where: 'contactName=\'Wilson, Carl\'' } }).should.return200OnGet();
-     test.should.supportPagination('id');
+         test.should.supportPagination('id');
  });

--- a/src/test/elements/autotaskhelpdesk/contracts.js
+++ b/src/test/elements/autotaskhelpdesk/contracts.js
@@ -1,8 +1,6 @@
 'use strict';
 
 const suite = require('core/suite');
-const tools = require('core/tools');
-const cloud = require('core/cloud');
 const contractPayload = require('./assets/contracts');
 
 suite.forElement('helpdesk', 'contracts', { payload: contractPayload }, (test) => {

--- a/src/test/elements/autotaskhelpdesk/contracts.js
+++ b/src/test/elements/autotaskhelpdesk/contracts.js
@@ -1,0 +1,12 @@
+'use strict';
+
+const suite = require('core/suite');
+const tools = require('core/tools');
+const cloud = require('core/cloud');
+const contractPayload = require('./assets/contracts');
+
+suite.forElement('helpdesk', 'contracts', { payload: contractPayload }, (test) => {
+	 test.should.supportCrus();
+	 test.withOptions({ qs: { where: 'contactName=\'Wilson, Carl\'' } }).should.return200OnGet();
+     test.should.supportPagination('id');
+ });

--- a/src/test/elements/autotaskhelpdesk/contracts.js
+++ b/src/test/elements/autotaskhelpdesk/contracts.js
@@ -6,5 +6,5 @@ const contractPayload = require('./assets/contracts');
 suite.forElement('helpdesk', 'contracts', { payload: contractPayload }, (test) => {
 	 test.should.supportCrus();
 	 test.withOptions({ qs: { where: 'contactName=\'Wilson, Carl\'' } }).should.return200OnGet();
-         test.should.supportPagination('id');
+        test.should.supportPagination('id');
  });

--- a/src/test/elements/autotaskhelpdesk/contracts.js
+++ b/src/test/elements/autotaskhelpdesk/contracts.js
@@ -4,6 +4,7 @@ const suite = require('core/suite');
 const contractPayload = require('./assets/contracts');
 const expect = require('chakram').expect;
 
+//skipping the testcases as there is no delete API present
 suite.forElement('helpdesk', 'contracts', { payload: contractPayload, skip: true }, (test) => {	
 	 test.should.supportCrus();
 	 test.should.supportPagination('id');


### PR DESCRIPTION
## Highlights
* Added testcases for Autotask Helpdesk - `contracts` CRUS. There was no DELETE API mentioned in the vendor Documentation -https://www.autotask.net/help/Content/LinkedDOCUMENTS/WSAPI/T_WebServicesAPIv1_5.pdf
Hence DELETE is not implemented. Hence have added skip as well

## Screenshot
![churros](https://user-images.githubusercontent.com/20634723/37462586-8679481e-2878-11e8-8088-f0b57a293bf3.PNG)


## Reference
* [SOBA](https://github.com/cloud-elements/soba/pull/8276)
* [US10054](https://rally1.rallydev.com/#/144349237612ud/detail/userstory/203777846060)

## Closes
* [US10054](https://rally1.rallydev.com/#/144349237612ud/detail/userstory/203777846060)
