### PR TITLE
Stripe : Added test for where clause on nested fields

### DIFF
--- a/src/test/elements/stripe/charges.js
+++ b/src/test/elements/stripe/charges.js
@@ -47,6 +47,15 @@ suite.forElement('payment', 'charges', { payload: payload }, (test) => {
       const validValues = r.body.filter(obj => obj.transfer_group === 'group_ch_1CCK6bGdZbyQGmEeC1eUPelf');
       expect(validValues.length).to.equal(r.body.length);
     }).should.return200OnGet();
+
+  test
+    .withName(`should support searching ${test.api} by nested fields source.object`)
+    .withOptions({ qs: { where: 'source.object = \'card\'' } })
+    .withValidation((r) => {
+      expect(r).to.have.statusCode(200);
+      const validValues = r.body.filter(obj => obj.source.object === 'card');
+      expect(validValues.length).to.equal(r.body.length);
+    }).should.return200OnGet();
   
   test.should.supportPagination();
   test.should.supportNextPagePagination(1);

--- a/src/test/elements/stripe/orders.js
+++ b/src/test/elements/stripe/orders.js
@@ -4,6 +4,7 @@ const suite = require('core/suite');
 const tools = require('core/tools');
 const cloud = require('core/cloud');
 const payload = require('./assets/orders');
+const expect = require('chakram').expect;
 
 const updateOrders = () => ({
   "metadata": {
@@ -13,6 +14,16 @@ const updateOrders = () => ({
 
 suite.forElement('payment', 'orders', (test) => {
   test.should.supportSr();
+  test
+    .withOptions({ qs: { where: 'status_transitions.canceled >= \'1522740054\'' } })
+    .withName('should support search by nested field source.object')
+    .withValidation(r => {
+      expect(r).to.statusCode(200);
+      const validValues = r.body.filter(obj => obj.status_transitions.canceled = '1522740054');
+      expect(validValues.length).to.equal(r.body.length);
+    })
+    .should.return200OnGet();
+
   it(`should allow CU for ${test.api}`, () => {
     let orderId;
     return cloud.post(test.api, payload)


### PR DESCRIPTION
## Highlights
* Added test for where clause to search on nested fields for `orders` and `charges`

## Screen-shot
![churros1](https://user-images.githubusercontent.com/22442264/38356977-e7fa66ce-38de-11e8-847a-ddd78a8650ba.PNG)
![churros2](https://user-images.githubusercontent.com/22442264/38356978-e84ea0d6-38de-11e8-96ae-d8ba0378129b.PNG)
![churros3](https://user-images.githubusercontent.com/22442264/38356981-e898c36e-38de-11e8-9318-7015d2c143ab.PNG)


## Reference
* [SOBA](https://github.com/cloud-elements/soba/pull/8425)
* [RALLY-#DE1211](https://rally1.rallydev.com/#/144349237612d/detail/defect/208699181044)

## Closes
* [DE1211](https://rally1.rallydev.com/#/144349237612d/detail/defect/208699181044)
