### PR TITLE
Added test cases for stripe-charges where clause fields

### DIFF
--- a/src/test/elements/stripe/charges.js
+++ b/src/test/elements/stripe/charges.js
@@ -4,6 +4,7 @@ const suite = require('core/suite');
 const tools = require('core/tools');
 const cloud = require('core/cloud');
 const payload = require('./assets/charges');
+const expect = require('chakram').expect;
 
 const updateCharges = () => ({
   "receipt_email": tools.randomEmail()
@@ -19,6 +20,34 @@ suite.forElement('payment', 'charges', { payload: payload }, (test) => {
       .then(r => cloud.post(`${test.api}/${chargeId}/capture`))
       .then(r => cloud.withOptions({ qs: { where: `currency='usd' and  created=1485255289` } }).get(test.api));
   });
+  
+  test
+    .withName(`should support searching ${test.api} by created`)
+    .withOptions({ qs: { where: 'created = 1485255289' } })
+    .withValidation((r) => {
+      expect(r).to.have.statusCode(200);
+      const validValues = r.body.filter(obj => obj.created === 1485255289);
+      expect(validValues.length).to.equal(r.body.length);
+    }).should.return200OnGet();
+  
+  test
+    .withName(`should support searching ${test.api} by customer`)
+    .withOptions({ qs: { where: 'customer = \'cus_CbzmZUdLk4GsA0\'' } })
+    .withValidation((r) => {
+      expect(r).to.have.statusCode(200);
+      const validValues = r.body.filter(obj => obj.customer === 'cus_CbzmZUdLk4GsA0');
+      expect(validValues.length).to.equal(r.body.length);
+    }).should.return200OnGet();
+	
+  test
+    .withName(`should support searching ${test.api} by transfer_group`)
+    .withOptions({ qs: { where: 'transfer_group = \'group_ch_1CCK6bGdZbyQGmEeC1eUPelf\'' } })
+    .withValidation((r) => {
+      expect(r).to.have.statusCode(200);
+      const validValues = r.body.filter(obj => obj.transfer_group === 'group_ch_1CCK6bGdZbyQGmEeC1eUPelf');
+      expect(validValues.length).to.equal(r.body.length);
+    }).should.return200OnGet();
+  
   test.should.supportPagination();
   test.should.supportNextPagePagination(1);
 });


### PR DESCRIPTION
## Highlights
* Enhanced test cases for searching for `charges` resource in stripes
* Added test cases for searching in `charges` resource.

## Screenshot
* Churros result for `charges`.
![get test case_charges_stripe](https://user-images.githubusercontent.com/35719878/38249249-a8caf9c2-3768-11e8-91bc-94565ad2cbde.png)

## Reference
* [SOBA](https://github.com/cloud-elements/soba/pull/8404)

## Closes
* [DE1220](https://rally1.rallydev.com/#/144349237612d/detail/defect/208991134680)
