### PR TITLE
Added /objects/{objectName}/docs tests

### DIFF
--- a/src/test/platform/elements/assets/element.metadata.docs.json
+++ b/src/test/platform/elements/assets/element.metadata.docs.json
@@ -1,0 +1,1097 @@
+{
+  "name": "Rocketzen",
+  "key": "rocketzen",
+  "description": "Rocket Element to do all our testing stuff...can be anything",
+  "image": "http://developers.cloud-elements.com/assets/img/default-ce-logo-element-builder.png",
+  "active": true,
+  "deleted": false,
+  "typeOauth": false,
+  "trialAccount": false,
+  "configuration": [
+    {
+      "id": 24061,
+      "name": "Pagination Type",
+      "key": "pagination.type",
+      "description": "One Model Pagination Type",
+      "defaultValue": "page",
+      "resellerConfig": false,
+      "companyConfig": false,
+      "active": true,
+      "internal": false,
+      "groupControl": false,
+      "displayOrder": 1,
+      "type": "TEXTFIELD_32",
+      "hideFromConsole": true,
+      "required": false
+    },
+    {
+      "id": 24060,
+      "name": "Base URL",
+      "key": "base.url",
+      "description": "One Model Base URL",
+      "defaultValue": "https://onemodel.com",
+      "resellerConfig": false,
+      "companyConfig": false,
+      "active": true,
+      "internal": false,
+      "groupControl": false,
+      "displayOrder": 1,
+      "type": "TEXTFIELD_1000",
+      "hideFromConsole": true,
+      "required": false
+    },
+    {
+      "id": 24063,
+      "name": "Max Page Size (or limit)",
+      "key": "pagination.max",
+      "description": "One Model Max Page Size (or limit)",
+      "defaultValue": "100",
+      "resellerConfig": false,
+      "companyConfig": false,
+      "active": true,
+      "internal": false,
+      "groupControl": false,
+      "displayOrder": 1,
+      "type": "TEXTFIELD_32",
+      "hideFromConsole": true,
+      "required": false
+    },
+    {
+      "id": 24062,
+      "name": "Pagination Start Index",
+      "key": "pagination.page.startindex",
+      "description": "One Model Pagination Start Index",
+      "defaultValue": "1",
+      "resellerConfig": false,
+      "companyConfig": false,
+      "active": true,
+      "internal": false,
+      "groupControl": false,
+      "displayOrder": 1,
+      "type": "TEXTFIELD_32",
+      "hideFromConsole": true,
+      "required": false
+    },
+    {
+      "id": 27688,
+      "name": "Username",
+      "key": "username",
+      "description": "Rocketzen Username",
+      "resellerConfig": false,
+      "companyConfig": false,
+      "active": true,
+      "internal": false,
+      "groupControl": false,
+      "displayOrder": 2,
+      "type": "TEXTFIELD_32",
+      "hideFromConsole": false,
+      "required": true
+    },
+    {
+      "id": 27689,
+      "name": "Password",
+      "key": "password",
+      "description": "Rocketzen Password",
+      "resellerConfig": false,
+      "companyConfig": false,
+      "active": true,
+      "internal": false,
+      "groupControl": false,
+      "displayOrder": 3,
+      "type": "PASSWORD",
+      "hideFromConsole": false,
+      "required": true
+    },
+    {
+      "id": 24064,
+      "name": "Time of Getting Token or Performing Authentication",
+      "key": "authentication.time",
+      "description": "One Model Time of Getting Token or Performing Authentication",
+      "resellerConfig": false,
+      "companyConfig": false,
+      "active": true,
+      "internal": true,
+      "groupControl": false,
+      "displayOrder": 100,
+      "type": "TEXTFIELD_32",
+      "hideFromConsole": true,
+      "required": false
+    }
+  ],
+  "resources": [
+    {
+      "id": 37346,
+      "createdDate": "2017-10-02T22:25:46Z",
+      "updatedDate": "2018-03-28T21:00:19Z",
+      "description": "Search for  contacts",
+      "path": "/hubs/general/contacts",
+      "vendorPath": "/contacts",
+      "method": "GET",
+      "vendorMethod": "GET",
+      "parameters": [
+        {
+          "id": 92940,
+          "resourceId": 37346,
+          "createdDate": "2017-10-02T22:25:46Z",
+          "updatedDate": "2018-03-28T21:00:19Z",
+          "name": "page",
+          "vendorName": "page",
+          "description": "The page number of resources to retrieve",
+          "type": "query",
+          "vendorType": "query",
+          "dataType": "string",
+          "vendorDataType": "string",
+          "source": "request",
+          "required": false
+        },
+        {
+          "id": 92942,
+          "resourceId": 37346,
+          "createdDate": "2017-10-02T22:25:46Z",
+          "updatedDate": "2018-03-28T21:00:19Z",
+          "name": "where",
+          "vendorName": "converter:toQueryParameters",
+          "description": "The CEQL search expression.",
+          "type": "query",
+          "vendorType": "query",
+          "dataType": "string",
+          "vendorDataType": "string",
+          "source": "request",
+          "converter": "toQueryParameters",
+          "required": false
+        },
+        {
+          "id": 92941,
+          "resourceId": 37346,
+          "createdDate": "2017-10-02T22:25:46Z",
+          "updatedDate": "2018-03-28T21:00:19Z",
+          "name": "pageSize",
+          "vendorName": "pageSize",
+          "description": "The number of resources to return in a given page",
+          "type": "query",
+          "vendorType": "query",
+          "dataType": "string",
+          "vendorDataType": "string",
+          "source": "request",
+          "required": false
+        }
+      ],
+      "model": {
+        "name": "contactsList",
+        "transform": false,
+        "swagger": {
+          "contactsList": {
+            "items": {
+              "type": "contactsListObject"
+            },
+            "type": "array"
+          },
+          "contactsListObject": {
+            "properties": {
+              "country": {
+                "type": "string",
+                "x-samplevalue": "united kingdom"
+              },
+              "email": {
+                "type": "string",
+                "x-samplevalue": "Theresa.May@westminister.gov.uk"
+              },
+              "firstName": {
+                "type": "string",
+                "x-samplevalue": "Theresa"
+              },
+              "jobTitle": {
+                "type": "string",
+                "x-samplevalue": "Prime Minister"
+              },
+              "leadScore": {
+                "format": "int32",
+                "type": "integer",
+                "x-samplevalue": 45
+              },
+              "website": {
+                "type": "string",
+                "x-samplevalue": "www.brexit.com"
+              }
+            },
+            "title": "contactsList",
+            "type": "object",
+            "x-has-customfields": false
+          }
+        }
+      },
+      "type": "api",
+      "hooks": [],
+      "response": {
+        "contentType": "application/json"
+      },
+      "paginationType": "VENDOR_SUPPORTED",
+      "ownerAccountId": 241,
+      "kind": "eb",
+      "modelId": 0
+    },
+    {
+      "id": 37347,
+      "createdDate": "2017-10-02T22:25:46Z",
+      "updatedDate": "2018-03-28T21:00:19Z",
+      "description": "Create a(n)  contacts",
+      "path": "/hubs/general/contacts",
+      "vendorPath": "/contacts",
+      "method": "POST",
+      "vendorMethod": "POST",
+      "parameters": [
+        {
+          "id": 92943,
+          "resourceId": 37347,
+          "createdDate": "2017-10-02T22:25:46Z",
+          "updatedDate": "2018-03-28T21:00:19Z",
+          "name": "contacts",
+          "vendorName": "contacts",
+          "description": "The contacts object",
+          "type": "body",
+          "vendorType": "body",
+          "dataType": "contactsPostrequest",
+          "vendorDataType": "contacts",
+          "source": "request",
+          "required": true
+        },
+        {
+          "id": 92944,
+          "resourceId": 37347,
+          "createdDate": "2017-10-02T22:25:46Z",
+          "updatedDate": "2018-03-28T21:00:19Z",
+          "name": "id",
+          "vendorName": "id",
+          "description": "The contacts ID",
+          "type": "path",
+          "vendorType": "path",
+          "dataType": "string",
+          "vendorDataType": "string",
+          "source": "request",
+          "required": true
+        }
+      ],
+      "model": {
+        "name": "contactsPostresponse",
+        "transform": false,
+        "swagger": {
+          "contactsPostresponse": {
+            "properties": {
+              "country": {
+                "type": "string",
+                "x-samplevalue": "united kingdom"
+              },
+              "email": {
+                "type": "string",
+                "x-samplevalue": "Theresa.May@westminister.gov.uk"
+              },
+              "firstName": {
+                "type": "string",
+                "x-samplevalue": "Theresa"
+              },
+              "jobTitle": {
+                "type": "string",
+                "x-samplevalue": "Prime Minister"
+              },
+              "leadScore": {
+                "format": "int32",
+                "type": "integer",
+                "x-samplevalue": 45
+              },
+              "website": {
+                "type": "string",
+                "x-samplevalue": "www.brexit.com"
+              }
+            },
+            "title": "contactsPostresponse",
+            "x-has-customfields": false
+          }
+        },
+        "requestSwagger": {
+          "contactsPostrequest": {
+            "properties": {
+              "country": {
+                "type": "string",
+                "x-samplevalue": "united kingdom"
+              },
+              "email": {
+                "type": "string",
+                "x-samplevalue": "Theresa.May@westminister.gov.uk"
+              },
+              "firstName": {
+                "type": "string",
+                "x-samplevalue": "Theresa"
+              },
+              "jobTitle": {
+                "type": "string",
+                "x-samplevalue": "Prime Minister"
+              },
+              "website": {
+                "type": "string",
+                "x-samplevalue": "www.brexit.com"
+              }
+            },
+            "title": "contactsPostrequest",
+            "x-has-customfields": false
+          }
+        },
+        "requestName": "contactsPostrequest"
+      },
+      "type": "api",
+      "hooks": [],
+      "response": {
+        "contentType": "application/json"
+      },
+      "paginationType": "VENDOR_SUPPORTED",
+      "ownerAccountId": 241,
+      "kind": "eb",
+      "modelId": 0
+    },
+    {
+      "id": 37351,
+      "createdDate": "2017-10-02T22:30:18Z",
+      "updatedDate": "2018-03-28T21:00:19Z",
+      "description": "Search for  contacts",
+      "path": "/hubs/general/contacts-nonexec",
+      "vendorPath": "/contacts",
+      "method": "GET",
+      "vendorMethod": "GET",
+      "parameters": [
+        {
+          "id": 92949,
+          "resourceId": 37351,
+          "createdDate": "2017-10-02T22:30:18Z",
+          "updatedDate": "2018-03-28T21:00:19Z",
+          "name": "where",
+          "vendorName": "converter:toQueryParameters",
+          "description": "The CEQL search expression.",
+          "type": "query",
+          "vendorType": "query",
+          "dataType": "string",
+          "vendorDataType": "string",
+          "source": "request",
+          "converter": "toQueryParameters",
+          "required": false
+        },
+        {
+          "id": 92951,
+          "resourceId": 37351,
+          "createdDate": "2017-10-02T22:30:18Z",
+          "updatedDate": "2018-03-28T21:00:19Z",
+          "name": "page",
+          "vendorName": "page",
+          "description": "The page number of resources to retrieve",
+          "type": "query",
+          "vendorType": "query",
+          "dataType": "string",
+          "vendorDataType": "string",
+          "source": "request",
+          "required": false
+        },
+        {
+          "id": 92950,
+          "resourceId": 37351,
+          "createdDate": "2017-10-02T22:30:18Z",
+          "updatedDate": "2018-03-28T21:00:19Z",
+          "name": "pageSize",
+          "vendorName": "pageSize",
+          "description": "The number of resources to return in a given page",
+          "type": "query",
+          "vendorType": "query",
+          "dataType": "string",
+          "vendorDataType": "string",
+          "source": "request",
+          "required": false
+        }
+      ],
+      "type": "api",
+      "hooks": [],
+      "response": {
+        "contentType": "application/json"
+      },
+      "paginationType": "VENDOR_SUPPORTED",
+      "ownerAccountId": 241,
+      "kind": "eb",
+      "modelId": 0
+    },
+    {
+      "id": 37348,
+      "createdDate": "2017-10-02T22:25:46Z",
+      "updatedDate": "2018-03-28T21:00:19Z",
+      "description": "Delete a(n) contacts",
+      "path": "/hubs/general/contacts/{id}",
+      "vendorPath": "/contacts/{id}",
+      "method": "DELETE",
+      "vendorMethod": "DELETE",
+      "parameters": [
+        {
+          "id": 92945,
+          "resourceId": 37348,
+          "createdDate": "2017-10-02T22:25:46Z",
+          "updatedDate": "2018-03-28T21:00:19Z",
+          "name": "id",
+          "vendorName": "id",
+          "description": "The contacts ID",
+          "type": "path",
+          "vendorType": "path",
+          "dataType": "string",
+          "vendorDataType": "string",
+          "source": "request",
+          "required": true
+        }
+      ],
+      "type": "api",
+      "hooks": [],
+      "response": {
+        "contentType": "application/json"
+      },
+      "paginationType": "VENDOR_SUPPORTED",
+      "ownerAccountId": 241,
+      "kind": "eb",
+      "modelId": 0
+    },
+    {
+      "id": 37349,
+      "createdDate": "2017-10-02T22:25:46Z",
+      "updatedDate": "2018-03-28T21:00:19Z",
+      "description": "Retrieve a(n)  contacts",
+      "path": "/hubs/general/contacts/{id}",
+      "vendorPath": "/contacts/{id}",
+      "method": "GET",
+      "vendorMethod": "GET",
+      "parameters": [
+        {
+          "id": 92946,
+          "resourceId": 37349,
+          "createdDate": "2017-10-02T22:25:46Z",
+          "updatedDate": "2018-03-28T21:00:19Z",
+          "name": "id",
+          "vendorName": "id",
+          "description": "dsfsd",
+          "type": "path",
+          "vendorType": "path",
+          "dataType": "string",
+          "vendorDataType": "string",
+          "source": "request",
+          "required": true
+        }
+      ],
+      "model": {
+        "name": "contacts",
+        "transform": false,
+        "swagger": {
+          "emails": {
+            "id": "emails",
+            "properties": {
+              "email": {
+                "type": "string"
+              },
+              "email_lower": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string"
+              }
+            }
+          },
+          "contactsContacts": {
+            "id": "contactsContacts",
+            "properties": {
+              "created_by": {
+                "type": "unknown"
+              },
+              "date_created": {
+                "type": "string"
+              },
+              "date_updated": {
+                "type": "string"
+              },
+              "emails": {
+                "items": {
+                  "$ref": "emails"
+                },
+                "type": "array"
+              },
+              "id": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "organization_id": {
+                "type": "string"
+              },
+              "phones": {
+                "items": {
+                  "$ref": "phones"
+                },
+                "type": "array"
+              },
+              "title": {
+                "type": "string"
+              },
+              "updated_by": {
+                "type": "string"
+              }
+            }
+          },
+          "phones": {
+            "id": "phones",
+            "properties": {
+              "phone": {
+                "type": "string"
+              },
+              "phone_formatted": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string"
+              }
+            }
+          },
+          "opportunities": {
+            "id": "opportunities",
+            "properties": {
+              "confidence": {
+                "format": "int32",
+                "type": "integer"
+              },
+              "contact_id": {
+                "type": "unknown"
+              },
+              "created_by": {
+                "type": "unknown"
+              },
+              "date_created": {
+                "type": "string"
+              },
+              "date_updated": {
+                "type": "string"
+              },
+              "date_won": {
+                "type": "unknown"
+              },
+              "id": {
+                "type": "string"
+              },
+              "lead_id": {
+                "type": "string"
+              },
+              "lead_name": {
+                "type": "string"
+              },
+              "note": {
+                "type": "string"
+              },
+              "organization_id": {
+                "type": "string"
+              },
+              "status_id": {
+                "type": "string"
+              },
+              "status_label": {
+                "type": "string"
+              },
+              "status_type": {
+                "type": "string"
+              },
+              "updated_by": {
+                "type": "unknown"
+              },
+              "user_id": {
+                "type": "string"
+              },
+              "user_name": {
+                "type": "string"
+              },
+              "value": {
+                "format": "int32",
+                "type": "integer"
+              },
+              "value_currency": {
+                "type": "string"
+              },
+              "value_formatted": {
+                "type": "string"
+              },
+              "value_period": {
+                "type": "string"
+              }
+            }
+          },
+          "contacts": {
+            "id": "contacts",
+            "properties": {
+              "contacts": {
+                "items": {
+                  "$ref": "contactsContacts"
+                },
+                "type": "array"
+              },
+              "created_by": {
+                "type": "unknown"
+              },
+              "custom.lcf_ORxgoOQ5YH1p7lDQzFJ88b4z0j7PLLTRaG66m8bmcKv": {
+                "type": "string"
+              },
+              "date_created": {
+                "type": "string"
+              },
+              "date_updated": {
+                "type": "string"
+              },
+              "description": {
+                "type": "string"
+              },
+              "display_name": {
+                "type": "string"
+              },
+              "html_url": {
+                "type": "string"
+              },
+              "id": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "opportunities": {
+                "items": {
+                  "$ref": "opportunities"
+                },
+                "type": "array"
+              },
+              "organization_id": {
+                "type": "string"
+              },
+              "status_id": {
+                "type": "string"
+              },
+              "status_label": {
+                "type": "string"
+              },
+              "updated_by": {
+                "type": "string"
+              },
+              "url": {
+                "type": "unknown"
+              }
+            }
+          }
+        }
+      },
+      "type": "api",
+      "hooks": [],
+      "response": {
+        "contentType": "application/json"
+      },
+      "paginationType": "VENDOR_SUPPORTED",
+      "ownerAccountId": 241,
+      "kind": "eb",
+      "modelId": 0
+    },
+    {
+      "id": 37350,
+      "createdDate": "2017-10-02T22:25:46Z",
+      "updatedDate": "2018-03-28T21:00:19Z",
+      "description": "Update a(n)  contacts",
+      "path": "/hubs/general/contacts/{id}",
+      "vendorPath": "/contacts/{id}",
+      "method": "PATCH",
+      "vendorMethod": "PATCH",
+      "parameters": [
+        {
+          "id": 92948,
+          "resourceId": 37350,
+          "createdDate": "2017-10-02T22:25:46Z",
+          "updatedDate": "2018-03-28T21:00:19Z",
+          "name": "id",
+          "vendorName": "id",
+          "description": "The contacts ID",
+          "type": "path",
+          "vendorType": "path",
+          "dataType": "string",
+          "vendorDataType": "string",
+          "source": "request",
+          "required": true
+        },
+        {
+          "id": 92947,
+          "resourceId": 37350,
+          "createdDate": "2017-10-02T22:25:46Z",
+          "updatedDate": "2018-03-28T21:00:19Z",
+          "name": "contacts",
+          "vendorName": "contacts",
+          "description": "The contacts object",
+          "type": "body",
+          "vendorType": "body",
+          "dataType": "contactsPatchRequest",
+          "vendorDataType": "contacts",
+          "source": "request",
+          "required": true
+        }
+      ],
+      "model": {
+        "name": "contactsPatchResponse",
+        "transform": false,
+        "swagger": {
+          "contactsPatchResponse": {
+            "properties": {
+              "country": {
+                "type": "string",
+                "x-samplevalue": "united kingdom"
+              },
+              "email": {
+                "type": "string",
+                "x-samplevalue": "Theresa.May@westminister.gov.uk"
+              },
+              "firstName": {
+                "type": "string",
+                "x-samplevalue": "Theresa"
+              },
+              "jobTitle": {
+                "type": "string",
+                "x-samplevalue": "Prime Minister"
+              },
+              "leadScore": {
+                "format": "int32",
+                "type": "integer",
+                "x-samplevalue": 45
+              },
+              "website": {
+                "type": "string",
+                "x-samplevalue": "www.brexit.com"
+              }
+            },
+            "title": "contactsPatchResponse",
+            "x-has-customfields": false
+          }
+        },
+        "requestSwagger": {
+          "contactsPatchRequest": {
+            "properties": {
+              "country": {
+                "type": "string",
+                "x-samplevalue": "united kingdom"
+              },
+              "email": {
+                "type": "string",
+                "x-samplevalue": "Theresa.May@westminister.gov.uk"
+              },
+              "firstName": {
+                "type": "string",
+                "x-samplevalue": "Theresa"
+              },
+              "jobTitle": {
+                "type": "string",
+                "x-samplevalue": "Prime Minister"
+              },
+              "website": {
+                "type": "string",
+                "x-samplevalue": "www.brexit.com"
+              }
+            },
+            "title": "contactsPatchRequest",
+            "x-has-customfields": false
+          }
+        },
+        "requestName": "contactsPatchRequest"
+      },
+      "type": "api",
+      "hooks": [],
+      "response": {
+        "contentType": "application/json"
+      },
+      "paginationType": "VENDOR_SUPPORTED",
+      "ownerAccountId": 241,
+      "kind": "eb",
+      "modelId": 0
+    },
+    {
+      "id": 45437,
+      "createdDate": "2018-03-08T16:10:09Z",
+      "updatedDate": "2018-03-28T21:00:19Z",
+      "description": "Search for /noquery",
+      "path": "/hubs/general/noquery",
+      "vendorPath": "/noquery",
+      "method": "GET",
+      "vendorMethod": "GET",
+      "parameters": [
+        {
+          "id": 113984,
+          "resourceId": 45437,
+          "createdDate": "2018-03-08T16:10:55Z",
+          "updatedDate": "2018-03-28T21:00:19Z",
+          "name": "second",
+          "vendorName": "s",
+          "description": "lets see again",
+          "type": "query",
+          "vendorType": "query",
+          "dataType": "string",
+          "vendorDataType": "string",
+          "source": "request",
+          "required": false
+        },
+        {
+          "id": 113983,
+          "resourceId": 45437,
+          "createdDate": "2018-03-08T16:10:09Z",
+          "updatedDate": "2018-03-28T21:00:19Z",
+          "name": "sample",
+          "vendorName": "sample",
+          "description": "lets see",
+          "type": "query",
+          "vendorType": "query",
+          "dataType": "string",
+          "vendorDataType": "string",
+          "source": "request",
+          "required": false
+        }
+      ],
+      "type": "api",
+      "hooks": [],
+      "response": {
+        "contentType": "application/json"
+      },
+      "ownerAccountId": 241,
+      "kind": "eb",
+      "modelId": 0
+    },
+    {
+      "id": 46122,
+      "createdDate": "2018-03-28T19:53:16Z",
+      "updatedDate": "2018-03-28T21:00:19Z",
+      "description": "Search for /objects/{objectName}/metadata",
+      "path": "/hubs/general/objects/{objectName}/metadata",
+      "vendorPath": "/no-op",
+      "method": "GET",
+      "vendorMethod": "GET",
+      "parameters": [
+        {
+          "id": 115599,
+          "resourceId": 46122,
+          "createdDate": "2018-03-28T19:53:16Z",
+          "updatedDate": "2018-03-28T21:00:19Z",
+          "name": "customFieldsOnly",
+          "vendorName": "customFieldsOnly",
+          "description": "customFieldsOnly",
+          "type": "query",
+          "vendorType": "query",
+          "dataType": "boolean",
+          "vendorDataType": "boolean",
+          "source": "request",
+          "required": false
+        },
+        {
+          "id": 115598,
+          "resourceId": 46122,
+          "createdDate": "2018-03-28T19:53:16Z",
+          "updatedDate": "2018-03-28T21:00:19Z",
+          "name": "objectName",
+          "vendorName": "objectName",
+          "description": "The objectName ID",
+          "type": "path",
+          "vendorType": "path",
+          "dataType": "string",
+          "vendorDataType": "string",
+          "source": "request",
+          "required": true
+        }
+      ],
+      "type": "api",
+      "hooks": [
+        {
+          "id": 11134,
+          "resourceId": 46122,
+          "mimeType": "application/javascript",
+          "type": "preRequest",
+          "body": "\ndone({\n  continue : false\n})",
+          "isLegacy": false
+        },
+        {
+          "id": 11133,
+          "resourceId": 46122,
+          "mimeType": "application/javascript",
+          "type": "postRequest",
+          "body": "let objectMeatadata = {\n  \"fields\": [\n    {\n      \"type\": \"string\",\n      \"path\": \"custom_email\",\n      \"vendorPath\": \"custom_email\",\n   \"custom\": true,\n   \"displayName\": \"Email\",\n      \"vendorDisplayName\": \"Email\",\n      \"vendorNativeType\": \"string\",\n      \"vendorRequired\": false,\n      \"vendorReadOnly\": false,\n      \"hidden\": false,\n      \"filterable\": false,\n      \"createable\": false,\n      \"updateable\": false,\n      \"method\": [\n        {\n          \"name\": \"GET\",\n          \"response\": true,\n          \"request\": false\n        }\n      ]\n    },\n    {\n      \"type\": \"string\",\n      \"path\": \"customobject.custom_firstName\",\n      \"vendorPath\": \"customobject.custom_firstName\",\n   \"custom\": true,\n   \"displayName\": \"First Name\",\n      \"vendorDisplayName\": \"First Name\",\n      \"vendorNativeType\": \"string\",\n      \"vendorRequired\": true,\n      \"vendorReadOnly\": false,\n      \"hidden\": false,\n      \"filterable\": false,\n      \"createable\": false,\n      \"updateable\": false,\n      \"method\": [\n        {\n          \"name\": \"GET\",\n          \"response\": true,\n          \"request\": false\n        }\n      ]\n    }\n  ]\n}\n\ndone({\n  response_body : objectMeatadata\n})",
+          "isLegacy": false
+        }
+      ],
+      "response": {
+        "contentType": "application/json"
+      },
+      "ownerAccountId": 241,
+      "kind": "eb",
+      "modelId": 0
+    }
+  ],
+  "objects": [
+    {
+      "id": 849,
+      "name": "address",
+      "customFields": false,
+      "ownerAccountId": 241,
+      "bulkDownloadEnabled": false,
+      "bulkUploadEnabled": false,
+      "eventsEnabled": false,
+      "fields": [
+        {
+          "id": 5395,
+          "objectId": 849,
+          "name": "addressId",
+          "type": "integer",
+          "format": "int64",
+          "ownerAccountId": 241,
+          "primaryKey": false,
+          "hidden": false,
+          "readOnly": false
+        },
+        {
+          "id": 5396,
+          "objectId": 849,
+          "name": "country",
+          "type": "string",
+          "ownerAccountId": 241,
+          "primaryKey": false,
+          "hidden": false,
+          "readOnly": false
+        }
+      ],
+      "nullsRequired": false,
+      "searchable": false
+    },
+    {
+      "id": 848,
+      "name": "contacts",
+      "primaryKeyName": "id",
+      "createdDateName": "created_dt",
+      "createdDateFormat": "yyyy/mm/dd",
+      "vendorName": "Contact",
+      "customFields": false,
+      "ownerAccountId": 241,
+      "bulkDownloadEnabled": false,
+      "bulkUploadEnabled": false,
+      "eventsEnabled": false,
+      "fields": [
+        {
+          "id": 5390,
+          "objectId": 848,
+          "name": "facebook",
+          "type": "string",
+          "ownerAccountId": 241,
+          "primaryKey": false,
+          "hidden": false,
+          "readOnly": false
+        },
+        {
+          "id": 5388,
+          "objectId": 848,
+          "name": "id",
+          "type": "integer",
+          "displayName": "Id",
+          "sampleValue": "122",
+          "description": "Id field",
+          "format": "int64",
+          "ownerAccountId": 241,
+          "primaryKey": true,
+          "hidden": false,
+          "readOnly": false
+        },
+        {
+          "id": 5389,
+          "objectId": 848,
+          "name": "first_name",
+          "type": "string",
+          "ownerAccountId": 241,
+          "primaryKey": false,
+          "hidden": false,
+          "readOnly": false
+        },
+        {
+          "id": 5394,
+          "objectId": 848,
+          "referenceObjectId": 177,
+          "name": "address",
+          "type": "object",
+          "ownerAccountId": 241,
+          "primaryKey": false,
+          "hidden": false,
+          "readOnly": false
+        },
+        {
+          "id": 5392,
+          "objectId": 848,
+          "name": "last_name",
+          "type": "string",
+          "ownerAccountId": 241,
+          "primaryKey": false,
+          "hidden": false,
+          "readOnly": false
+        },
+        {
+          "id": 5393,
+          "objectId": 848,
+          "name": "phone",
+          "type": "string",
+          "ownerAccountId": 241,
+          "primaryKey": false,
+          "hidden": false,
+          "readOnly": false
+        },
+        {
+          "id": 5391,
+          "objectId": 848,
+          "name": "email",
+          "type": "string",
+          "ownerAccountId": 241,
+          "primaryKey": false,
+          "hidden": false,
+          "readOnly": false
+        }
+      ],
+      "nullsRequired": false,
+      "searchable": false
+    }
+  ],
+  "models": [],
+  "transformationsEnabled": true,
+  "bulkDownloadEnabled": false,
+  "bulkUploadEnabled": false,
+  "cloneable": true,
+  "extendable": true,
+  "beta": false,
+  "authentication": {
+    "type": "basic"
+  },
+  "hooks": [],
+  "extended": true,
+  "hub": "general",
+  "protocolType": "http",
+  "parameters": [
+    {
+      "id": 1532,
+      "createdDate": "2017-11-21T17:24:37Z",
+      "updatedDate": "2018-03-28T21:00:19Z",
+      "name": "application/json",
+      "vendorName": "Accept",
+      "type": "value",
+      "vendorType": "header",
+      "source": "request",
+      "elementId": 2335,
+      "required": false
+    },
+    {
+      "id": 1531,
+      "createdDate": "2017-11-21T17:24:37Z",
+      "updatedDate": "2018-03-28T21:00:19Z",
+      "name": "application/json",
+      "vendorName": "Content-Type",
+      "type": "value",
+      "vendorType": "header",
+      "source": "request",
+      "elementId": 2335,
+      "required": false
+    }
+  ],
+  "private": true
+}

--- a/src/test/platform/elements/metadata-docs.js
+++ b/src/test/platform/elements/metadata-docs.js
@@ -1,0 +1,73 @@
+'use strict';
+
+const expect = require('chakram').expect;
+const suite = require('core/suite');
+const cloud = require('core/cloud');
+const provisioner = require('core/provisioner');
+const rocketzenelement = require('./assets/element.metadata.docs.json');
+
+suite.forPlatform('metadata-docs', {}, (test) => {
+  let createdElement, instanceId;
+  before(() => cloud.post('elements', rocketzenelement)
+      .then(r => createdElement = r.body)
+      .then(r => provisioner.create('rocketzen', undefined, 'elements/rocketzen/instances'))
+      .then(r => instanceId = r.body.id));
+
+
+  it('should return object docs', () => {
+      return cloud.get(`/hubs/general/objects/contacts/docs`, (r) => {
+        expect(r).to.have.statusCode(200);
+        expect(r.body).to.not.be.empty;
+        expect(r.body.paths).to.not.be.empty;
+        expect(Object.keys(r.body.paths).length).to.equal(2);
+        expect(r.body.definitions).to.not.be.empty;
+        expect(Object.keys(r.body.definitions).length).to.equal(10);
+      });
+  });
+
+  it('should return object docs with custom fields when discovery is true', () => {
+      return cloud.withOptions({qs: {discovery:true}}).get(`/hubs/general/objects/contacts/docs`, (r) => {
+        expect(r).to.have.statusCode(200);
+        expect(r.body).to.not.be.empty;
+        expect(r.body.paths).to.not.be.empty;
+        expect(Object.keys(r.body.paths).length).to.equal(2);
+        expect(r.body.definitions).to.not.be.empty;
+        expect(Object.keys(r.body.definitions).length).to.equal(11);
+        expect(Object.keys(r.body.definitions)).to.include('customobject');
+        expect(Object.keys(r.body.definitions.contacts.properties)).to.include('custom_email');
+      });
+  });
+
+  it('should return object docs with custom fields when discovery is true and basic is true', () => {
+      return cloud.withOptions({qs: {discovery:true, basic:true}}).get(`/hubs/general/objects/contacts/docs`, (r) => {
+        expect(r).to.have.statusCode(200);
+        expect(r.body).to.not.be.empty;
+        expect(r.body.paths).to.not.be.empty;
+        expect(Object.keys(r.body.paths).length).to.equal(2);
+        expect(r.body.definitions).to.not.be.empty;
+        expect(Object.keys(r.body.definitions).length).to.equal(11);
+        expect(Object.keys(r.body.definitions)).to.include('customobject');
+        expect(Object.keys(r.body.definitions.contacts.properties)).to.include('custom_email');
+      });
+  });
+
+
+  it('should return object docs with custom fields when discovery is true and resolveReference is true', () => {
+      return cloud.withOptions({qs: {discovery:true, basic:true, resolveReferences: true}}).get(`/hubs/general/objects/contacts/docs`, (r) => {
+        expect(r).to.have.statusCode(200);
+        expect(r.body).to.not.be.empty;
+        expect(r.body.paths).to.not.be.empty;
+        expect(Object.keys(r.body.paths).length).to.equal(2);
+        expect(r.body.definitions).to.not.be.empty;
+        expect(Object.keys(r.body.definitions).length).to.equal(6);
+        expect(Object.keys(r.body.definitions)).to.not.include('customobject');
+        expect(Object.keys(r.body.definitions.contacts.properties)).to.include('custom_email');
+      });
+  });
+
+  after(() => {
+    return provisioner.delete(instanceId, 'elements/rocketzen/instances')
+        .then(r => cloud.delete(`elements/${createdElement.id}`));
+  });
+
+});


### PR DESCRIPTION
## Highlights
* Added /objects/{objectName}/docs tests

## Examples
```
elements-mac112:churros ramana$ churros test platform/elements --file metadata-docs
sleep: using busy loop fallback


  metadata-docs
    ✓ should return object docs (261ms)
    ✓ should return object docs with custom fields when discovery is true (630ms)
    ✓ should return object docs with custom fields when discovery is true and basic is true (704ms)
    ✓ should return object docs with custom fields when discovery is true and resolveReference is true (597ms)


  4 passing (5s)
````

## Reference
* [US10439](https://rally1.rallydev.com/#/144349237612d/detail/userstory/206385306616)
