### PR TITLE
Added tests for timeline resource for Hubspot Marketing

### DIFF
--- a/src/test/elements/hubspot/assets/timelineeventproperties.json
+++ b/src/test/elements/hubspot/assets/timelineeventproperties.json
@@ -1,0 +1,5 @@
+{
+  "name": "<<random.word>>",
+  "label": "<<random.word>>",
+  "propertyType":"String"
+}

--- a/src/test/elements/hubspot/assets/timelineevents.json
+++ b/src/test/elements/hubspot/assets/timelineevents.json
@@ -1,0 +1,4 @@
+{
+  "id":"<<random.word>>",
+  "email":"<<internet.email>>"
+}

--- a/src/test/elements/hubspot/assets/timelineeventtypes.json
+++ b/src/test/elements/hubspot/assets/timelineeventtypes.json
@@ -1,0 +1,3 @@
+{
+  "name": "<<random.word>>"
+}

--- a/src/test/elements/hubspot/timeline-event-types.js
+++ b/src/test/elements/hubspot/timeline-event-types.js
@@ -30,18 +30,18 @@ suite.forElement('marketing', 'timeline-event-types', {payload: payload}, (test)
        .then(r => cloud.delete(`${test.api}/${eventTypes.id}`));
    };
 
-   it('it should allow CUD for /timeline-event-types/:id/properties', () => {
+   it('it should allow CUD for /timeline-event-types/:id/timelineEventTypesProperties', () => {
      const cb = (eventTypes) => {
        let eventProperties;
-       return cloud.post(`${test.api}/${eventTypes.id}/properties`,propertiesPayload)
+       return cloud.post(`${test.api}/${eventTypes.id}/timelineEventTypesProperties`,propertiesPayload)
          .then(r => {
              expect(r.body).to.contain.key('name');
              eventProperties = r.body;
              eventProperties.label = faker.random.word();
          })
-         .then(r => cloud.patch(`${test.api}/${eventTypes.id}/properties/${eventProperties.id}`,eventProperties))
+         .then(r => cloud.patch(`${test.api}/${eventTypes.id}/timelineEventTypesProperties/${eventProperties.id}`,eventProperties))
          .then(r => expect(r.body).to.contain.key('label'))
-         .then(r => cloud.delete(`${test.api}/${eventTypes.id}/properties/${eventProperties.id}`));
+         .then(r => cloud.delete(`${test.api}/${eventTypes.id}/timelineEventTypesProperties/${eventProperties.id}`));
      };
      return eventTypesWrap(cb);
    });

--- a/src/test/elements/hubspot/timeline-event-types.js
+++ b/src/test/elements/hubspot/timeline-event-types.js
@@ -1,0 +1,67 @@
+'use strict';
+
+const suite = require('core/suite');
+const cloud = require('core/cloud');
+const tools = require('core/tools');
+const expect = require('chakram').expect;
+const faker = require('faker');
+const payload = tools.requirePayload(`${__dirname}/assets/timelineeventtypes.json`);
+const propertiesPayload = tools.requirePayload(`${__dirname}/assets/timelineeventproperties.json`);
+const eventsPayload = tools.requirePayload(`${__dirname}/assets/timelineevents.json`);
+
+suite.forElement('marketing', 'timeline-event-types', {payload: payload}, (test) => {
+
+    test.should.supportPagination("id");
+
+    it('should support CUDS for /hubs/marketing/timeline-event-types', () => {
+      let createdId = null;
+      return cloud.post(test.api, payload)
+        .then(r => createdId = r.body.id)
+        .then(() => cloud.patch(`${test.api}/${createdId}`, payload))
+        .then(() => cloud.delete(`${test.api}/${createdId}`))
+        .then(() => cloud.get(test.api));
+    });
+
+  const eventTypesWrap = (cb) => {
+     let eventTypes;
+     return cloud.post(`${test.api}`, payload)
+       .then(r => eventTypes = r.body)
+       .then(r => cb(eventTypes))
+       .then(r => cloud.delete(`${test.api}/${eventTypes.id}`));
+   };
+
+   it('it should allow CUD for /timeline-event-types/:id/properties', () => {
+     const cb = (eventTypes) => {
+       let eventProperties;
+       return cloud.post(`${test.api}/${eventTypes.id}/properties`,propertiesPayload)
+         .then(r => {
+             expect(r.body).to.contain.key('name');
+             eventProperties = r.body;
+             eventProperties.label = faker.random.word();
+         })
+         .then(r => cloud.patch(`${test.api}/${eventTypes.id}/properties/${eventProperties.id}`,eventProperties))
+         .then(r => expect(r.body).to.contain.key('label'))
+         .then(r => cloud.delete(`${test.api}/${eventTypes.id}/properties/${eventProperties.id}`));
+     };
+     return eventTypesWrap(cb);
+   });
+
+   it('it should allow CRU for /timeline-event-types/:id/events', () => {
+     const cb = (eventTypes) => {
+       let events;
+       return cloud.post(`${test.api}/${eventTypes.id}/events`,eventsPayload)
+         .then(r => expect(r.body).to.be.empty)
+         .then(r => cloud.get(`${test.api}/${eventTypes.id}/events/${eventsPayload.id}`))
+         .then(r => {
+                    expect(r.body).to.contain.key('email');
+                    expect(r.body).to.have.property('id', `${eventsPayload.id}`);
+                    events = r.body;
+                    events.email = faker.internet.email();
+                  })
+        .then(r => cloud.patch(`${test.api}/${eventTypes.id}/events/${eventsPayload.id}`,events))
+        .then(r => expect(r.body).to.be.empty);
+     };
+     return eventTypesWrap(cb);
+   });
+
+});


### PR DESCRIPTION
## Highlights
* Added tests for timeline resource.

## Screenshot
- Churros Report - [hubspot churros marketing.txt](https://github.com/cloud-elements/churros/files/1884257/hubspot.churros.marketing.txt) . Some metadata tests are failing. Raised [defect ](https://rally1.rallydev.com/#/144349237612ud/detail/defect/211046505152?fdp=true) for that.


## Reference
* [SOBA](https://github.com/cloud-elements/soba/pull/8435)
* [RALLY-#US10495](https://rally1.rallydev.com/#/144349237612ud/detail/userstory/207345899004)

## Closes
* Closes #[US10495](https://rally1.rallydev.com/#/144349237612ud/detail/userstory/207345899004)