### PR TITLE
Added test cases for transactions API on BigCommerce

### DIFF
--- a/src/test/elements/bigcommerce/orders.js
+++ b/src/test/elements/bigcommerce/orders.js
@@ -29,7 +29,7 @@ const shipmentsUpdate = () => ({
   "comments": "UpdateThis"
 });
 /*  orders with Sales Tax Calculation set to 'automatic' in Vendor account are not allowed to be deleted
-    Hence skip the tests if Tax calculation = 'automatic' 
+    Hence skip the tests if Tax calculation = 'automatic'
 */
 suite.forElement('ecommerce', 'orders', { payload: payload}, (test) => {
   test.withOptions(options).should.supportCruds();
@@ -88,6 +88,9 @@ suite.forElement('ecommerce', 'orders', { payload: payload}, (test) => {
       .then(r => cloud.get(`${test.api}/${orderId}/shipments/count`))
       //For delete orders to be success ,Sales Tax Calculation should be set to 'manual' in the vendor account
       .then(r => cloud.delete(`${test.api}/${orderId}/shipments/${shipmentId}`));
+  });
+  it('should support CRUDS for orders/{id}/transations', () => {
+    return cloud.get(`${test.api}/${orderId}/transactions`);
   });
   after(() => cloud.delete(`${test.api}/${orderId}`));
 

--- a/src/test/elements/bigcommerce/orders.js
+++ b/src/test/elements/bigcommerce/orders.js
@@ -89,7 +89,7 @@ suite.forElement('ecommerce', 'orders', { payload: payload}, (test) => {
       //For delete orders to be success ,Sales Tax Calculation should be set to 'manual' in the vendor account
       .then(r => cloud.delete(`${test.api}/${orderId}/shipments/${shipmentId}`));
   });
-  it('should support CRUDS for orders/{id}/transations', () => {
+  it('should support search for orders/{id}/transations', () => {
     return cloud.get(`${test.api}/${orderId}/transactions`);
   });
   after(() => cloud.delete(`${test.api}/${orderId}`));


### PR DESCRIPTION
## Non-customer highlights
* Added churros test case for the newly added GET `/orders/{id}/transactions` API on BigCommerce

## Screenshot


(node:3044) [DEP0022] DeprecationWarning: os.tmpDir() is deprecated. Use os.tmpdir() instead.

info: Using url: http://localhost:8080
info: Using user: mithila.garud@gslab.com
info: Using api key: 6eiwidt0hc15od30a1bq7c3lp0uk15m
info: Running tests for element: bigcommerce--custom
info: Provisioned with instance id of 270
(node:3044) [DEP0013] DeprecationWarning: Calling an asynchronous function without callback is deprecated.
  Basic tests
    √ should provision
    √ should GET /objects (154ms)
    - docs
    √ metadata (175ms)
    √ transformations (13195ms)
    - should not allow provisioning with bad credentials

  customers
    √ should allow CRUDS for /hubs/ecommerce/customers (10682ms)
    √ should allow GET for /hubs/ecommerce/customers/count (872ms)
    √ should allow GET for /hubs/ecommerce/customers (778ms)
    √ should allow paginating with page and pageSize for /hubs/ecommerce/customers (2495ms)
    √ should support searching /hubs/ecommerce/customers by email (3309ms)
    √ should allow CRUDS for customer/addresses (8580ms)
    √ should allow CRUDS for customer/groups and then GET customer/groups/count (8301ms)

  orders
    √ should allow CRUDS for /hubs/ecommerce/orders (10404ms)
    √ should allow GET for /hubs/ecommerce/orders (828ms)
    √ should allow GET for /hubs/ecommerce/orders/count (866ms)
    √ should allow GET for /hubs/ecommerce/orders/products/count (803ms)
    √ should allow GET for /hubs/ecommerce/orders/shipments/count (797ms)
    √ should allow SR for /hubs/ecommerce/orders/statuses (1637ms)
    √ should allow paginating with page and pageSize for /hubs/ecommerce/orders (2443ms)
    √ should support searching /hubs/ecommerce/orders by payment_method (8476ms)
    √ should allow SR for orders/addresses (2490ms)
    √ should allow SR for orders/products (3217ms)
    √ should allow S for orders/coupons, orders/comments, and orders/taxes (3403ms)
    √ should support CRUDS for orders/shipments (9806ms)
    √ should support search for orders/{id}/transations (7518ms)

  ping
    √ should allow GET for /hubs/ecommerce/ping (302ms)

  polling
    - polling /hubs/ecommerce/products
    - polling /hubs/ecommerce/customers
    - polling /hubs/ecommerce/orders

  products
    √ should allow CRUDS for /hubs/ecommerce/products (9744ms)
    √ should allow GET for /hubs/ecommerce/products/count (840ms)
    √ should allow GET for /hubs/ecommerce/products/options (828ms)
    √ should allow GET for /hubs/ecommerce/products/options (874ms)
    √ should allow paginating with page and pageSize for /hubs/ecommerce/products (2524ms)
    √ should support searching /hubs/ecommerce/products by name (2669ms)
    √ should support CRUDS for products/brands (6981ms)
    √ should support CRUDS for products/categories (6717ms)
    √ should support CRUDS for products/fields (5008ms)
    √ should support CRUDS for products/images (5406ms)
    - should support CRUDS for products/skus


  35 passing (3m)
  6 pending

## Reference
* [SOBA](https://github.com/cloud-elements/soba/pull/8288)
* [RALLY-#US10055](https://rally1.rallydev.com/#/144349237612d/detail/userstory/203777847324)
* Depenedent on [Churros sauce](https://github.com/cloud-elements/churros-sauce/pull/173)

## Closes
* [#US10055](https://rally1.rallydev.com/#/144349237612d/detail/userstory/203777847324)
