### PR TITLE
Added test case for CUD /bank-accounts and /ledger-account

### DIFF
--- a/src/test/elements/sageone/assets/bankAccount.json
+++ b/src/test/elements/sageone/assets/bankAccount.json
@@ -1,0 +1,12 @@
+{
+ 
+    "bank_account_type_id": "CREDIT_CARD",
+    "bank_account_details": {
+      "account_name": "<<random.word>>",
+     "account_number": "<<random.number>>",
+      "sort_code": "112233",
+      "bic": "MIDLGB22123",
+      "iban": "GB15 MIDL 4005 1512 3456 78"
+}
+
+}

--- a/src/test/elements/sageone/assets/ledgerAccount.json
+++ b/src/test/elements/sageone/assets/ledgerAccount.json
@@ -1,0 +1,12 @@
+{
+  
+    "ledger_account_type_id": "OVERHEADS",
+   
+    "included_in_chart": true,
+    "name": "ce<<random.alphaNumeric##6>>",
+    "display_name": "ce<<random.alphaNumeric##6>>",
+    "nominal_code": "<<random.number>>",
+    "visible_in_sales": true,
+    "visible_in_other_receipts": true
+  
+}

--- a/src/test/elements/sageone/bank-accounts.js
+++ b/src/test/elements/sageone/bank-accounts.js
@@ -2,10 +2,15 @@
 
 const suite = require('core/suite');
 const expect = require('chakram').expect;
+const tools = require('core/tools');
+const build = (overrides) => Object.assign({}, payload, overrides);
+const payload = tools.requirePayload(`${__dirname}/assets/bankAccount.json`);
+const bankAccountPayload = build({ date: Date(), reference: "re" + tools.randomInt() });
 
-suite.forElement('finance', 'bank-accounts', (test) => {
+
+suite.forElement('finance', 'bank-accounts', { payload: bankAccountPayload },(test) => {
   let date = '2017-05-05';
-  test.should.supportSr();
+  test.should.supportCrs();
   test.should.supportPagination();
   test
    .withName(`should support searching ${test.api} by lastModifiedDate`)

--- a/src/test/elements/sageone/bank-accounts.js
+++ b/src/test/elements/sageone/bank-accounts.js
@@ -6,11 +6,8 @@ const tools = require('core/tools');
 
 
 const payload = tools.requirePayload(`${__dirname}/assets/bankAccount.json`);
-const build = (overrides) => Object.assign({}, payload, overrides);
-const bankAccountPayload = build({ date: Date(), reference: "re" + tools.randomInt() });
 
-
-suite.forElement('finance', 'bank-accounts', { payload: bankAccountPayload },(test) => {
+suite.forElement('finance', 'bank-accounts', { payload: payload },(test) => {
   let date = '2017-05-05';
   test.should.supportCrs();
   test.should.supportPagination();

--- a/src/test/elements/sageone/bank-accounts.js
+++ b/src/test/elements/sageone/bank-accounts.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const chakram = require('chakram');
 const suite = require('core/suite');
 const expect = require('chakram').expect;
 const tools = require('core/tools');
@@ -9,7 +10,7 @@ const payload = tools.requirePayload(`${__dirname}/assets/bankAccount.json`);
 
 suite.forElement('finance', 'bank-accounts', { payload: payload },(test) => {
   let date = '2017-05-05';
-  test.should.supportCrs();
+  test.should.supportCruds(chakram.put);
   test.should.supportPagination();
   test
    .withName(`should support searching ${test.api} by lastModifiedDate`)

--- a/src/test/elements/sageone/bank-accounts.js
+++ b/src/test/elements/sageone/bank-accounts.js
@@ -3,8 +3,10 @@
 const suite = require('core/suite');
 const expect = require('chakram').expect;
 const tools = require('core/tools');
-const build = (overrides) => Object.assign({}, payload, overrides);
+
+
 const payload = tools.requirePayload(`${__dirname}/assets/bankAccount.json`);
+const build = (overrides) => Object.assign({}, payload, overrides);
 const bankAccountPayload = build({ date: Date(), reference: "re" + tools.randomInt() });
 
 

--- a/src/test/elements/sageone/ledger-accounts.js
+++ b/src/test/elements/sageone/ledger-accounts.js
@@ -2,9 +2,15 @@
 
 const suite = require('core/suite');
 const expect = require('chakram').expect;
+const tools = require('core/tools');
 
-suite.forElement('finance', 'ledger-accounts', (test) => {
-  test.should.supportSr();
+const payload = tools.requirePayload(`${__dirname}/assets/ledgerAccount.json`);
+const build = (overrides) => Object.assign({}, payload, overrides);
+const ledgerAccountPayload = build({ date: Date(), reference: "re" + tools.randomInt() });
+
+
+suite.forElement('finance', 'ledger-accounts', { payload: ledgerAccountPayload },(test) => {
+  test.should.supportCrs();
   test.should.supportPagination();
   test
     .withName(`should support searching ${test.api} by visible_in`)

--- a/src/test/elements/sageone/ledger-accounts.js
+++ b/src/test/elements/sageone/ledger-accounts.js
@@ -5,11 +5,10 @@ const expect = require('chakram').expect;
 const tools = require('core/tools');
 
 const payload = tools.requirePayload(`${__dirname}/assets/ledgerAccount.json`);
-const build = (overrides) => Object.assign({}, payload, overrides);
-const ledgerAccountPayload = build({ date: Date(), reference: "re" + tools.randomInt() });
 
 
-suite.forElement('finance', 'ledger-accounts', { payload: ledgerAccountPayload },(test) => {
+
+suite.forElement('finance', 'ledger-accounts', { payload: payload },(test) => {
   test.should.supportCrs();
   test.should.supportPagination();
   test

--- a/src/test/elements/sageone/ledger-accounts.js
+++ b/src/test/elements/sageone/ledger-accounts.js
@@ -3,13 +3,15 @@
 const suite = require('core/suite');
 const expect = require('chakram').expect;
 const tools = require('core/tools');
+const chakram = require('chakram');
+
 
 const payload = tools.requirePayload(`${__dirname}/assets/ledgerAccount.json`);
 
 
 
 suite.forElement('finance', 'ledger-accounts', { payload: payload },(test) => {
-  test.should.supportCrs();
+  test.should.supportCrus(chakram.put);
   test.should.supportPagination();
   test
     .withName(`should support searching ${test.api} by visible_in`)


### PR DESCRIPTION
## Highlights
* Enhanced test cases for CUD for `bank-accounts` and `ledger-accounts`.

## Screenshot
* Churros result for `bank-accounts` and `ledger-accounts`.
![churros-la-ba](https://user-images.githubusercontent.com/29943090/38243877-871fedee-3756-11e8-814a-0b33a8b5767f.PNG)


## Reference
* [SOBA](https://github.com/cloud-elements/soba/pull/8352)
* [SOBA](https://github.com/cloud-elements/soba/pull/8406)

## Closes
* #[US10532](https://rally1.rallydev.com/#/144349237612d/detail/userstory/207618302300)
* #[US10656](https://rally1.rallydev.com/#/144349237612d/detail/userstory/209157374828)
