### PR TITLE
Enhanced Autotask Helpdesk, Finance, CRM and Zoho CRM - Test cases for Discovery API

### DIFF
--- a/src/test/elements/autotaskcrm/metadata.js
+++ b/src/test/elements/autotaskcrm/metadata.js
@@ -4,15 +4,44 @@ const suite = require('core/suite');
 const cloud = require('core/cloud');
 const expect = require('chakram').expect;
 
-suite.forElement('crm', 'objects', (test) => {
+var objects = [
+  "Account",
+  "Task",
+  "Invoice",
+  "Opportunity",
+  "ClientPortalUser",
+  "Resource",
+  "Product",
+  "BillingItem",
+  "Contact",
+  "SalesOrder"
+];
+
+objects.forEach(obj => {
+  suite.forElement('crm', `objects/${obj}/metadata`, (test) => {
+
     const validateAccountType = (fields) => {
-        let isPicklist = false;
-        fields.forEach(field => isPicklist = (field.vendorPath === 'accountType' && field.vendorNativeType === 'picklist' && expect(field).to.contain.key('picklistValues')));
-        return isPicklist;
+      if (expect(fields.filter(field => (field.vendorPath === 'accountType' && field.vendorNativeType === 'picklist' && expect(field).to.contain.key('picklistValues')))).to.not.be.empty)
+        return true;
+      else
+        return false;
     };
 
-    it('should include picklist for account metadata', () => {
-        return cloud.get(test.api + '/Account/metadata')
-            .then(r => validateAccountType(r.body.fields));
-    });
+    test.should.supportS();
+    test.withApi(test.api)
+      .withValidation(r => {
+        expect(r.body.fields.filter(field => (field.custom === false))).to.not.be.empty;
+        if (obj === 'Account') {
+          expect(validateAccountType(r.body.fields)).to.be.true;
+        }
+      })
+      .withName('should support return all fields')
+      .should.return200OnGet();
+
+    test.withApi(test.api)
+      .withOptions({ qs: { customFieldsOnly: true } })
+      .withValidation(r => expect(r.body.fields.filter(field => (field.custom === true))))
+      .withName('should support return only custom fields')
+      .should.return200OnGet();
+  });
 });

--- a/src/test/elements/autotaskcrm/metadata.js
+++ b/src/test/elements/autotaskcrm/metadata.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const suite = require('core/suite');
-const cloud = require('core/cloud');
 const expect = require('chakram').expect;
 
 var objects = [

--- a/src/test/elements/autotaskcrm/metadata.js
+++ b/src/test/elements/autotaskcrm/metadata.js
@@ -30,5 +30,5 @@ suite.forElement('crm', '/objects', (test) => {
              // we cannot guarantee that every object has custom fields ... so here i am checking reverese condition
              .then(r => expect(r.body.fields.filter(field => (field.custom === false))).to.be.empty);
         });
-    }))
+    }));
 });

--- a/src/test/elements/autotaskfinance/metadata.js
+++ b/src/test/elements/autotaskfinance/metadata.js
@@ -29,5 +29,5 @@ suite.forElement('finance', '/objects', (test) => {
              // we cannot guarantee that every object has custom fields ... so here i am checking reverese condition
              .then(r => expect(r.body.fields.filter(field => (field.custom === false))).to.be.empty);
         });
-    }))
+    }));
 });

--- a/src/test/elements/autotaskfinance/metadata.js
+++ b/src/test/elements/autotaskfinance/metadata.js
@@ -1,5 +1,6 @@
 'use strict';
 const suite = require('core/suite');
+const cloud = require('core/cloud');
 const expect = require('chakram').expect;
 var objects = [
   "Quote",
@@ -15,13 +16,18 @@ var objects = [
   "ProductVendor"
 ];
 
-objects.forEach(obj => {
-    suite.forElement('finance', `objects/${obj}/metadata`, (test) => {
-        test.should.supportS();
-        test.withApi(test.api)
-            .withOptions({ qs: { customFieldsOnly: true } })
-            .withValidation(r => expect(r.body.fields.filter(field => (field.custom === true))))
-            .withName('should support return only custom fields')
-            .should.return200OnGet();
-    });
+suite.forElement('finance', '/objects', (test) => {
+    return Promise.all(objects.map(obj => {
+        it(`should support GET /objects/${obj}/metadata`, () => {
+             return cloud.get(`${test.api}/${obj}/metadata`)
+             // we can guarantee that every object has fields ... which holds custom = false
+            .then(r => expect(r.body.fields.filter(field => (field.custom === false))).to.not.be.empty);
+        });
+
+        it(`should support GET /objects/${obj}/metadata customFieldsOnly parameter`, () => {
+             return cloud.withOptions({qs:{customFieldsOnly: true}}).get(`${test.api}/${obj}/metadata`)
+             // we cannot guarantee that every object has custom fields ... so here i am checking reverese condition
+             .then(r => expect(r.body.fields.filter(field => (field.custom === false))).to.be.empty);
+        });
+    }))
 });

--- a/src/test/elements/autotaskfinance/metadata.js
+++ b/src/test/elements/autotaskfinance/metadata.js
@@ -1,0 +1,27 @@
+'use strict';
+const suite = require('core/suite');
+const expect = require('chakram').expect;
+var objects = [
+  "Quote",
+  "Account",
+  "Invoice",
+  "TimeEntry",
+  "TaxCategory",
+  "Product",
+  "PurchaseOrder",
+  "Tax",
+  "BillingItem",
+  "ExpenseReport",
+  "ProductVendor"
+];
+
+objects.forEach(obj => {
+    suite.forElement('finance', `objects/${obj}/metadata`, (test) => {
+        test.should.supportS();
+        test.withApi(test.api)
+            .withOptions({ qs: { customFieldsOnly: true } })
+            .withValidation(r => expect(r.body.fields.filter(field => (field.custom === true))))
+            .withName('should support return only custom fields')
+            .should.return200OnGet();
+    });
+});

--- a/src/test/elements/autotaskhelpdesk/metadata.js
+++ b/src/test/elements/autotaskhelpdesk/metadata.js
@@ -26,5 +26,5 @@ suite.forElement('helpdesk', '/objects', (test) => {
              // we cannot guarantee that every object has custom fields ... so here i am checking reverese condition
              .then(r => expect(r.body.fields.filter(field => (field.custom === false))).to.be.empty);
         });
-    }))
+    }));
 });

--- a/src/test/elements/autotaskhelpdesk/metadata.js
+++ b/src/test/elements/autotaskhelpdesk/metadata.js
@@ -1,5 +1,6 @@
 'use strict';
 const suite = require('core/suite');
+const cloud = require('core/cloud');
 const expect = require('chakram').expect;
 var objects = [
   "Ticket",
@@ -12,13 +13,18 @@ var objects = [
   "Contact"
 ];
 
-objects.forEach(obj => {
-    suite.forElement('helpdesk', `objects/${obj}/metadata`, (test) => {
-        test.should.supportS();
-        test.withApi(test.api)
-            .withOptions({ qs: { customFieldsOnly: true } })
-            .withValidation(r => expect(r.body.fields.filter(field => (field.custom === true))))
-            .withName('should support return only custom fields')
-            .should.return200OnGet();
-    });
+suite.forElement('helpdesk', '/objects', (test) => {
+    return Promise.all(objects.map(obj => {
+        it(`should support GET /objects/${obj}/metadata`, () => {
+             return cloud.get(`${test.api}/${obj}/metadata`)
+             // we can guarantee that every object has fields ... which holds custom = false
+            .then(r => expect(r.body.fields.filter(field => (field.custom === false))).to.not.be.empty);
+        });
+
+        it(`should support GET /objects/${obj}/metadata customFieldsOnly parameter`, () => {
+             return cloud.withOptions({qs:{customFieldsOnly: true}}).get(`${test.api}/${obj}/metadata`)
+             // we cannot guarantee that every object has custom fields ... so here i am checking reverese condition
+             .then(r => expect(r.body.fields.filter(field => (field.custom === false))).to.be.empty);
+        });
+    }))
 });

--- a/src/test/elements/autotaskhelpdesk/metadata.js
+++ b/src/test/elements/autotaskhelpdesk/metadata.js
@@ -1,0 +1,24 @@
+'use strict';
+const suite = require('core/suite');
+const expect = require('chakram').expect;
+var objects = [
+  "Ticket",
+  "TicketNote",
+  "ClientPortalUser",
+  "Resource",
+  "AttachmentInfo",
+  "Contract",
+  "incident_field",
+  "Contact"
+];
+
+objects.forEach(obj => {
+    suite.forElement('helpdesk', `objects/${obj}/metadata`, (test) => {
+        test.should.supportS();
+        test.withApi(test.api)
+            .withOptions({ qs: { customFieldsOnly: true } })
+            .withValidation(r => expect(r.body.fields.filter(field => (field.custom === true))))
+            .withName('should support return only custom fields')
+            .should.return200OnGet();
+    });
+});

--- a/src/test/elements/zohocrm/metadata.js
+++ b/src/test/elements/zohocrm/metadata.js
@@ -28,5 +28,5 @@ suite.forElement('crm', '/objects', (test) => {
              // we cannot guarantee that every object has custom fields ... so here i am checking reverese condition
              .then(r => expect(r.body.fields.filter(field => (field.custom === false))).to.be.empty);
         });
-    }))
+    }));
 });

--- a/src/test/elements/zohocrm/metadata.js
+++ b/src/test/elements/zohocrm/metadata.js
@@ -1,0 +1,26 @@
+'use strict';
+const suite = require('core/suite');
+const expect = require('chakram').expect;
+var objects = [
+  "PriceBooks",
+  "Products",
+  "Potentials",
+  "Tasks",
+  "Contacts",
+  "Events",
+  "Calls",
+  "Leads",
+  "Campaigns",
+  "Accounts"
+];
+
+objects.forEach(obj => {
+    suite.forElement('crm', `objects/${obj}/metadata`, (test) => {
+        test.should.supportS();
+        test.withApi(test.api)
+            .withOptions({ qs: { customFieldsOnly: true } })
+            .withValidation(r => expect(r.body.fields.filter(field => (field.custom === true))))
+            .withName('should support return only custom fields')
+            .should.return200OnGet();
+    });
+});


### PR DESCRIPTION
## Highlights
* Enhanced Testcases for `/objects/{objectName}/metadata API` for Autotask  Helpdesk, Finance , CRM and Zoho CRM to support customFieldsOnly 

## Checklist
* [x] applicable churros tests are still passing
* [ ] includes a dbdeploy script that is backward-incompatible with one previous Soba minor version

## Screenshot
![screen shot 2018-03-23 at 12 53 06 pm](https://user-images.githubusercontent.com/26943831/37860469-c058f8aa-2ef3-11e8-9afe-4f00c8857a1a.png)
![screen shot 2018-03-23 at 12 57 28 pm](https://user-images.githubusercontent.com/26943831/37860470-ca6b108a-2ef3-11e8-9c54-ff53bce44024.png)
<img width="702" alt="screen shot 2018-03-23 at 8 10 33 pm" src="https://user-images.githubusercontent.com/26943831/37860471-cccede74-2ef3-11e8-9e27-f222ae73ff13.png">
![screen shot 2018-03-26 at 4 26 26 pm](https://user-images.githubusercontent.com/26943831/37934152-f2994704-3112-11e8-877d-3e0b8d8283cb.png)


## Related PRs
[Soba](https://github.com/cloud-elements/soba/pull/8340)

## Closes
[Rally](https://rally1.rallydev.com/#/144349237612d/detail/userstory/204382421512)