### PR TITLE
Marketo : Added new APIs for Custom-objects 

### DIFF
--- a/src/test/elements/marketo/assets/custom-objects.json
+++ b/src/test/elements/marketo/assets/custom-objects.json
@@ -1,0 +1,7 @@
+{
+  "input": [
+    {
+      "dedupeFieldafrin": "<<name.firstName>>"
+    }
+  ]
+}

--- a/src/test/elements/marketo/custom-objects.js
+++ b/src/test/elements/marketo/custom-objects.js
@@ -7,40 +7,38 @@ const expect = require('chakram').expect;
 const payload = tools.requirePayload(`${__dirname}/assets/custom-objects.json`);
 
 suite.forElement('marketing', 'custom-objects', { payload: payload }, (test) => {
- 
-  let customObjectName = 'afrinCustom_c', id;
-  it('should allow R for /custom-objects', () => {
-	 const options = { qs: {   where: `names='leadActivities_c'`} };
-	 return cloud.withOptions(options).get(test.api);
-  });
-  it('should allow S for /custom-objects{customObjectName}/custom-fields', () =>{
-	 const options = { qs: { where: `marketoGUID='c244523c-0a21-4c56-aa71-a845af615d4c,dab80af7-849f-47da-97af-cb3160867892, a3305990-a7e6-46f4-9a5b-9f81ae5db16c'`} };
-	 return cloud.withOptions(options).get(`${test.api}/${customObjectName}/custom-fields`);
-  });
-  it('should allow paginating with page and nextPage /custom-objects{customObjectName}/custom-fields', () => {
-     const options = { qs: { pageSize: 1 ,  where: `marketoGUID='c244523c-0a21-4c56-aa71-a845af615d4c,dab80af7-849f-47da-97af-cb3160867892'`} };
-     return cloud.withOptions(options).get(`${test.api}/${customObjectName}/custom-fields`)
-      .then(r => {
-       expect(r.body).to.not.be.null;
-       options.qs.nextPage = r.response.headers['elements-next-page-token'];
-       return cloud.withOptions(options).get(`${test.api}/${customObjectName}/custom-fields`);
-     });
-  });
-  it('should allow CRUD for /custom-objects/{customObjectName}/custom-fields', () =>{
-     const updatePayload = () => ({
-        "input" : [{
-	    "afrinchaks" : tools.random()
-      }]
-     });
-	 return cloud.post(`${test.api}/${customObjectName}/custom-fields`, payload)
-	  .then(r => id = r.body[0].marketoGUID)
-	  .then(r => cloud.get(`${test.api}/${customObjectName}/custom-fields/${id}`))
-	  .then(r => cloud.patch(`${test.api}/${customObjectName}/custom-fields/${id}`, updatePayload()))
-	  .then(r => cloud.delete(`${test.api}/${customObjectName}/custom-fields/${id}`));
-  });
-  it('should allow R for /custom-fields-templates', () =>{
-	 return cloud.get(`${test.api}/${customObjectName}/custom-fields-templates`);
-  });
+	let customObjectName = 'afrinCustom_c', id;
+	it('should allow R for /custom-objects', () => {
+		const options = { qs: {   where: `names='leadActivities_c'`} };
+		return cloud.withOptions(options).get(test.api);
+	});
+	it('should allow S for /custom-objects{customObjectName}/custom-fields', () =>{
+		const options = { qs: { where: `marketoGUID='c244523c-0a21-4c56-aa71-a845af615d4c,dab80af7-849f-47da-97af-cb3160867892, a3305990-a7e6-46f4-9a5b-9f81ae5db16c'`} };
+		return cloud.withOptions(options).get(`${test.api}/${customObjectName}/custom-fields`);	
+	});
+	it('should allow paginating with page and nextPage /custom-objects{customObjectName}/custom-fields', () => {
+		const options = { qs: { pageSize: 1 ,  where: `marketoGUID='c244523c-0a21-4c56-aa71-a845af615d4c,dab80af7-849f-47da-97af-cb3160867892'`} };
+		return cloud.withOptions(options).get(`${test.api}/${customObjectName}/custom-fields`)
+		.then(r => {
+			expect(r.body).to.not.be.null;
+			options.qs.nextPage = r.response.headers['elements-next-page-token'];
+			return cloud.withOptions(options).get(`${test.api}/${customObjectName}/custom-fields`);
+		});
+	});
+	it('should allow CRUD for /custom-objects/{customObjectName}/custom-fields', () =>{
+		const updatePayload = () => ({
+			"input" : [{
+			"afrinchaks" : tools.random()
+			}]
+		});
+
+		return cloud.post(`${test.api}/${customObjectName}/custom-fields`, payload)
+		.then(r => id = r.body[0].marketoGUID)
+		.then(r => cloud.get(`${test.api}/${customObjectName}/custom-fields/${id}`))
+		.then(r => cloud.patch(`${test.api}/${customObjectName}/custom-fields/${id}`, updatePayload()))
+		.then(r => cloud.delete(`${test.api}/${customObjectName}/custom-fields/${id}`));
+	});
+	it('should allow R for /custom-fields-templates', () =>{
+		return cloud.get(`${test.api}/${customObjectName}/custom-fields-templates`);
+	});
 });
-
-

--- a/src/test/elements/marketo/custom-objects.js
+++ b/src/test/elements/marketo/custom-objects.js
@@ -7,10 +7,9 @@ const expect = require('chakram').expect;
 const payload = tools.requirePayload(`${__dirname}/assets/custom-objects.json`);
 
 suite.forElement('marketing', 'custom-objects', { payload: payload }, (test) => {
-	let customObjectName, id;
+  let customObjectName = 'afrinCustom_c', id;
   it('should allow R for /custom-objects, /custom-fields-templates and CRUD for /custom-objects{customObjectName}/custom-fields', () => {
     return cloud.get(test.api)
-	.then(r => customObjectName = 'afrinCustom_c')
 	.then(r => cloud.get(`${test.api}/${customObjectName}/custom-fields-templates`))
 	.then(r => cloud.post(`${test.api}/${customObjectName}/custom-fields`, payload))
 	.then(r => id = r.body[0].marketoGUID)

--- a/src/test/elements/marketo/custom-objects.js
+++ b/src/test/elements/marketo/custom-objects.js
@@ -12,11 +12,11 @@ suite.forElement('marketing', 'custom-objects', { payload: payload }, (test) => 
 		const options = { qs: {   where: `names='leadActivities_c'`} };
 		return cloud.withOptions(options).get(test.api);
 	});
-	it('should allow S for /custom-objects{customObjectName}/custom-fields', () =>{
+	it('should allow S for /custom-objects/{customObjectName}/custom-fields', () =>{
 		const options = { qs: { where: `marketoGUID='c244523c-0a21-4c56-aa71-a845af615d4c,dab80af7-849f-47da-97af-cb3160867892, a3305990-a7e6-46f4-9a5b-9f81ae5db16c'`} };
 		return cloud.withOptions(options).get(`${test.api}/${customObjectName}/custom-fields`);	
 	});
-	it('should allow paginating with page and nextPage /custom-objects{customObjectName}/custom-fields', () => {
+	it('should allow paginating with page and nextPage /custom-objects/{customObjectName}/custom-fields', () => {
 		const options = { qs: { pageSize: 1 ,  where: `marketoGUID='c244523c-0a21-4c56-aa71-a845af615d4c,dab80af7-849f-47da-97af-cb3160867892'`} };
 		return cloud.withOptions(options).get(`${test.api}/${customObjectName}/custom-fields`)
 		.then(r => {

--- a/src/test/elements/marketo/custom-objects.js
+++ b/src/test/elements/marketo/custom-objects.js
@@ -21,9 +21,11 @@ suite.forElement('marketing', 'custom-objects', { payload: payload }, (test) => 
 		return cloud.withOptions(options).get(`${test.api}/${customObjectName}/custom-fields`)
 		.then(r => {
 			expect(r.body).to.not.be.null;
+			id = r.body[0].marketoGUID;
 			options.qs.nextPage = r.response.headers['elements-next-page-token'];
-			return cloud.withOptions(options).get(`${test.api}/${customObjectName}/custom-fields`);
-		});
+		})
+		.then(r => cloud.withOptions(options).get(`${test.api}/${customObjectName}/custom-fields`))
+		.then(r => expect(r.body[0].marketoGUID).to.not.be.equal(id));
 	});
 	it('should allow CRUD for /custom-objects/{customObjectName}/custom-fields', () =>{
 		const updatePayload = () => ({

--- a/src/test/elements/marketo/custom-objects.js
+++ b/src/test/elements/marketo/custom-objects.js
@@ -10,27 +10,27 @@ suite.forElement('marketing', 'custom-objects', { payload: payload }, (test) => 
  
   let customObjectName = 'afrinCustom_c', id;
   it('should allow R for /custom-objects', () => {
-	  const options = { qs: {   where: `names='leadActivities_c'`} };
-	  return cloud.withOptions(options).get(test.api);
+	 const options = { qs: {   where: `names='leadActivities_c'`} };
+	 return cloud.withOptions(options).get(test.api);
   });
   it('should allow S for /custom-objects{customObjectName}/custom-fields', () =>{
-	  const options = { qs: { where: `marketoGUID='c244523c-0a21-4c56-aa71-a845af615d4c,dab80af7-849f-47da-97af-cb3160867892, a3305990-a7e6-46f4-9a5b-9f81ae5db16c'`} };
-	  return cloud.withOptions(options).get(`${test.api}/${customObjectName}/custom-fields`);
+	 const options = { qs: { where: `marketoGUID='c244523c-0a21-4c56-aa71-a845af615d4c,dab80af7-849f-47da-97af-cb3160867892, a3305990-a7e6-46f4-9a5b-9f81ae5db16c'`} };
+	 return cloud.withOptions(options).get(`${test.api}/${customObjectName}/custom-fields`);
   });
   it('should allow paginating with page and nextPage /custom-objects{customObjectName}/custom-fields', () => {
      const options = { qs: { pageSize: 1 ,  where: `marketoGUID='c244523c-0a21-4c56-aa71-a845af615d4c,dab80af7-849f-47da-97af-cb3160867892'`} };
      return cloud.withOptions(options).get(`${test.api}/${customObjectName}/custom-fields`)
       .then(r => {
-        expect(r.body).to.not.be.null;
-        options.qs.nextPage = r.response.headers['elements-next-page-token'];
-        return cloud.withOptions(options).get(`${test.api}/${customObjectName}/custom-fields`);
-      });
+       expect(r.body).to.not.be.null;
+       options.qs.nextPage = r.response.headers['elements-next-page-token'];
+       return cloud.withOptions(options).get(`${test.api}/${customObjectName}/custom-fields`);
+     });
   });
   it('should allow CRUD for /custom-objects/{customObjectName}/custom-fields', () =>{
      const updatePayload = () => ({
         "input" : [{
 	    "afrinchaks" : tools.random()
-       }]
+      }]
      });
 	 return cloud.post(`${test.api}/${customObjectName}/custom-fields`, payload)
 	  .then(r => id = r.body[0].marketoGUID)
@@ -39,7 +39,7 @@ suite.forElement('marketing', 'custom-objects', { payload: payload }, (test) => 
 	  .then(r => cloud.delete(`${test.api}/${customObjectName}/custom-fields/${id}`));
   });
   it('should allow R for /custom-fields-templates', () =>{
-	  return cloud.get(`${test.api}/${customObjectName}/custom-fields-templates`);
+	 return cloud.get(`${test.api}/${customObjectName}/custom-fields-templates`);
   });
 });
 

--- a/src/test/elements/marketo/custom-objects.js
+++ b/src/test/elements/marketo/custom-objects.js
@@ -7,23 +7,40 @@ const expect = require('chakram').expect;
 const payload = tools.requirePayload(`${__dirname}/assets/custom-objects.json`);
 
 suite.forElement('marketing', 'custom-objects', { payload: payload }, (test) => {
+ 
   let customObjectName = 'afrinCustom_c', id;
-  it('should allow R for /custom-objects, /custom-fields-templates and CRUD for /custom-objects{customObjectName}/custom-fields', () => {
-    return cloud.get(test.api)
-	.then(r => cloud.get(`${test.api}/${customObjectName}/custom-fields-templates`))
-	.then(r => cloud.post(`${test.api}/${customObjectName}/custom-fields`, payload))
-	.then(r => id = r.body[0].marketoGUID)
-	.then(r => cloud.patch(`${test.api}/${customObjectName}/custom-fields/${id}`, payload))
-	.then(r => cloud.delete(`${test.api}/${customObjectName}/custom-fields/${id}`));
+  it('should allow R for /custom-objects', () => {
+	  const options = { qs: {   where: `names='leadActivities_c'`} };
+	  return cloud.withOptions(options).get(test.api);
   });
-  
-  it('should allow S and cursor pagination for /custom-objects{customObjectName}/custom-fields', () => {
-    const options = { qs: { pageSize: 2 ,  where: `marketoGUID='c244523c-0a21-4c56-aa71-a845af615d4c,dab80af7-849f-47da-97af-cb3160867892, a3305990-a7e6-46f4-9a5b-9f81ae5db16c'`} };
-    return cloud.withOptions(options).get(`${test.api}/${customObjectName}/custom-fields`)
+  it('should allow S for /custom-objects{customObjectName}/custom-fields', () =>{
+	  const options = { qs: { where: `marketoGUID='c244523c-0a21-4c56-aa71-a845af615d4c,dab80af7-849f-47da-97af-cb3160867892, a3305990-a7e6-46f4-9a5b-9f81ae5db16c'`} };
+	  return cloud.withOptions(options).get(`${test.api}/${customObjectName}/custom-fields`);
+  });
+  it('should allow paginating with page and nextPage /custom-objects{customObjectName}/custom-fields', () => {
+     const options = { qs: { pageSize: 1 ,  where: `marketoGUID='c244523c-0a21-4c56-aa71-a845af615d4c,dab80af7-849f-47da-97af-cb3160867892'`} };
+     return cloud.withOptions(options).get(`${test.api}/${customObjectName}/custom-fields`)
       .then(r => {
         expect(r.body).to.not.be.null;
         options.qs.nextPage = r.response.headers['elements-next-page-token'];
         return cloud.withOptions(options).get(`${test.api}/${customObjectName}/custom-fields`);
       });
   });
+  it('should allow CRUD for /custom-objects/{customObjectName}/custom-fields', () =>{
+     const updatePayload = () => ({
+        "input" : [{
+	    "afrinchaks" : tools.random()
+       }]
+     });
+	 return cloud.post(`${test.api}/${customObjectName}/custom-fields`, payload)
+	  .then(r => id = r.body[0].marketoGUID)
+	  .then(r => cloud.get(`${test.api}/${customObjectName}/custom-fields/${id}`))
+	  .then(r => cloud.patch(`${test.api}/${customObjectName}/custom-fields/${id}`, updatePayload()))
+	  .then(r => cloud.delete(`${test.api}/${customObjectName}/custom-fields/${id}`));
+  });
+  it('should allow R for /custom-fields-templates', () =>{
+	  return cloud.get(`${test.api}/${customObjectName}/custom-fields-templates`);
+  });
 });
+
+

--- a/src/test/elements/marketo/custom-objects.js
+++ b/src/test/elements/marketo/custom-objects.js
@@ -1,0 +1,30 @@
+'use strict';
+
+const suite = require('core/suite');
+const tools = require('core/tools');
+const cloud = require('core/cloud');
+const expect = require('chakram').expect;
+const payload = tools.requirePayload(`${__dirname}/assets/custom-objects.json`);
+
+suite.forElement('marketing', 'custom-objects', { payload: payload }, (test) => {
+	let customObjectName, id;
+  it('should allow R for /custom-objects, /custom-fields-templates and CRUD for /custom-objects{customObjectName}/custom-fields', () => {
+    return cloud.get(test.api)
+	.then(r => customObjectName = 'afrinCustom_c')
+	.then(r => cloud.get(`${test.api}/${customObjectName}/custom-fields-templates`))
+	.then(r => cloud.post(`${test.api}/${customObjectName}/custom-fields`, payload))
+	.then(r => id = r.body[0].marketoGUID)
+	.then(r => cloud.patch(`${test.api}/${customObjectName}/custom-fields/${id}`, payload))
+	.then(r => cloud.delete(`${test.api}/${customObjectName}/custom-fields/${id}`));
+  });
+  
+  it('should allow S and cursor pagination for /custom-objects{customObjectName}/custom-fields', () => {
+    const options = { qs: { pageSize: 2 ,  where: `marketoGUID='c244523c-0a21-4c56-aa71-a845af615d4c,dab80af7-849f-47da-97af-cb3160867892, a3305990-a7e6-46f4-9a5b-9f81ae5db16c'`} };
+    return cloud.withOptions(options).get(`${test.api}/${customObjectName}/custom-fields`)
+      .then(r => {
+        expect(r.body).to.not.be.null;
+        options.qs.nextPage = r.response.headers['elements-next-page-token'];
+        return cloud.withOptions(options).get(`${test.api}/${customObjectName}/custom-fields`);
+      });
+  });
+});


### PR DESCRIPTION
## Highlights
 Following APIs are supported for CustomObjects : 
- `GET /custom-objects`
- `GET /custom-objects/{customObjectName}/custom-fields` 
- `GET /custom-objects/{customObjectName}/custom-fields-templates` 
- `POST /custom-objects/{customObjectName}/custom-fields` 
- `GET /custom-objects/{customObjectName}/custom-fields/{id}` 
- `PATCH /custom-objects/{customObjectName}/custom-fields/{id}` 
- `DELETE /custom-objects/{customObjectName}/custom-fields/{id}` 

Please note that `afrinCustom_c` is a custom-object and `dedupeFieldafrin` is a custom-field, defined only via Marketo UI.

## Screenshot
![churros-2](https://user-images.githubusercontent.com/20634723/37970289-bf75bcca-31f0-11e8-896d-8f58e2709782.PNG)


## Reference
* [SOBA](https://github.com/cloud-elements/soba/pull/8344)

## Closes
* [US10078](https://rally1.rallydev.com/#/144349237612ud/detail/userstory/203863314560)
* [US10553](https://rally1.rallydev.com/#/144349237612ud/detail/userstory/207973634500)
