### PR TITLE
Bullhorn : Added testcase for job-orders APIs

### DIFF
--- a/src/test/elements/bullhorn/assets/job-orders.json
+++ b/src/test/elements/bullhorn/assets/job-orders.json
@@ -1,0 +1,11 @@
+{
+   "clientContact": {
+      "firstName": "Mayur Dhande",
+      "lastName": "Mayur dhande",
+      "id": 582
+    },
+    "clientCorporation": {
+      "name": "GS",
+      "id": 73
+    }
+}

--- a/src/test/elements/bullhorn/job-orders.js
+++ b/src/test/elements/bullhorn/job-orders.js
@@ -1,0 +1,18 @@
+'use strict';
+const suite = require('core/suite');
+const payload = require('./assets/job-orders');
+const expect = require('chakram').expect;
+
+suite.forElement('crm', 'job-orders', { payload: payload }, (test) => {
+  test.should.supportCruds();
+  test
+    .withOptions({ qs: { where: `dateAdded >= 1516384739657` } })
+    .withName('should support Ceql date search')
+    .withValidation(r => {
+      expect(r).to.statusCode(200);
+      const validValues = r.body.filter(obj => new Date(obj.dateAdded).getTime() >= 1516384739657);
+      expect(validValues.length).to.equal(r.body.length);
+    })
+    .should.return200OnGet();
+  test.should.supportPagination('id');
+});


### PR DESCRIPTION
## Highlights
* Added testcase for Job-orders CRUDS.

## Screenshot
![churros-bullhorn](https://user-images.githubusercontent.com/20634723/38726196-227dc144-3f27-11e8-89fa-da620488785f.PNG)

## Reference
* [SOBA](https://github.com/cloud-elements/soba/pull/8480)
* [RALLY-#${US10847}](https://rally1.rallydev.com/#/144349237612ud/detail/userstory/210887131944)

## Closes
* [US10847](https://rally1.rallydev.com/#/144349237612ud/detail/userstory/210887131944)
