### PR TITLE
Expensify: Added test cases for /reports/contents

### DIFF
--- a/src/test/elements/expensify/reports.js
+++ b/src/test/elements/expensify/reports.js
@@ -23,4 +23,8 @@ suite.forElement('payment', 'reports', { payload: payload }, (test) => {
         return cloud.patch(`/hubs/payment/reports/${r.body.id}/status-reimbursed`);
       });
   });
+  it(`should support S for /{test.api}/reports/contents`, () => {
+    return cloud.withOptions({ qs: { fileName: 'exportcfaa17d1-b738-4f69-b121-6f54eab40adb.txt' }}).get('/hubs/payment/reports/contents')
+	then(r => expect(r.body).to.not.be.empty);
+  });
 });

--- a/src/test/elements/expensify/reports.js
+++ b/src/test/elements/expensify/reports.js
@@ -25,6 +25,6 @@ suite.forElement('payment', 'reports', { payload: payload }, (test) => {
   });
   it(`should support S for /{test.api}/reports/contents`, () => {
     return cloud.withOptions({ qs: { fileName: 'exportcfaa17d1-b738-4f69-b121-6f54eab40adb.txt' }}).get('/hubs/payment/reports/contents')
-	then(r => expect(r.body).to.not.be.empty);
+	.then(r => expect(r.body).to.not.be.empty);
   });
 });


### PR DESCRIPTION
## Highlights
* Added test cases for `/reports/contents` API

## Screenshot

![image](https://user-images.githubusercontent.com/34128818/38199518-a99eb9a2-36ae-11e8-8ec2-46210a27d4ce.png)


## Reference
* [SOBA](https://github.com/cloud-elements/soba/pull/8399)
* [RALLY-#${DE1179}](https://rally1.rallydev.com/#/144349237612d/detail/defect/207590533028/tasks)

## Closes
* [DE1179](https://rally1.rallydev.com/#/144349237612d/detail/defect/207590533028/tasks)