### PR TITLE
Sales Force Service Cloud Model Payloads

### DIFF
--- a/src/test/elements/sfdcservicecloud/assets/models_activities_post.json
+++ b/src/test/elements/sfdcservicecloud/assets/models_activities_post.json
@@ -1,0 +1,22 @@
+{
+  "DurationInMinutes": 23,
+  "ActivityDateTime": "2018-03-16T08:00:00.000+0000",
+  "attributes": {
+    "type": "string",
+    "url": "string"
+  },
+  "Description": "string",
+  "EventSubtype": "Event",
+  "IsAllDayEvent": false,
+  "IsPrivate": false,
+  "IsReminderSet": true,
+  "Location": "string",
+  "RecurrenceInterval": null,
+  "ReminderDateTime": "2018-03-16T07:00:00.000+0000",
+  "ShowAs": "Busy",
+  "StartDateTime": "2018-03-16T08:00:00.000+0000",
+  "Subject": "string",
+  "WhatId": "5000H000013a1UPQAY",
+  "WhoId": "0030H00004ucHpdQAE"
+}
+

--- a/src/test/elements/sfdcservicecloud/assets/models_contacts_post.json
+++ b/src/test/elements/sfdcservicecloud/assets/models_contacts_post.json
@@ -1,0 +1,42 @@
+{
+  "AccountId": "0010H00002IqSxqQAF",
+  "AssistantName": "appcond37rplczl6bwmc4k7qfr",
+  "AssistantPhone": "8004633339",
+  "attributes": {
+    "type": "appcon2e6moq1iinhftswwb3xr",
+    "url": "http://www.maoyeqhshuhbrnewmi.com"
+  },
+  "Birthdate": "2018-03-14T11:57:23.482Z",
+  "Department": "appcona3qg4yquaoz5bwrpy14i",
+  "Description": "appconzu25dlg5kzhgm3nv1jor",
+  "Email": "77v1fedv605mdjclo8qwipb9@in.ibm.com",
+  "EmailBouncedDate": "2017-12-11T23:11:00.000+0000",
+  "EmailBouncedReason": "Insufficient Balance maintained",
+  "Fax": "8004633339",
+  "FirstName": "appconxa1r46o4xjq1v3paatt9",
+  "HasOptedOutOfEmail": true,
+  "HomePhone": "8004633339",
+  "LastName": "appconm0dfjil5jwyisru23xr",
+  "LeadSource": "appconfb9aym21morjadsll3di",
+  "MailingCity": "appcongfar8k7mhruwvhiqhyqfr",
+  "MailingCountry": "appcon66jjo8ntmn823385s714i",
+  "MailingLatitude": 70.443,
+  "MailingLongitude": 72.9312,
+  "MailingPostalCode": "411045",
+  "MailingState": "appconqxrcn6kutybl5w6hcl3di",
+  "MailingStreet": "appcon2aoxb7asdcugil7j02j4i",
+  "MobilePhone": "8004633339",
+  "OtherCity": "appcon1ogfldix125kz060f6r",
+  "OtherCountry": "appconowdxis3wgryr3wdp74x6r",
+  "OtherLatitude": -88.22,
+  "OtherLongitude": -36.12,
+  "OtherPhone": "8004633339",
+  "OtherPostalCode": "411045",
+  "OtherState": "appconn4on7gbntjixzih8semi",
+  "OtherStreet": "appcon7ybabap2pbzlkvpzm2t9",
+  "OwnerId": "005i0000001VNdeAAG",
+  "Phone": "8004633339",
+  "Title": "appcon0txhmon32qln87tit3xr"
+}
+
+

--- a/src/test/elements/sfdcservicecloud/assets/models_incidents_post.json
+++ b/src/test/elements/sfdcservicecloud/assets/models_incidents_post.json
@@ -1,0 +1,22 @@
+{
+    "AccountId": "0010H00002IqSxqQAF",
+    "attributes": {
+        "type": "attribute_type_1",
+        "url": "www.ven-test.com"
+    },
+    "ContactId": "0030H00004rpk55QAA",
+    "Description": "string",
+    "IsEscalated": false,
+    "Origin": "Email",
+    "OwnerId": "005i0000001VNdeAAG",
+    "ParentId": "",
+    "Priority": "Normal1234",
+    "Reason": "ven-test-model-payload",
+    "Status": "New123",
+    "Subject": "ven-test-subject",
+    "SuppliedCompany": "ven-test-company",
+    "SuppliedEmail": "info@salesforce.com",
+    "SuppliedName": "ven-test1442",
+    "SuppliedPhone": "5785089",
+    "Type": "Feature564"
+}

--- a/src/test/elements/sfdcservicecloud/assets/models_task_post.json
+++ b/src/test/elements/sfdcservicecloud/assets/models_task_post.json
@@ -1,0 +1,17 @@
+{
+  "CallDisposition": "string",
+  "CallDurationInSeconds": 0,
+  "CallObject": "string",
+  "CallType": "Inbound",
+  "Description": "string",
+  "IsReminderSet": true,
+  "Priority": "Normal",
+  "Status": "Not Started",
+  "Subject": "string",
+  "TaskSubtype": "Task",
+  "IsRecurrence": true,
+  "RecurrenceStartDateOnly": "2018-03-14T11:57:23.482Z",
+  "RecurrenceType": "RecursEveryWeekday",
+  "RecurrenceDayOfWeekMask": 2,
+  "RecurrenceEndDateOnly": "2018-05-14T11:57:23.482Z"
+}


### PR DESCRIPTION
## Highlights
Added SFDC Service Cloud model Payloads for:
     - `Contacts` 
                         (sub-resource - Tasks, Events)
     - `Incidents` mapped to `Case` on vendor Side
                         (sub-resource - Tasks, Events)<br/><br/>

Note: Payloads for Tasks, Events in both `Contacts` and `Incidents` is the same. Thus they have been name as *models_task_post* and *models_activities_post* respectively.

## Reference
* [SOBA_model_PR](https://github.com/cloud-elements/soba/pull/8253)

