### PR TITLE
Updated tests for Chargify

### DIFF
--- a/src/test/elements/chargify/product-families.js
+++ b/src/test/elements/chargify/product-families.js
@@ -13,14 +13,17 @@ suite.forElement('payment', 'product-families', (test) => {
     "description": "churros description",
     "handle": tools.random()
   };
-  test.withOptions({ qs: { where: 'direction=\'desc\''}}).should.return200OnGet();
-  it(`should allow GET for ${test.api}/{productFamilyId}`, () => {
+  test.withOptions({ qs: { where: 'direction=\'desc\'' } }).should.return200OnGet();
+  it(`should allow SR for ${test.api}/{productFamilyId}`, () => {
     let productFamilyId;
     return cloud.post(test.api, payload)
       .then(r => cloud.get(test.api))
       .then(r => productFamilyId = r.body[0].id)
-      .then(r => cloud.get(`${test.api}/${productFamilyId}`))
-      .then(r => cloud.post(`${test.api}/${productFamilyId}/products`, updatePayload));
+      .then(r => cloud.get(`${test.api}/${productFamilyId}`));
+  });
+  // skipping because no delete API is present for prdocuts resource
+  it.skip(`should allow POST for ${test.api}/{productFamilyId}/products`, () => {
+    return cloud.post(`${test.api}/${productFamilyId}/products`, updatePayload);
   });
   test.should.supportPagination();
 });

--- a/src/test/elements/chargify/product-families.js
+++ b/src/test/elements/chargify/product-families.js
@@ -8,6 +8,7 @@ const build = (overrides) => Object.assign({}, productsPayload, overrides);
 const updatePayload = build({ handle: tools.random() });
 
 suite.forElement('payment', 'product-families', (test) => {
+  let productFamilyId;
   const payload = {
     "name": "churros name",
     "description": "churros description",
@@ -15,7 +16,6 @@ suite.forElement('payment', 'product-families', (test) => {
   };
   test.withOptions({ qs: { where: 'direction=\'desc\'' } }).should.return200OnGet();
   it(`should allow SR for ${test.api}/{productFamilyId}`, () => {
-    let productFamilyId;
     return cloud.post(test.api, payload)
       .then(r => cloud.get(test.api))
       .then(r => productFamilyId = r.body[0].id)

--- a/src/test/elements/chargify/products.js
+++ b/src/test/elements/chargify/products.js
@@ -10,15 +10,12 @@ const updateProduct = (productName) => ({
 });
 
 suite.forElement('payment', 'products', (test) => {
-  test.withOptions({ qs: { where: 'direction=\'desc\''}}).should.return200OnGet();
   it(`should allow RU for ${test.api}`, () => {
-    let productId;
+    let productId = 3802547;
     let productName;
-    return cloud.get(`${test.api}`)
-      .then(r => productId = r.body[0].id)
-      .then(r => cloud.get(`${test.api}/${productId}`))
+    // no GET /products API is available and deleting existing products is not allowed
+    return cloud.get(`${test.api}/${productId}`)
       .then(r => productName = r.body.product.name)
       .then(r => cloud.patch(`${test.api}/${productId}`, updateProduct(productName)));
   });
-  test.should.supportPagination();
 });

--- a/src/test/elements/chargify/subscriptions.js
+++ b/src/test/elements/chargify/subscriptions.js
@@ -6,8 +6,7 @@ const cloud = require('core/cloud');
 const subscriptionPayload = tools.requirePayload(`${__dirname}/assets/subscriptions.json`);
 
 suite.forElement('payment', 'subscriptions', { payload: subscriptionPayload }, (test) => {
-  test.withOptions({ qs: { where: 'direction=\'desc\''}}).should.return200OnGet();
-//  test.should.supportCrds();
+  test.withOptions({ qs: { where: 'direction=\'desc\'' } }).should.return200OnGet();
 
   it(`should allow SR for ${test.api}`, () => {
     let subscriptionId;

--- a/src/test/elements/chargify/subscriptions.js
+++ b/src/test/elements/chargify/subscriptions.js
@@ -2,10 +2,22 @@
 
 const suite = require('core/suite');
 const tools = require('core/tools');
+const cloud = require('core/cloud');
 const subscriptionPayload = tools.requirePayload(`${__dirname}/assets/subscriptions.json`);
 
 suite.forElement('payment', 'subscriptions', { payload: subscriptionPayload }, (test) => {
   test.withOptions({ qs: { where: 'direction=\'desc\''}}).should.return200OnGet();
-  test.should.supportCrds();
+//  test.should.supportCrds();
+
+  it(`should allow SR for ${test.api}`, () => {
+    let subscriptionId;
+    return cloud.get(test.api)
+      .then(r => subscriptionId = r.body[0].id)
+      .then(r => cloud.get(`${test.api}/${subscriptionId}`));
+  });
+  // skipping because no deleting subscriptions doesn't actually deletes
+  it.skip(`should allow POST for ${test.api}`, () => {
+    return cloud.post(test.api, subscriptionPayload);
+  });
   test.should.supportPagination();
 });


### PR DESCRIPTION
## Highlights
* Skipped POST tests for /subscriptions and /product-families/products as deleting subscriptions and products archives the items instead of deleting.
* Removed POST /products from `products` test suite as no API available on CE platform.
* Vendor doc is [here](https://reference.chargify.com/v1/basics/introduction).
* Test for GET /products is removed as no vendor API is present for this. Raised a bug [DE1389 ](https://rally1.rallydev.com/#/144349237612ud/detail/defect/213671799188) to update element for the same.

## Screenshot
Report- [chargify churros.txt](https://github.com/cloud-elements/churros/files/1918793/chargify.churros.txt)
## Reference
* [RALLY-#DE1292](https://rally1.rallydev.com/#/144349237612ud/detail/defect/211017348380)

## Closes
* Closes #[DE1292](https://rally1.rallydev.com/#/144349237612ud/detail/defect/211017348380)
