### PR TITLE
Test cases for new resource financial-settings on SageOne

### DIFF
--- a/src/test/elements/sageone/assets/financial-settings.json
+++ b/src/test/elements/sageone/assets/financial-settings.json
@@ -1,0 +1,16 @@
+{
+  "financial_settings": {
+    "year_end_date": null,
+    "year_end_lockdown_date": null,
+    "accounts_start_date": null,
+    "base_currency_id" : "USD",
+    "multi_currency_enabled": true,
+    "use_live_exchange_rates": true,
+    "tax_scheme": {
+        "id": "STANDARD",
+        "displayed_as": "Standard",
+        "$path": "/tax_schemes/STANDARD"
+    },
+    "tax_return_frequency": null
+}
+}

--- a/src/test/elements/sageone/financial-settings.js
+++ b/src/test/elements/sageone/financial-settings.js
@@ -1,0 +1,13 @@
+'use strict';
+
+const suite = require('core/suite');
+const expect = require('chakram').expect;
+const cloud = require('core/cloud');
+const updatePayload =  require('./assets/financial-settings');
+
+suite.forElement('finance', 'financial-settings', { payload: updatePayload }, (test) => {
+    it(`should support search and update on ${test.api}`, () => {
+      return cloud.get(`${test.api}`)
+        .then(r => cloud.put(`${test.api}`, updatePayload));
+    });
+});

--- a/src/test/elements/sageone/financial-settings.js
+++ b/src/test/elements/sageone/financial-settings.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const suite = require('core/suite');
-const expect = require('chakram').expect;
 const cloud = require('core/cloud');
 const updatePayload =  require('./assets/financial-settings');
 


### PR DESCRIPTION
## Non-customer Highlights
* Added test cases for new resource `financial-settings` on SageOne
  - `GET /financial-settings`
  - `PUT /financial-settings`

## Screenshot
* Complete report: [SageOne_churros.txt](https://github.com/cloud-elements/churros/files/1828597/SageOne_churros.txt)

![image](https://user-images.githubusercontent.com/20282215/37642404-f9652974-2c42-11e8-99f5-ec967376584d.png)

## Reference
* [SOBA](https://github.com/cloud-elements/soba/pull/8302)
* [RALLY-#US10286](https://rally1.rallydev.com/#/144349237612d/detail/userstory/205610401792)

## Closes
* [#US10286](https://rally1.rallydev.com/#/144349237612d/detail/userstory/205610401792)
