### PR TITLE
modified churros for magentov20

### DIFF
--- a/src/test/elements/magentov20/categories.js
+++ b/src/test/elements/magentov20/categories.js
@@ -5,6 +5,7 @@ const tools = require('core/tools');
 const cloud = require('core/cloud');
 const expect = require('chakram').expect;
 const payload = tools.requirePayload(`${__dirname}/assets/categories.json`);
+const payload2 = tools.requirePayload(`${__dirname}/assets/categories.json`);
 
 const categoryProduct = (categoryId, position, sku) => ({
   "productLink": {
@@ -20,7 +21,7 @@ const categoryMove = (parentId) => ({
 const product = (attributeSetId) => ({
   "product": {
     "attribute_set_id": attributeSetId,
-    "name": tools.random(),
+    "name": tools.randomStr('abcdefghijklmnopqrstuvwxyz', 10),
     "price": 300,
     "sku": "ce" + tools.randomInt(),
     "status": 1,
@@ -75,7 +76,7 @@ suite.forElement('ecommerce', 'categories', { payload: payload }, (test) => {
   });
   it(`should allow CUDS for /hubs/ecommerce/categories/{id}/products`, () => {
     let position, sku, attributeSetId;
-    return cloud.post(`/hubs/ecommerce/categories`, payload)
+    return cloud.post(`/hubs/ecommerce/categories`, payload2)
       .then(r => categoryId = r.body.id)
       .then(r => cloud.get(`/hubs/ecommerce/categories/${categoryId}`))
       .then(r => position = r.body.position)

--- a/src/test/elements/magentov20/products-attribute-sets.js
+++ b/src/test/elements/magentov20/products-attribute-sets.js
@@ -68,11 +68,11 @@ suite.forElement('ecommerce', 'products-attribute-sets', { payload: productsAttr
   });
   test
     .withName(`should support searching /hubs/ecommerce/products-attribute-sets-groups by attribute_set_id`)
-    .withOptions({ qs: { where: `attribute_set_id=21` } })
+    .withOptions({ qs: { where: `attribute_set_id=15` } })
     .withApi(`/hubs/ecommerce/products-attribute-sets-groups`)
     .withValidation((r) => {
       expect(r).to.have.statusCode(200);
-      const validValues = r.body.filter(obj => obj.attribute_set_id === 21);
+      const validValues = r.body.filter(obj => obj.attribute_set_id === 15);
       expect(validValues.length).to.equal(r.body.length);
     }).should.return200OnGet();
 


### PR DESCRIPTION
## Highlights
 fix churros tests for the following resources
* /hubs/ecommerce/categories/{id}/products
* /hubs/ecommerce/products-attribute-sets-groups

## Checklist
* [X] applicable churros tests are still passing
* [ ] includes a dbdeploy script that is backward-incompatible with one previous Soba minor version


## Screenshot
<img width="1504" alt="screen shot 2018-03-26 at 7 03 22 pm" src="https://user-images.githubusercontent.com/35976783/37939837-c8e3ccc8-312a-11e8-85a7-b56ba1169926.png">
<img width="1249" alt="screen shot 2018-03-26 at 7 03 44 pm" src="https://user-images.githubusercontent.com/35976783/37939839-cbcad8be-312a-11e8-90bf-35390aec3277.png">
<img width="1795" alt="screen shot 2018-03-26 at 7 04 06 pm" src="https://user-images.githubusercontent.com/35976783/37939842-ce5513ba-312a-11e8-82c6-a545a9a56896.png">

## Closes
* [DE1176](https://rally1.rallydev.com/#/144349237612d/detail/defect/207566662640)
