### PR TITLE
Added metadata churros for Bullhorn

### DIFF
--- a/src/test/elements/bullhorn/metadata.js
+++ b/src/test/elements/bullhorn/metadata.js
@@ -1,0 +1,27 @@
+'use strict';
+const suite = require('core/suite');
+const cloud = require('core/cloud');
+const expect = require('chakram').expect;
+var objects = [
+    "candidates",
+    "search",
+    "companies",
+    "notes",
+    "clientContacts",
+    "leads",
+    "placements",
+    "opportunities",
+    "contacts"
+];
+
+objects.forEach(obj => {
+    suite.forElement('crm', `objects/${obj}/metadata`, (test) => {
+        test.should.supportS();
+        test.withApi(test.api)
+            .withOptions({ qs: { customFieldsOnly: true } })
+            .withValidation(r => expect(r.body.fields.filter(field => (field.vendorPath.startsWith("custom") && field.custom === true))))
+            .withName('should support return only custom fields')
+            .should.return200OnGet();
+    });
+
+});

--- a/src/test/elements/bullhorn/metadata.js
+++ b/src/test/elements/bullhorn/metadata.js
@@ -1,6 +1,5 @@
 'use strict';
 const suite = require('core/suite');
-const cloud = require('core/cloud');
 const expect = require('chakram').expect;
 var objects = [
     "candidates",
@@ -23,5 +22,4 @@ objects.forEach(obj => {
             .withName('should support return only custom fields')
             .should.return200OnGet();
     });
-
 });


### PR DESCRIPTION
## Highlights
* Added churros for `objects/{objectName}/metaData`.

## Screenshot
<img width="704" alt="screen shot 2018-03-15 at 9 10 31 pm" src="https://user-images.githubusercontent.com/26589919/37551317-b0d9970a-296b-11e8-90e9-282f57373d13.png">

## Reference
* [8284](https://github.com/cloud-elements/soba/pull/8284)
* [RALLY-#${US10234}](https://rally1.rallydev.com/#/144349237612d/detail/userstory/204671642908)

## Closes
* [US10234](https://rally1.rallydev.com/#/144349237612d/detail/userstory/204671642908)
