### PR TITLE
Tests to ensure that VDR metadata includes only mapped fields

### DIFF
--- a/src/test/elements/sfdc/assets/objects.json
+++ b/src/test/elements/sfdc/assets/objects.json
@@ -1,0 +1,41 @@
+{
+  "churrosTestObject": {
+    "fields": [{
+        "type": "string",
+        "path": "id"
+      },
+      {
+        "type": "string",
+        "path": "email"
+      },
+      {
+        "type": "string",
+        "path": "firstName"
+      }
+    ],
+    "level": "organization"
+  },
+  "churrosTestObjectXform": {
+    "level": "organization",
+    "vendorName": "Contact",
+    "fields": [{
+        "path": "id",
+        "vendorPath": "Id",
+        "level": "organization"
+      },
+      {
+        "path": "email",
+        "vendorPath": "Email",
+        "level": "organization"
+      }
+    ],
+    "configuration": [{
+      "type": "passThrough",
+      "properties": {
+        "fromVendor": false,
+        "toVendor": false
+      }
+    }],
+    "isLegacy": false
+  }
+}

--- a/src/test/elements/sfdc/metadata.js
+++ b/src/test/elements/sfdc/metadata.js
@@ -2,7 +2,9 @@
 
 //dependencies at the top
 const suite = require('core/suite');
+const cloud = require('core/cloud');
 const expect = require('chakram').expect;
+const resources = require('./assets/objects');
 
 suite.forElement('crm', 'metadata', (test) => {
 
@@ -17,6 +19,39 @@ suite.forElement('crm', 'metadata', (test) => {
     expect(metadata.filterable).to.exist;
     expect(metadata.createable).to.exist;
     expect(metadata.updateable).to.exist;
+  };
+
+  const validEmail = (r) => {
+    expect(r).to.have.statusCode(200);
+    expect(r.body.fields).to.not.be.null;
+    expect(r.body.fields).to.be.an('array');
+    let email = r.body.fields.find((obj) => { return obj.vendorPath === 'Email'; });
+    expect(email).to.not.be.null;
+    expect(email.filterable).to.exist;
+    expect(email.createable).to.exist.and.to.be.true;
+    expect(email.updateable).to.exist.and.to.be.true;
+    return true;
+  };
+
+  const validVdrMetadata = r => {
+    expect(r).to.have.statusCode(200);
+    expect(r.body.fields).to.be.an.array;
+    expect(r.body.fields.length).to.equal(2);
+
+    let field = r.body.fields.find((obj) => { return obj.vendorPath === 'Id'; });
+    expect(field).to.not.be.null;
+    field = r.body.fields.find((obj) => { return obj.path === 'id'; });
+    expect(field).to.not.be.null;
+
+    field = r.body.fields.find((obj) => { return obj.vendorPath === 'Email'; });
+    expect(field).to.not.be.null;
+    field = r.body.fields.find((obj) => { return obj.path === 'email'; });
+    expect(field).to.not.be.null;
+
+    field = r.body.fields.find((obj) => { return obj.vendorPath === 'FirstName'; });
+    expect(field).to.be.undefined;
+    field = r.body.fields.find((obj) => { return obj.path === 'firstName'; });
+    expect(field).to.be.undefined;
   };
 
   const validateSalutation = (r) => {
@@ -37,6 +72,27 @@ suite.forElement('crm', 'metadata', (test) => {
 
   test.withApi('/objects/contacts/metadata').withValidation(metaValid).withName(
     'should include filterable, createable, and updateable for canonical object metadata').should.return200OnGet();
+
+  it('should have email property with filterable, createable, and updateable metadata for VDR', () => {
+    return cloud.post('/organizations/objects/churrosTestObject/definitions', resources.churrosTestObject, () => {})
+      .then(r => cloud.post('/organizations/elements/sfdc/transformations/churrosTestObject', resources.churrosTestObjectXform, () => {}))
+      .then(r => cloud.get('/objects/churrosTestObject/metadata'))
+      .then(r => validEmail(r))
+      .then(r => cloud.delete('/organizations/elements/sfdc/transformations/churrosTestObject'))
+      .then(r => cloud.delete('/organizations/objects/churrosTestObject/definitions'));
+  });
+
+  it('should include only mapped fields for VDR metadata', () => {
+    return cloud.post('/organizations/objects/churrosTestObject/definitions', resources.churrosTestObject, () => {})
+      .then(r => cloud.post('/organizations/elements/sfdc/transformations/churrosTestObject', resources.churrosTestObjectXform, () => {}))
+      .then(r => cloud.get('/objects/churrosTestObject/metadata'))
+      .then(r => validVdrMetadata(r))
+      .then(r => cloud.delete('/organizations/elements/sfdc/transformations/churrosTestObject'))
+      .then(r => cloud.delete('/organizations/objects/churrosTestObject/definitions'));
+  });
+
+  test.withApi('/objects/contacts/metadata').withValidation(metaValid).withName(
+    'should include only defined fields for VDR object metadata').should.return200OnGet();
 
   test.withApi('/objects/contacts/metadata').withValidation(validateSalutation).withName(
     'should include picklist for canonical contact metadata').should.return200OnGet();


### PR DESCRIPTION
## Highlights
* When the `GET /objects/{objectName}/metadata` API is used for VDRs, the metadata for only those fields that are mapped in the VDR should be returned

## Screenshot
Please include a screenshot of the tests running successfully
![image](https://user-images.githubusercontent.com/3017448/38581309-ba533892-3cc9-11e8-8920-af91ccd88dd3.png)


## Reference
* [SOBA PR 8462](https://github.com/cloud-elements/soba/pull/8462)
* [DE1318](https://rally1.rallydev.com/#/144349238268d/detail/defect/211748346892)

## Closes
* Closes #DE1318
