### PR TITLE
Oracle Sales Cloud:Post and Patch request payload for opportunities

### DIFF
--- a/src/test/elements/oraclesalescloud/assets/models_opportunities_patch.json
+++ b/src/test/elements/oraclesalescloud/assets/models_opportunities_patch.json
@@ -1,42 +1,18 @@
 {
-  "SalesMethodId": 300000000118806,
-  "OptyLastUpdateDate": "2018-03-05T09:59:26.001+00:00",
-  "UpsideAmount": 0,
-  "ExpectAmount": 0,
-  "StatusCode": "OPEN",
-  "Name": "optName",
-  "CurrencyCode": "USD",
-  "OwnerResourcePartyId": 300000001367905,
-  "PrimaryOrganizationId": 300000001341151,
-  "links": [
-    {
-      "kind": "item",
-      "rel": "self",
-      "name": "opportunities",
-      "href": "https://ucf5-fap0642-crm.oracledemos.com:443/salesApi/resources/11.1.11/opportunities/17002",
-      "properties": {
-        "changeIndicator": "ACED0005737200136A6176612E7574696C2E41727261794C6973747881D21D99C7619D03000149000473697A65787000000002770400000002737200116A6176612E6C616E672E496E746567657212E2A0A4F781873802000149000576616C7565787200106A6176612E6C616E672E4E756D62657286AC951D0B94E08B0200007870000000017371007E00020000000178"
-      }
-    },
-    {
-      "kind": "item",
-      "rel": "canonical",
-      "name": "opportunities",
-      "href": "https://ucf5-fap0642-crm.oracledemos.com:443/salesApi/resources/11.1.11/opportunities/17002"
-    }
-  ],
-  "DownsideAmount": 0,
-  "BudgetedFlag": false,
-  "OptyCreatedBy": "lisa.jones",
-  "SalesStageId": 300000000118812,
-  "WinProb": 0,
-  "OptyCreationDate": "2018-03-05T09:59:26+00:00",
-  "OptyLastUpdatedBy": "lisa.jones",
-  "SalesChannelCd": "ZPM_DIRECT_CHANNEL_TYPES",
-  "ForecastOverrideCode": "NEVER",
-  "Revenue": 0,
-  "ChampionFlag": false,
-  "PrimaryRevenueId": 300000081315687,
-  "Registered": "NO",
-  "EffectiveDate": "2018-03-25"
+    "Name": "opt67Ptach", 
+    "BudgetAvailableDate": "2018-05-06T09:59:26+00:00",
+    "Comments":"commentsPatch",
+    "Description": "LookingPatch",
+    "Registered": "NO",
+    "UpsideAmount": 12,
+    "ExpectAmount": 134,
+    "StatusCode": "OPEN",
+    "CurrencyCode": "INR",
+    "Revenue": 10,
+    "DownsideAmount": 2,
+    "BudgetedFlag": true,
+    "WinProb": 1,
+    "ForecastOverrideCode": "NEVER",
+    "ChampionFlag": true,
+    "EffectiveDate": "2018-04-26"
 }

--- a/src/test/elements/oraclesalescloud/assets/models_opportunities_post.json
+++ b/src/test/elements/oraclesalescloud/assets/models_opportunities_post.json
@@ -1,42 +1,19 @@
 {
-  "SalesMethodId": 300000000118806,
-  "OptyLastUpdateDate": "2018-03-05T09:59:26.001+00:00",
-  "UpsideAmount": 0,
-  "ExpectAmount": 0,
-  "StatusCode": "OPEN",
-  "Name": "opt46",
-  "CurrencyCode": "USD",
-  "OwnerResourcePartyId": 300000001367905,
-  "PrimaryOrganizationId": 300000001341151,
-  "links": [
-    {
-      "kind": "item",
-      "rel": "self",
-      "name": "opportunities",
-      "href": "https://ucf5-fap0642-crm.oracledemos.com:443/salesApi/resources/11.1.11/opportunities/17002",
-      "properties": {
-        "changeIndicator": "ACED0005737200136A6176612E7574696C2E41727261794C6973747881D21D99C7619D03000149000473697A65787000000002770400000002737200116A6176612E6C616E672E496E746567657212E2A0A4F781873802000149000576616C7565787200106A6176612E6C616E672E4E756D62657286AC951D0B94E08B0200007870000000017371007E00020000000178"
-      }
-    },
-    {
-      "kind": "item",
-      "rel": "canonical",
-      "name": "opportunities",
-      "href": "https://ucf5-fap0642-crm.oracledemos.com:443/salesApi/resources/11.1.11/opportunities/17002"
-    }
-  ],
-  "DownsideAmount": 0,
-  "OptyNumber": "170028700",
-  "BudgetedFlag": false,
-  "OptyCreatedBy": "lisa.jones",
-  "WinProb": 0,
-  "OptyCreationDate": "2018-03-05T09:59:26+00:00",
-  "OptyLastUpdatedBy": "lisa.jones",
-  "SalesChannelCd": "ZPM_DIRECT_CHANNEL_TYPES",
-  "ForecastOverrideCode": "NEVER",
-  "Revenue": 0,
-  "ChampionFlag": false,
-  "PrimaryRevenueId": 300000081315687,
-  "Registered": "NO",
-  "EffectiveDate": "2018-03-25"
+    "Name": "opt71", 
+    "BudgetAvailableDate": "2018-05-05T09:59:26+00:00",
+    "Comments":"comments",
+    "Description": "Looking for the Right Contacts, Characteristics, Determining the Need, Budget and Sponsor",
+    "Registered": "NO",
+    "UpsideAmount": 0,
+    "ExpectAmount": 0,
+    "StatusCode": "OPEN",
+    "CurrencyCode": "USD",
+    "Revenue": 0,
+    "DownsideAmount": 0,
+    "BudgetedFlag": false,
+    "OptyCreatedBy": "lisa.jones",
+    "WinProb": 0,
+    "ForecastOverrideCode": "NEVER",
+    "ChampionFlag": false,
+    "EffectiveDate": "2018-04-25"
 }


### PR DESCRIPTION
## Non-customer Highlights
 - Updated payloads for Oracle Sales Cloud - opportunities resource 
 - There are few fields for which the API gives error similar to following , so they are not put in the 
   payload (fields like `DeleteFlag ,DescriptionText ,EmailAddress,MaximumDaysInStage,PartyName1 ,PartyUniqueName1 ,PhaseCd ,PrimaryContactFormattedPhoneNumber,PrimaryContactPartyName`)
   {
      "requestId": "5ad498d0e4b0649d09e32afa",
      "message": "Request failed",
      "providerMessage": "Attribute AverageDaysAtStage in view object Opportunity cannot be set."
   } 
- `PrimaryRevenueId` gets posted without error but   GET and GET by id API fails for that posted record id. 
  So its been removed from the payload.
## Screenshot
PFA the screenshot the python script result with these payloads
![python script result osc opportunities](https://user-images.githubusercontent.com/30625203/38852752-a8865c6a-4238-11e8-8609-f07a5d0e74d0.png)

## Reference
* [RALLY-#{DE1234}](https://rally1.rallydev.com/#/144349237612ud/detail/defect/209288256268)

## Closes
* Closes #[DE1234](https://rally1.rallydev.com/#/144349237612ud/detail/defect/209288256268)
