### PR TITLE
Enhanced Marketo with GET /objects/{objectName}/metadata API Testcases

### DIFF
--- a/src/test/elements/marketo/metadata.js
+++ b/src/test/elements/marketo/metadata.js
@@ -1,0 +1,43 @@
+'use strict';
+const suite = require('core/suite');
+const cloud = require('core/cloud');
+const expect = require('chakram').expect;
+var objects = [
+  "afrinCustom_c",
+  "folders",
+  "externalActivityTypeAttributes",
+  "activityTypes",
+  "externalActivityType",
+  "externalActivityTypeApprove",
+  "campaigns",
+  "leadActivities_c",
+  "contactsMerge",
+  "company",
+  "externalActivityTypes",
+  "sampleBulkCustomObject_c",
+  "tagTypes",
+  "partitions",
+  "listsLeadsIsMember",
+  "filesContent",
+  "attendance_c",
+  "opportunity",
+  "linktest_c",
+  "channels",
+  "leads",
+  "lists",
+  "activities",
+  "aw_c",
+  "files",
+  "programsLeads",
+  "programs",
+  "readyTalkMeetingInfo_c"
+];
+
+suite.forElement('marketing', 'objects', (test) => {
+    return Promise.all(objects.map(obj => {
+        it(`should support GET /objects/${obj}/metadata`, () => {
+             return cloud.get(`${test.api}/${obj}/metadata`)
+            .then(r => expect(r.body.fields.filter(field => field.vendorPath)).to.not.be.empty);
+        });
+    }));
+});

--- a/src/test/elements/marketo/objects.js
+++ b/src/test/elements/marketo/objects.js
@@ -37,7 +37,10 @@ suite.forElement('marketing', 'objects', (test) => {
     return Promise.all(objects.map(obj => {
         it(`should support GET /objects/${obj}/metadata`, () => {
              return cloud.get(`${test.api}/${obj}/metadata`)
-            .then(r => expect(r.body.fields.filter(field => field.vendorPath)).to.not.be.empty);
+            .then(r => {
+              expect(r.body.fields).to.not.be.empty;
+              expect(r.body.fields.filter(field => field.vendorPath)).to.not.be.empty;
+            });
         });
     }));
 });


### PR DESCRIPTION
## Highlights
* Added Testcases for /objects/{objectName}/metadata for Marketo 


## Checklist
* [x] applicable churros tests are still passing
* [ ] includes a dbdeploy script that is backward-incompatible with one previous Soba minor version

## Screensot
<img width="851" alt="screen shot 2018-04-06 at 1 06 37 am" src="https://user-images.githubusercontent.com/26943831/38405702-c97e822c-3936-11e8-983b-96d1269d8297.png">


## Related PRs
[Soba](https://github.com/cloud-elements/soba/pull/8431)

## Closes
[Rally](https://rally1.rallydev.com/#/144349237612d/detail/defect/209422551924)