### PR TITLE
Added metadata API for intacct

### DIFF
--- a/src/test/elements/intacct/metadata.js
+++ b/src/test/elements/intacct/metadata.js
@@ -11,7 +11,7 @@ var objects = [
 ];
 
 objects.forEach(obj => {
-    suite.forElement('finan', `objects/${obj}/metadata`, (test) => {
+    suite.forElement('finance', `objects/${obj}/metadata`, (test) => {
         test.should.supportS();
         test.withApi(test.api)
             .withOptions({ qs: { customFieldsOnly: true } })

--- a/src/test/elements/intacct/metadata.js
+++ b/src/test/elements/intacct/metadata.js
@@ -22,5 +22,5 @@ suite.forElement('finance', '/objects', (test) => {
       then(r => expect(r.body.fields.filter(field => (field.vendorPath.startsWith("custom") &&
         field.custom === true))));
     });
-  }))
+  }));
 });

--- a/src/test/elements/intacct/metadata.js
+++ b/src/test/elements/intacct/metadata.js
@@ -15,6 +15,7 @@ objects.forEach(obj => {
         test.should.supportS();
         test.withApi(test.api)
             .withOptions({ qs: { customFieldsOnly: true } })
+                        .withValidation(r => expect(r.body.fields.filter(field => (field.vendorPath.startsWith("custom") && field.custom === true))))
             .withName('should support return only custom fields')
             .should.return200OnGet();
     });

--- a/src/test/elements/intacct/metadata.js
+++ b/src/test/elements/intacct/metadata.js
@@ -1,6 +1,7 @@
 'use strict';
 const suite = require('core/suite');
 const expect = require('chakram').expect;
+const cloud = require('core/cloud');
 var objects = [
   "chargecardTransactions",
   "billsPayments",
@@ -10,13 +11,16 @@ var objects = [
   "exchangeRateTypes"
 ];
 
-objects.forEach(obj => {
-    suite.forElement('finance', `objects/${obj}/metadata`, (test) => {
-        test.should.supportS();
-        test.withApi(test.api)
-            .withOptions({ qs: { customFieldsOnly: true } })
-                        .withValidation(r => expect(r.body.fields.filter(field => (field.vendorPath.startsWith("custom") && field.custom === true))))
-            .withName('should support return only custom fields')
-            .should.return200OnGet();
+suite.forElement('finance', '/objects', (test) => {
+  return Promise.all(objects.map(obj => {
+    it(`should support GET /objects/${obj}/metadata`, () => {
+      return cloud.get(`${test.api}/${obj}/metadata`);
     });
+
+    it(`should support GET /objects/${obj}/metadata customFieldsOnly parameter`, () => {
+      return cloud.withOptions({ qs: { customFieldsOnly: true } }).get(`${test.api}/${obj}/metadata`).
+      then(r => expect(r.body.fields.filter(field => (field.vendorPath.startsWith("custom") &&
+        field.custom === true))));
+    });
+  }))
 });

--- a/src/test/elements/intacct/metadata.js
+++ b/src/test/elements/intacct/metadata.js
@@ -1,0 +1,21 @@
+'use strict';
+const suite = require('core/suite');
+const expect = require('chakram').expect;
+var objects = [
+  "chargecardTransactions",
+  "billsPayments",
+  "checkingAccounts",
+  "exchangeRateEntries",
+  "exchangeRates",
+  "exchangeRateTypes"
+];
+
+objects.forEach(obj => {
+    suite.forElement('finan', `objects/${obj}/metadata`, (test) => {
+        test.should.supportS();
+        test.withApi(test.api)
+            .withOptions({ qs: { customFieldsOnly: true } })
+            .withName('should support return only custom fields')
+            .should.return200OnGet();
+    });
+});


### PR DESCRIPTION
## Highlights
* Added metadata API for "billsPayments,"checkingAccounts", "CCTRANSACTION" , "EXCHANGERATEENTRY", "EXCHANGERATE","exchangeRateTypes

## Examples
If applicable, please include any images, GIFs, etc. showing up these changes

## Screenshot

```
PS C:\Users\GS-1259\CE-4656\churros\finalch\churros> churros -i 666 test


info: Using url: http://localhost:8080
info: Using user: madhuri.kadam@gslab.com
info: Running tests for element: intacct
info: Provisioned with instance id of 666
error: Failed to create or validate: /instances/666/objects/bills/definit
error: Failed to create or validate: /instances/666/objects/bills/definit
error: Failed to create or validate: /instances/666/transformations/bills
error: Failed to create or validate: /instances/666/transformations/bills
  Basic tests
    √ should provision
    √ should GET /objects (4560ms)
    - docs
    √ metadata (491ms)
    1) transformations
    - should not allow provisioning with bad credentials

  bills-payments
    √ should allow SR for /hubs/finance/bills-payments (7404ms)
    √ should support Ceql date search
    √ should allow paginating with page and nextPage /hubs/finance/bills-

  bills
    √ should allow CRDS for /hubs/finance/bills
    √ should allow paginating with page and pageSize for /hubs/finance/bi
    √ should support updated > {date} Ceql search (5905ms)

  checking-accounts
    √ should allow SR for /hubs/finance/checking-accounts (4473ms)
    √ should allow paginating with page and nextPage /hubs/finance/checki
    √ should support Ceql WHENMODIFIED search (1860ms)

  classes
    √ should allow CRUDS for /hubs/finance/classes (7727ms)
    √ should allow paginating with page and pageSize for /hubs/finance/cl
    √ should support updated > {date} Ceql search (2292ms)

  contacts
    √ should allow CRDS for /hubs/finance/contacts (7706ms)
    √ should allow PATCH for /hubs/finance/contacts/{id} (4421ms)
    √ should allow paginating with page and pageSize for /hubs/finance/co
    √ should support status Ceql search (3644ms)

  customers
    √ should allow CRUDS for /hubs/finance/customers (11865ms)
    √ should allow paginating with page and pageSize for /hubs/finance/cu
    √ should support updated > {date} Ceql search (3691ms)

  departments
    √ should allow CRUDS for /hubs/finance/departments (9378ms)
    √ should allow paginating with page and pageSize for /hubs/finance/de
    √ should support updated > {date} Ceql search (2185ms)

  employees
    √ should allow CRDS for /hubs/finance/employees (10365ms)
    √ should allow PATCH for /hubs/finance/employees/{id} (6416ms)
    √ should allow paginating with page and pageSize for /hubs/finance/em
    √ should support updated > {date} Ceql search (4281ms)

  expense-reports
    √ should allow CRDS for /hubs/finance/expense-reports
    √ should allow PATCH for /hubs/finance/expense-reports/{id}
    √ should allow paginating with page and pageSize for /hubs/finance/ex
    √ should support Ceql batchKey search (1707ms)

  invoices
    √ should allow CRUDS for /hubs/finance/invoices
    √ should allow paginating with page and pageSize for /hubs/finance/in
    √ should support updated > {date} Ceql search (4584ms)

  items
    √ should allow CRUDS for /hubs/finance/items (9805ms)
    √ should allow paginating with page and pageSize for /hubs/finance/it
    √ should support updated > {date} Ceql search (3727ms)

  journals
    √ should allow CRUDS for /hubs/finance/journals (11390ms)
    √ should allow paginating with page and pageSize for /hubs/finance/jo
    √ should support updated > {date} Ceql search (1618ms)

  ledger-accounts
    √ should allow CRUDS for /hubs/finance/ledger-accounts (9924ms)
    √ should allow paginating with page and pageSize for /hubs/finance/le
    √ should support updated > {date} Ceql search (2745ms)

  locations
    √ should allow CRUDS for /hubs/finance/locations (10588ms)
    √ should allow paginating with page and pageSize for /hubs/finance/lo
    √ should support updated > {date} Ceql search (1708ms)

  objects/chargecardTransactions/metadata
    √ should allow S for /hubs/finan/objects/chargecardTransactions/metad
    √ should support return only custom fields (2163ms)

  objects/billsPayments/metadata
    √ should allow S for /hubs/finan/objects/billsPayments/metadata (2101
    √ should support return only custom fields (2089ms)

  objects/checkingAccounts/metadata
    √ should allow S for /hubs/finan/objects/checkingAccounts/metadata (2
    √ should support return only custom fields (2400ms)

  objects/exchangeRateEntries/metadata
    √ should allow S for /hubs/finan/objects/exchangeRateEntries/metadata
    √ should support return only custom fields (1185ms)

  objects/exchangeRates/metadata
    √ should allow S for /hubs/finan/objects/exchangeRates/metadata (2019
    √ should support return only custom fields (1261ms)

  objects/exchangeRateTypes/metadata
    √ should allow S for /hubs/finan/objects/exchangeRateTypes/metadata (
    √ should support return only custom fields (1828ms)

  payments
    - should allow CRS for /hubs/finance/payments
    - should allow paginating with page and pageSize for /hubs/finance/pa
    - should support updated > {date} Ceql search
    - should allow C for /hubs/finance/payments/{id}/apply

  ping
    √ should allow GET for /hubs/finance/ping (229ms)

  polling
    - polling /hubs/finance/customers
    - polling /hubs/finance/employees
    - polling /hubs/finance/invoices
    - polling /hubs/finance/items
    - polling /hubs/finance/journals
    - polling /hubs/finance/ledger-accounts
    - polling /hubs/finance/payments
    - polling /hubs/finance/vendors

  projects
    √ should allow CRUDS for /hubs/finance/projects (11799ms)
    √ should allow paginating with page and pageSize for /hubs/finance/pr
    √ should support updated > {date} Ceql search (2993ms)

  purchase-orders
    - should allow CRDS for /hubs/finance/purchase-orders
    - should allow paginating with page and pageSize for /hubs/finance/pu
    - should support updated > {date} Ceql search

  sales-orders
    √ should allow CRUDS for /hubs/finance/sales-orders
    √ should allow paginating with page and pageSize for /hubs/finance/sa
    √ should support updated > {date} Ceql search (4455ms)

  terms
    √ should allow SR for /hubs/finance/terms (3052ms)
    √ should allow CUD for /hubs/finance/terms (5225ms)
    √ should allow paginating with page and pageSize for /hubs/finance/te
    √ should support updated > {date} Ceql search (2019ms)

  transactions
    - should allow CRDS for /hubs/finance/transactions
    - should allow GET for /hubs/finance/transactions-entries
    - should allow paginating with page and pageSize for /hubs/finance/tr
    - should support updated > {date} Ceql search

  vendors
    √ should allow CRDS for /hubs/finance/vendors (11647ms)
    √ should allow paginating with page and pageSize for /hubs/finance/ve
    √ should support updated > {date} Ceql search (4796ms)
    √ should support paginated search and return less than requested (165

  vouchers
    √ should allow CRDS for /hubs/finance/vouchers
    √ should allow paginating with page and pageSize for /hubs/finance/vo
    √ should support updated > {date} Ceql search (2871ms)

  warehouses
    √ should allow SR for /hubs/finance/warehouses (3386ms)
    √ should allow paginating with page and pageSize for /hubs/finance/wa
    √ should support updated > {date} Ceql search (2241ms)

```

  74 passing (7m)
  21 pending
  0 failing
## Reference
* [SOBA](https://github.com/cloud-elements/soba/pull/8320)
* [churros-sauce](Link to Associated Churros-sauce PR, when applicable)
* [RALLY-#${US10157}](https://rally1.rallydev.com/#/144349237612d/detail/userstory/204383376276)

## Closes
* Closes #${[${US10157}](https://rally1.rallydev.com/#/144349237612d/detail/userstory/204383376276)}
