### PR TITLE
Fixed Authentication for QBO via Oauth2

### DIFF
--- a/src/core/oauth.js
+++ b/src/core/oauth.js
@@ -461,7 +461,7 @@ const manipulateDom = (element, browser, r, username, password, config) => {
       browser.sleep(2000); //Paypal takes some time to confirm creds
       return browser.getCurrentUrl();
     case 'quickbooks--oauth2': 
-	 browser.get(r.body.oauthUrl);
+      browser.get(r.body.oauthUrl);
       browser.findElement(webdriver.By.name('Email')).sendKeys(username);
       browser.findElement(webdriver.By.name('Password')).sendKeys(password);
       browser.findElement(webdriver.By.id('ius-sign-in-submit-btn')).click();

--- a/src/core/oauth.js
+++ b/src/core/oauth.js
@@ -460,6 +460,20 @@ const manipulateDom = (element, browser, r, username, password, config) => {
         .then((element) => element.click(), (err) => {}); // ignore this
       browser.sleep(2000); //Paypal takes some time to confirm creds
       return browser.getCurrentUrl();
+    case 'quickbooks--oauth2': 
+	 browser.get(r.body.oauthUrl);
+      browser.findElement(webdriver.By.name('Email')).sendKeys(username);
+      browser.findElement(webdriver.By.name('Password')).sendKeys(password);
+      browser.findElement(webdriver.By.id('ius-sign-in-submit-btn')).click();
+      browser.wait(() => browser.isElementPresent(webdriver.By.name('companySelectionWidgetCompanySelector_href')), 10000)
+        .thenCatch(r => true);
+      browser.findElement(webdriver.By.name('companySelectionWidgetCompanySelector_href'))
+        .then((element) => element.click(), (err) => {}); // ignore this
+      browser.wait(() => browser.isElementPresent(webdriver.By.id('authorizeBtn')), 5000)
+        .thenCatch(r => true);
+      browser.findElement(webdriver.By.className('btn ha-button ha-button-primary pull-right')).click();
+      browser.sleep(5000); // So flaky, quickbooks' 302 takes forever
+      return browser.getCurrentUrl();
     case 'quickbooks':
       browser.get(r.body.oauthUrl);
       browser.findElement(webdriver.By.name('Email')).sendKeys(username);


### PR DESCRIPTION
## Highlights
* Now churros will be able to make an instance for QBO via Oauth2 provisioning
* However the churros are failing for some resources as `quickbooks--oauth2` in sauce.json points to `quickbooks+oauth2@cloud-elements.com` account and runs churros of key `quickbooks`. These churros are written for account `quickbooks@cloud-elements.com` for key `quickbooks` in sauce.json
Hence not fixing them as part of this story.

## Screenshot 
![churros1](https://user-images.githubusercontent.com/20634723/38132575-372406de-3429-11e8-9374-92df6884ce8b.PNG)
![churros2](https://user-images.githubusercontent.com/20634723/38132588-3e07e16e-3429-11e8-8db3-8940e1454043.PNG)
![churros3](https://user-images.githubusercontent.com/20634723/38132591-40c36658-3429-11e8-9800-cb7af487591b.PNG)
![churros4](https://user-images.githubusercontent.com/20634723/38132599-47a081b8-3429-11e8-9d72-dc8ec7441d24.PNG)
![churros5](https://user-images.githubusercontent.com/20634723/38132607-4ec0068a-3429-11e8-8d49-8e5a45b867d7.PNG)


## Closes
*  [DE1091](https://rally1.rallydev.com/#/144349237612ud/detail/defect/204816326028)
