### PR TITLE
Fixed Acton churros for failing testcases

### DIFF
--- a/src/test/elements/acton/assets/contacts.json
+++ b/src/test/elements/acton/assets/contacts.json
@@ -1,5 +1,3 @@
 [{
-  "email": "fakeEmail@faker.com",
-  "first name": "<<name.firstName>>",
-  "last name": "<<name.lastName>>"
+  "email": "fakeEmail@faker.com"
 }]

--- a/src/test/elements/acton/assets/contactsUpdate.json
+++ b/src/test/elements/acton/assets/contactsUpdate.json
@@ -1,5 +1,3 @@
 {
-  "email": "fakeEmail@faker.com",
-  "first name": "<<name.firstName>>",
-  "last name": "<<name.lastName>>"
+  "email": "fakeEmail@faker.com"
 }


### PR DESCRIPTION
## Highlights
* Fixed failing testcase for resource `POST /lists/{}/contacts` and `PATCH /lists/{}/contacts/{id}`
* It is observed that the fields present for the POST and PATCH payloads are all custom fields. 

## Screenshot
![churros](https://user-images.githubusercontent.com/20634723/38134880-b625f2c2-3432-11e8-901f-5db1b3d40c44.PNG)


## Closes
* [DE1163](https://rally1.rallydev.com/#/144349237612ud/detail/defect/207151981156)
