### PR TITLE
QBO: Added test case for PATCH /payments/{id}/void API

### DIFF
--- a/src/test/elements/quickbooks/payments.js
+++ b/src/test/elements/quickbooks/payments.js
@@ -19,7 +19,12 @@ suite.forElement('finance', 'payments', { payload: payload }, (test) => {
       .then(r => {
         if (Id)
           return cloud.get(`${test.api}/${Id}`);
-      });
+      })
+	  .then(r=> {
+		  if(Id)
+			  return 
+	  })
+	  ;
   });
   //Need to skip as there is no delete API
   test.withOptions({ skip: true }).should.supportCrus();
@@ -32,5 +37,21 @@ suite.forElement('finance', 'payments', { payload: payload }, (test) => {
       expect(validValues.length).to.equal(r.body.length);
       expect(r.response.headers['elements-total-count']).to.exist;
     }).should.return200OnGet();
-
+  	
+  it('should allow Patch for hubs/finance/payments/{id}/void', () => {
+    let Id;
+    return cloud.get(`${test.api}`)
+      .then(r => {
+        if (r.body && r.body.length > 0) {
+          Id = r.body[0].id;
+        }
+      })
+	  .then(r=> {
+		  if(Id)
+			  return cloud.patch(`${test.api}/${Id}/void`)
+				.then(r=>{
+					expect(r.body.privateNote).to.contain('Voided');
+				});
+	  });
+  });
 });


### PR DESCRIPTION
## Highlights
* Added test cases for PATCH `/payments/{id}/void` API

## Screenshot
```
PS C:\Users\gs-1108\Documents\GitHub\churros> churros test elements/quickbooks

(node:16248) [DEP0022] DeprecationWarning: os.tmpDir() is deprecated. Use os.tmpdir() instead.

info: Using url: http://localhost:8080
info: Using user: pore@gslab.com
info: Using oauth username: quickbooks@cloud-elements.com
info: Using api key: qyprdxLrqNbUbzaIRo3AsvwE9bPwHO
info: Running tests for element: quickbooks
info: Provisioned with instance id of 416
  Basic tests
(node:16248) [DEP0013] DeprecationWarning: Calling an asynchronous function without callback is deprecated.
    √ should provision
    √ should GET /objects (5329ms)
    - docs
    √ metadata (261ms)
error: Failed to delete /instances/416/transformations
error: Failed to delete /instances/416/transformations
    √ transformations (9871ms)
    - should not allow provisioning with bad credentials

  bill-payments
    √ should allow CRDS for /hubs/finance/bill-payments (33643ms)
    √ should allow GET for /hubs/finance/bill-payments (3116ms)
    √ Test for search on totalAmt and returnCount in response (5052ms)

  bills
    √ should allow CRUDS for /hubs/finance/bills (34642ms)
    √ should allow GET for /hubs/finance/bills (2698ms)
    √ Test for search by totalAmt and returnCount in response (4035ms)

  budgets
    √ should allow SR for /hubs/finance/budgets (7338ms)
    √ should allow paginating with page and pageSize for /hubs/finance/budgets (10401ms)
    √ should allow GET with option active (4684ms)

  classes
    √ should allow SR for /hubs/finance/classes (5972ms)
    √ Test for search on id and returnCount in response (4756ms)

  credit-memos
    √ should allow CRUDS for /hubs/finance/credit-memos (34330ms)
    √ should allow GET for /hubs/finance/credit-memos (3339ms)
    √ Test for search on totalAmt and returnCount in response (4486ms)

  credit-terms
    √ should allow SR for /hubs/finance/credit-terms (8715ms)
    - should allow POST for /hubs/finance/credit-terms
    √ should allow GET for /hubs/finance/credit-terms (3036ms)
    √ should support searching /hubs/finance/credit-terms by Id and returnCount in response (5386ms)

  currencies
    √ should allow CRUDS for /hubs/finance/currencies (24668ms)
    √ should allow paginating with page and pageSize for /hubs/finance/currencies (12694ms)
    √ should support searching /hubs/finance/currencies by code (11666ms)

  customers-search
    √ should test newly added account resource customers-search (12264ms)

  customers
    √ should allow CRUDS for /hubs/finance/customers (28025ms)
    √ Test for pagination and returnCount in response (4651ms)
    √ should support searching /hubs/finance/customers by familyName (9322ms)
    √ should support CEQL style boolean queries with single quotes (16053ms)
    √ should support native style boolean queries without single quotes (11655ms)

  departments
    √ should allow CRUDS for /hubs/finance/departments (18323ms)
    √ Test for returnCount in response (4346ms)
    √ should support searching /hubs/finance/departments by name (10224ms)

  deposits
    √ should allow CRUDS for /hubs/finance/deposits (25002ms)
    √ should allow paginating with page and pageSize for /hubs/finance/deposits (10119ms)
    √ should support searching /hubs/finance/deposits by txnDate (16556ms)

  employees
    √ should allow CRUDS for /hubs/finance/employees (24805ms)
    √ Test for returnCount in response (4967ms)
    √ should support searching /hubs/finance/employees by displayName (11701ms)

  estimates
    √ should allow CRDS for /hubs/finance/estimates (28866ms)
    √ should allow paginating with page and pageSize for /hubs/finance/estimates (15558ms)
    √ Test for search on totalAmt and returnCount in response (5083ms)
    √ should allow pdf download for /estimates (14003ms)

  invoices
    √ should allow CRUDS for /hubs/finance/invoices (56314ms)
    √ should allow paginating with page and pageSize for /hubs/finance/invoices (11814ms)
    √ Test for search on totalAmt and returnCount in response (4715ms)
    √ should allow pdf download for /invoices (18829ms)

  journal-entries
    √ should allow CRUDS for /hubs/finance/journal-entries (26436ms)
    √ should allow GET for /hubs/finance/journal-entries (3050ms)
    √ should support searching /hubs/finance/journal-entries by Id and returnCount in response (4632ms)

  ledger-accounts
    √ should allow SR for /hubs/finance/ledger-accounts (9237ms)
    - should allow POST for /hubs/finance/ledger-accounts
    √ should allow GET for /hubs/finance/ledger-accounts (2761ms)
    √ should support searching /hubs/finance/ledger-accounts by Id and returnCount in response (4831ms)

  payment-methods
    √ should allow SR for /hubs/finance/payment-methods (8951ms)
    - should allow POST for /hubs/finance/payment-methods
    √ should allow GET for /hubs/finance/payment-methods (2846ms)
    √ should support searching /hubs/finance/payment-methods by Id and returnCount in response (5235ms)

  payments
    √ should allow S for /hubs/finance/payments (12924ms)
    √ should allow GET for hubs/finance/payments/{id} (19571ms)
    - should allow CRUS for /hubs/finance/payments
    √ should allow GET for /hubs/finance/payments (3631ms)
    √ should support searching /hubs/finance/payments by Id and returnCount in response (3906ms)
    √ should allow Patch for hubs/finance/payments/{id}/void (12954ms)

  ping
    √ should allow GET for /hubs/finance/ping (1301ms)

  polling
    - polling /hubs/finance/bill-payments
    - polling /hubs/finance/bills
    - polling /hubs/finance/credit-memos
    - polling /hubs/finance/credit-terms
    - polling /hubs/finance/customers
    - polling /hubs/finance/employees
    - polling /hubs/finance/invoices
    - polling /hubs/finance/journal-entries
    - polling /hubs/finance/ledger-accounts
    - polling /hubs/finance/payment-methods
    - polling /hubs/finance/payments
    - polling /hubs/finance/products
    - polling /hubs/finance/purchase-orders
    - polling /hubs/finance/sales-receipts
    - polling /hubs/finance/time-activities
    - polling /hubs/finance/vendor-credits
    - polling /hubs/finance/vendor

  preferences
    √ should allow paginating with page and pageSize for /hubs/finance/preferences (15303ms)
    √ should allow Patch for preferences (5351ms)

  products
    √ should allow CRUDS for /hubs/finance/products (20689ms)
    √ should allow GET for /hubs/finance/products (3480ms)
    √ Test for search on type and returnCount in response (5178ms)

  purchase-orders
    √ should allow CRUDS for /hubs/finance/purchase-orders (26164ms)
    √ should allow GET for /hubs/finance/purchase-orders (3355ms)
    √ should allow GET for /hubs/finance/purchase-orders (2993ms)
    √ should support searching /hubs/finance/purchase-orders by Id (4520ms)

  purchases
    √ should allow CRUDS for /hubs/finance/purchases (50602ms)
    √ Test for returnCount in headers (7102ms)
    √ should support searching /hubs/finance/purchases by docNumber (13578ms)

  refund-receipts
    - should allow CRUDS for /hubs/finance/refund-receipts
    √ should allow SR for /hubs/finance/refund-receipts (7155ms)
    √ should allow GET for /hubs/finance/refund-receipts (3713ms)
    √ should support searching /hubs/finance/refund-receipts by Id and returnCount in response (4936ms)

  reports
    √ should shupport GET /reports/meatadata and GET /reoprts/:id (6357ms)

  sales-receipts
    √ should allow GET for /hubs/finance/sales-receipts (3300ms)
    √ should support searching /hubs/finance/sales-receipts by Id and returnCount in response (6370ms)

  tax-agencies
    √ should allow SR for /hubs/finance/tax-agencies (7995ms)
    - should allow POST for /hubs/finance/tax-agencies
    √ should support searching /hubs/finance/tax-agencies by Id (4598ms)

  tax-codes
    √ should allow paginating with page and pageSize for /hubs/finance/tax-codes (9264ms)
    √ should allow S for /hubs/finance/tax-codes (3431ms)
    √ should support searching /hubs/finance/tax-codes by Id and returnCount in response (4695ms)

  tax-rates
    √ should allow SR for /hubs/finance/tax-rates (10888ms)
    √ should support searching /hubs/finance/tax-rates by Id and returnCount in response (4686ms)

  tax-service
    - should support create tax-service

  time-activities
    √ should allow CRUDS for /hubs/finance/time-activities (28067ms)
    √ should allow GET for /hubs/finance/time-activities (2962ms)
    √ should support searching /hubs/finance/time-activities by Id and returnCount in response (4551ms)

  transfers
    √ should allow CRUDS for /hubs/finance/transfers (21414ms)
    √ should allow paginating with page and pageSize for /hubs/finance/transfers (10833ms)
    √ should support searching /hubs/finance/transfers by txnDate (13490ms)

  vendor-credits
    √ should allow CRUDS for /hubs/finance/vendor-credits (27991ms)
    √ should allow GET for /hubs/finance/vendor-credits (4333ms)
    √ should allow GET for /hubs/finance/vendor-credits (3012ms)
    √ should support searching /hubs/finance/vendor-credits by Id and returnCount in response (8220ms)

  vendor
    √ should allow CRUDS for /hubs/finance/vendor (22692ms)
    √ should allow GET for /hubs/finance/vendor (3462ms)
    √ Test for search on id and returnCount in response (4851ms)


  100 passing (20m)
  26 pending

```
## Reference
* [SOBA](Link to SOBA or Other PR for which tests were written, when applicable)
* [RALLY-#${US10500}](https://rally1.rallydev.com/#/144349237612d/detail/userstory/207347384528)

## Closes
* [US10500](https://rally1.rallydev.com/#/144349237612d/detail/userstory/207347384528)
