### PR TITLE
Enhanced  Dropbox and Dropboxbusiness /me API testcases

### DIFF
--- a/src/test/elements/dropbox/me.js
+++ b/src/test/elements/dropbox/me.js
@@ -1,0 +1,7 @@
+'use strict';
+
+const suite = require('core/suite');
+
+suite.forElement('documents', 'me', (test) => {
+  test.should.supportS();
+});

--- a/src/test/elements/dropboxbusiness/me.js
+++ b/src/test/elements/dropboxbusiness/me.js
@@ -1,0 +1,9 @@
+'use strict';
+
+const suite = require('core/suite');
+const props = require('core/props');
+
+suite.forElement('documents', 'me', (test) => {
+  let memberId = props.getForKey('dropboxbusiness', 'username');
+  test.withOptions({ headers: { "Elements-As-Team-Member": memberId } }).should.supportS();
+});

--- a/src/test/elements/dropboxbusinessv2/me.js
+++ b/src/test/elements/dropboxbusinessv2/me.js
@@ -1,0 +1,7 @@
+'use strict';
+
+const suite = require('core/suite');
+
+suite.forElement('documents', 'me', (test) => {
+  test.should.supportS();
+});

--- a/src/test/elements/dropboxv2/me.js
+++ b/src/test/elements/dropboxv2/me.js
@@ -1,0 +1,7 @@
+'use strict';
+
+const suite = require('core/suite');
+
+suite.forElement('documents', 'me', (test) => {
+  test.should.supportS();
+});


### PR DESCRIPTION
## Highlights
* Added `GET /me API`  Testcases for Dropbox and DropboxBusiness

## Non-customer Highlights
* Normalized /me api across documentation hub

## Checklist
* [x] applicable churros tests are still passing
* [ ] includes a dbdeploy script that is backward-incompatible with one previous Soba minor version

## Screenshot
<img width="769" alt="screen shot 2018-03-15 at 5 47 45 pm" src="https://user-images.githubusercontent.com/26943831/37501911-62338566-289e-11e8-8a68-07762b05f8da.png">
<img width="735" alt="screen shot 2018-03-15 at 5 52 20 pm" src="https://user-images.githubusercontent.com/26943831/37501913-63e35314-289e-11e8-8a80-8f496769a847.png">


## Related PRs
[Soba](https://github.com/cloud-elements/soba/pull/8286)

## Closes
[Rally](https://rally1.rallydev.com/#/144349237612d/detail/userstory/201677248568)
[Rally](https://rally1.rallydev.com/#/144349237612d/detail/userstory/201677248816)