### PR TITLE
Enhanced maximizer with /appointments api Testcases

### DIFF
--- a/src/test/elements/assets/object.definitions.json
+++ b/src/test/elements/assets/object.definitions.json
@@ -26,6 +26,13 @@
       }
     ]
   },
+  "appointments": {
+    "vendorName": "appointments",
+    "fields": [{
+      "path": "id",
+      "vendorPath": "Key"
+    }]
+  },
   "custom-record-types": {
     "fields": [{
         "path": "idTransformed",

--- a/src/test/elements/maximizer/appointments.js
+++ b/src/test/elements/maximizer/appointments.js
@@ -1,0 +1,36 @@
+'use strict';
+
+const suite = require('core/suite');
+const tools = require('core/tools');
+const cloud = require('core/cloud');
+const expect = require('chakram').expect;
+const appointmentPayload = tools.requirePayload(`${__dirname}/assets/appointments.json`);
+
+// Appointment scheduled in one hour from current time
+appointmentPayload.StartDate = new Date(Date.now() + 3600000).toISOString();
+appointmentPayload.EndDate = new Date(Date.now() + 4600000).toISOString();
+
+suite.forElement('crm', 'appointments', { payload : appointmentPayload }, (test) => {
+  let appointmentRespBody;
+  test.should.supportPagination("id");
+
+  before(() =>
+    cloud.post(test.api, appointmentPayload)
+    .then(r => {
+      appointmentRespBody = r.body;
+      appointmentRespBody.Subject = 'ChurrosTestUpdate';
+    })
+    .then(() => cloud.patch(`${test.api}/${appointmentRespBody.id}`, appointmentRespBody)));
+
+  after(() => cloud.delete(`${test.api}/${appointmentRespBody.id}`));
+
+  test.withApi(test.api)
+      .withOptions({ qs: { where: `Subject='${appointmentPayload.Subject}'`, fields: `Subject,StartDate` } })
+      .withValidation(r => {
+         expect(r.body.filter(obj => obj.Subject === appointmentPayload.Subject).length).to.equal(r.body.length);
+         expect(Object.keys(r.body[0]).length).to.equal(2);
+      })
+      .withName('should allow GET with options /appointments')
+      .should.return200OnGet();
+
+});

--- a/src/test/elements/maximizer/assets/appointments.json
+++ b/src/test/elements/maximizer/assets/appointments.json
@@ -1,0 +1,5 @@
+{
+  "StartDate": "2018-03-21T15:00:00Z",
+  "Subject": "ChurrosTest",
+  "EndDate": "2018-03-21T15:00:00Z"
+}

--- a/src/test/elements/maximizer/assets/transformations.json
+++ b/src/test/elements/maximizer/assets/transformations.json
@@ -12,5 +12,12 @@
       "path": "id",
       "vendorPath": "Key"
     }]
+  },
+  "appointments": {
+    "vendorName": "appointments",
+    "fields": [{
+      "path": "id",
+      "vendorPath": "Key"
+    }]
   }
 }


### PR DESCRIPTION
## Non-customer Highlights
* Added /appointments API Testcases for Maximizer

## Checklist
* [x] applicable churros tests are still passing
* [ ] includes a dbdeploy script that is backward-incompatible with one previous Soba minor version

## Screenshot
<img width="1238" alt="screen shot 2018-03-22 at 1 00 47 am" src="https://user-images.githubusercontent.com/26943831/37803944-c9b842b0-2dff-11e8-8ca3-7c98c8e5e7c2.png">

## Related PRs
[Soba](https://github.com/cloud-elements/soba/pull/8328)

## Closes
[Rally](https://rally1.rallydev.com/#/144349237612d/detail/userstory/203863331304)