### PR TITLE
Added metadata test for SugarCRMV2

### DIFF
--- a/src/test/elements/sugarcrmv2/assets/metadata.json
+++ b/src/test/elements/sugarcrmv2/assets/metadata.json
@@ -1,0 +1,22 @@
+[
+  "accountsNotes",
+  "leadsNotes",
+  "campaigns",
+  "incidents",
+  "campaignsNotes",
+  "incidentsNotesAttachments",
+  "tasks",
+  "incidentsHistory",
+  "incidentsNotes",
+  "accountsActivities",
+  "contactsActivities",
+  "opportunities",
+  "users",
+  "activities",
+  "leads",
+  "activitiesRaw",
+  "accounts",
+  "opportunitiesNotes",
+  "contacts",
+  "contactsNotes"
+]

--- a/src/test/elements/sugarcrmv2/metadata.js
+++ b/src/test/elements/sugarcrmv2/metadata.js
@@ -7,12 +7,18 @@ const objects = require('./assets/metadata');
 suite.forElement('finance', `objects`, (test) => {
   return Promise.all(objects.map(obj => {
     it(`should support GET ${test.api}/${obj}/metadata`, () => {
-      return cloud.get(`${test.api}/${obj}/metadata`);
+      return cloud.get(`${test.api}/${obj}/metadata`)
+      then(r => expect(r.body.fields).to.not.be.empty);
     });
 
-    it(`should support GET ${test.api}/${obj}/metadata customFieldsOnly parameter`, () => {
-      return cloud.withOptions({ qs: { customFieldsOnly: true } }).get(`${test.api}/${obj}/metadata`).
-      then(r => expect(r.body.fields.filter(field => (field.vendorPath.endsWith("_c") && field.custom === true))));
-    });
+    test
+      .withName(`should support GET ${test.api}/${obj}/metadata customFieldsOnly parameter`)
+      .withApi(`${test.api}/${obj}/metadata`)
+      .withOptions({ qs: { customFieldsOnly: true } })
+      .withValidation((r) => {
+        expect(r).to.have.statusCode(200);
+        const validValues = r.body.fields.filter(field => (field.vendorPath.endsWith("_c") && field.custom === true));
+        expect(validValues.length).to.equal(r.body.fields.length);
+      }).should.return200OnGet();
   }));
 });

--- a/src/test/elements/sugarcrmv2/metadata.js
+++ b/src/test/elements/sugarcrmv2/metadata.js
@@ -1,0 +1,36 @@
+'use strict';
+const suite = require('core/suite');
+const expect = require('chakram').expect;
+var objects = [
+  "accountsNotes",
+  "leadsNotes",
+  "campaigns",
+  "incidents",
+  "campaignsNotes",
+  "incidentsNotesAttachments",
+  "tasks",
+  "incidentsHistory",
+  "incidentsNotes",
+  "accountsActivities",
+  "contactsActivities",
+  "opportunities",
+  "users",
+  "activities",
+  "leads",
+  "activitiesRaw",
+  "accounts",
+  "opportunitiesNotes",
+  "contacts",
+  "contactsNotes"
+];
+
+objects.forEach(obj => {
+  suite.forElement('finance', `objects/${obj}/metadata`, (test) => {
+    test.should.supportS();
+    test.withApi(test.api)
+      .withOptions({ qs: { customFieldsOnly: true } })
+      .withValidation(r => expect(r.body.fields.filter(field => (field.vendorPath.endsWith("_c") && field.custom === true))))
+      .withName(`should support return only custom fields for ${obj}`)
+      .should.return200OnGet();
+  });
+});

--- a/src/test/elements/sugarcrmv2/metadata.js
+++ b/src/test/elements/sugarcrmv2/metadata.js
@@ -26,11 +26,13 @@ var objects = [
 
 objects.forEach(obj => {
   suite.forElement('finance', `objects/${obj}/metadata`, (test) => {
-    test.should.supportS();
-    test.withApi(test.api)
-      .withOptions({ qs: { customFieldsOnly: true } })
-      .withValidation(r => expect(r.body.fields.filter(field => (field.vendorPath.endsWith("_c") && field.custom === true))))
-      .withName(`should support return only custom fields for ${obj}`)
-      .should.return200OnGet();
+    return Promise.all(objects.map(obj => {
+      test.should.supportS();
+      test.withApi(test.api)
+        .withOptions({ qs: { customFieldsOnly: true } })
+        .withValidation(r => expect(r.body.fields.filter(field => (field.vendorPath.endsWith("_c") && field.custom === true))))
+        .withName(`should support return only custom fields for ${obj}`)
+        .should.return200OnGet();
+    }))
   });
 });

--- a/src/test/elements/sugarcrmv2/metadata.js
+++ b/src/test/elements/sugarcrmv2/metadata.js
@@ -1,38 +1,18 @@
 'use strict';
 const suite = require('core/suite');
+const cloud = require('core/cloud');
 const expect = require('chakram').expect;
-var objects = [
-  "accountsNotes",
-  "leadsNotes",
-  "campaigns",
-  "incidents",
-  "campaignsNotes",
-  "incidentsNotesAttachments",
-  "tasks",
-  "incidentsHistory",
-  "incidentsNotes",
-  "accountsActivities",
-  "contactsActivities",
-  "opportunities",
-  "users",
-  "activities",
-  "leads",
-  "activitiesRaw",
-  "accounts",
-  "opportunitiesNotes",
-  "contacts",
-  "contactsNotes"
-];
+const objects = require('./assets/metadata');
 
-objects.forEach(obj => {
-  suite.forElement('finance', `objects/${obj}/metadata`, (test) => {
-    return Promise.all(objects.map(obj => {
-      test.should.supportS();
-      test.withApi(test.api)
-        .withOptions({ qs: { customFieldsOnly: true } })
-        .withValidation(r => expect(r.body.fields.filter(field => (field.vendorPath.endsWith("_c") && field.custom === true))))
-        .withName(`should support return only custom fields for ${obj}`)
-        .should.return200OnGet();
-    }));
-  });
+suite.forElement('finance', `objects`, (test) => {
+  return Promise.all(objects.map(obj => {
+    it('should support GET /objects/{objectName}/metadata', () => {
+      return cloud.get(`${test.api}/${obj}/metadata`);
+    });
+
+    it('should support GET /objects/{objectName}/metadata customFieldsOnly parameter', () => {
+      return cloud.withOptions({ qs: { customFieldsOnly: true } }).get(`${test.api}/${obj}/metadata`).
+      then(r => expect(r.body.fields.filter(field => (field.vendorPath.endsWith("_c") && field.custom === true))));
+    });
+  }));
 });

--- a/src/test/elements/sugarcrmv2/metadata.js
+++ b/src/test/elements/sugarcrmv2/metadata.js
@@ -33,6 +33,6 @@ objects.forEach(obj => {
         .withValidation(r => expect(r.body.fields.filter(field => (field.vendorPath.endsWith("_c") && field.custom === true))))
         .withName(`should support return only custom fields for ${obj}`)
         .should.return200OnGet();
-    }))
+    }));
   });
 });

--- a/src/test/elements/sugarcrmv2/metadata.js
+++ b/src/test/elements/sugarcrmv2/metadata.js
@@ -6,11 +6,11 @@ const objects = require('./assets/metadata');
 
 suite.forElement('finance', `objects`, (test) => {
   return Promise.all(objects.map(obj => {
-    it('should support GET /objects/{objectName}/metadata', () => {
+    it(`should support GET ${test.api}/${obj}/metadata`, () => {
       return cloud.get(`${test.api}/${obj}/metadata`);
     });
 
-    it('should support GET /objects/{objectName}/metadata customFieldsOnly parameter', () => {
+    it(`should support GET ${test.api}/${obj}/metadata customFieldsOnly parameter`, () => {
       return cloud.withOptions({ qs: { customFieldsOnly: true } }).get(`${test.api}/${obj}/metadata`).
       then(r => expect(r.body.fields.filter(field => (field.vendorPath.endsWith("_c") && field.custom === true))));
     });

--- a/src/test/elements/sugarcrmv2/metadata.js
+++ b/src/test/elements/sugarcrmv2/metadata.js
@@ -8,7 +8,7 @@ suite.forElement('finance', `objects`, (test) => {
   return Promise.all(objects.map(obj => {
     it(`should support GET ${test.api}/${obj}/metadata`, () => {
       return cloud.get(`${test.api}/${obj}/metadata`)
-      then(r => expect(r.body.fields).to.not.be.empty);
+      .then(r => expect(r.body.fields).to.not.be.empty);
     });
 
     test


### PR DESCRIPTION
## Highlights
* Added test for GET /object/{objectname}/metadata API.

## Screenshot
[churros sugarcrm](https://github.com/cloud-elements/churros/files/1894638/churros.updated.txt)


## Reference
* [SOBA](https://github.com/cloud-elements/soba/pull/8385)
* [RALLY-#US10441](https://rally1.rallydev.com/#/144349237612ud/detail/userstory/206386316544)
