### PR TITLE
[On-Hold] Sharepoint : Added test cases for sites resource

### DIFF
--- a/src/test/elements/assets/object.definitions.json
+++ b/src/test/elements/assets/object.definitions.json
@@ -2513,5 +2513,14 @@
       "path": "id",
       "type": "string"
     }]
+  },
+  "sites": {
+    "fields": [{
+      "path": "idTransformed",
+      "type": "string"
+    }, {
+      "path": "id",
+      "type": "string"
+    }]
   }
 }

--- a/src/test/elements/sharepoint/assets/listItems.json
+++ b/src/test/elements/sharepoint/assets/listItems.json
@@ -1,0 +1,6 @@
+{
+  "__metadata": {
+    "type": "SP.Data.April02ListItem"
+  },
+  "Title": "Sample List Item April 02"
+}

--- a/src/test/elements/sharepoint/assets/listItems.json
+++ b/src/test/elements/sharepoint/assets/listItems.json
@@ -2,5 +2,5 @@
   "__metadata": {
     "type": "SP.Data.April02ListItem"
   },
-  "Title": "Sample List Item April 02"
+  "Title": "<<random.word>>"
 }

--- a/src/test/elements/sharepoint/assets/sites.json
+++ b/src/test/elements/sharepoint/assets/sites.json
@@ -1,0 +1,13 @@
+{
+  "parameters": {
+    "__metadata": {
+        "type": "SP.WebInfoCreationInformation"
+    },
+    "Url": "RestSubWeb",
+    "Title": "RestSubWeb",
+    "Description": "All team projects",
+    "Language": 1033,
+    "WebTemplate": "sts",
+    "UseUniquePermissions": false
+  }
+}

--- a/src/test/elements/sharepoint/assets/sitesLists.json
+++ b/src/test/elements/sharepoint/assets/sitesLists.json
@@ -1,0 +1,10 @@
+{
+  "__metadata": {
+    "type": "SP.List"
+  },
+  "AllowContentTypes": true,
+  "BaseTemplate": 100,
+  "ContentTypesEnabled": true,
+  "Description": "<<random.word>>",
+  "Title": "<<random.word>>"
+}

--- a/src/test/elements/sharepoint/assets/transformations.json
+++ b/src/test/elements/sharepoint/assets/transformations.json
@@ -1,0 +1,9 @@
+{
+  "sites": {
+    "vendorName": "sites",
+    "fields": [{
+      "path": "id",
+      "vendorPath": "Id"
+    }]
+  }
+}

--- a/src/test/elements/sharepoint/sites.js
+++ b/src/test/elements/sharepoint/sites.js
@@ -2,7 +2,6 @@
 
 const suite = require('core/suite');
 const tools = require('core/tools');
-const expect = require('chakram').expect;
 const cloud = require('core/cloud');
 
 let listPayload = tools.requirePayload(`${__dirname}/assets/sitesLists.json`);

--- a/src/test/elements/sharepoint/sites.js
+++ b/src/test/elements/sharepoint/sites.js
@@ -1,0 +1,35 @@
+'use strict';
+
+const suite = require('core/suite');
+const tools = require('core/tools');
+const expect = require('chakram').expect;
+
+let listPayload = tools.requirePayload(`${__dirname}/assets/sitesLists.json`);
+let sitePayload = tools.requirePayload(`${__dirname}/assets/sites.json`);
+let listItemsPayload = tools.requirePayload(`${__dirname}/assets/listItems.json`);
+
+suite.forElement('documents', 'sites/lists', { payload: listPayload }, (test) => {
+  test.should.supportCrud();
+  test.should.supportPagination();
+  test
+    .withOptions({ qs: { where: 'Modified > \'2018-04-12T06:47:33Z\'' } })
+    .withName('should support search by filter')
+    .withValidation(r => {
+      expect(r).to.statusCode(200);
+      const validValues = r.body.filter(obj => obj.Modified = '2018-04-12T06:47:33Z');
+      expect(validValues.length).to.equal(r.body.length);
+    })
+    .should.return200OnGet();
+});
+
+it('should support CUDS for sites', () => {
+  let categoryId = -1;
+  return cloud.post(`${test.api}`, sitePayload)
+    .then(r => cloud.get(`${test.api}`))
+    .then(r => cloud.patch(`${test.api}`, sitePayload))
+    .then(r => cloud.delete(`${test.api}`));
+});
+
+suite.forElement('documents', 'sites/lists/{id}/items', { payload: listItemsPayload }, (test) => {
+  test.should.supportCruds();
+});

--- a/src/test/elements/sharepoint/sites.js
+++ b/src/test/elements/sharepoint/sites.js
@@ -3,33 +3,63 @@
 const suite = require('core/suite');
 const tools = require('core/tools');
 const expect = require('chakram').expect;
+const cloud = require('core/cloud');
 
 let listPayload = tools.requirePayload(`${__dirname}/assets/sitesLists.json`);
 let sitePayload = tools.requirePayload(`${__dirname}/assets/sites.json`);
 let listItemsPayload = tools.requirePayload(`${__dirname}/assets/listItems.json`);
 
-suite.forElement('documents', 'sites/lists', { payload: listPayload }, (test) => {
-  test.should.supportCrud();
-  test.should.supportPagination();
-  test
-    .withOptions({ qs: { where: 'Modified > \'2018-04-12T06:47:33Z\'' } })
-    .withName('should support search by filter')
-    .withValidation(r => {
-      expect(r).to.statusCode(200);
-      const validValues = r.body.filter(obj => obj.Modified = '2018-04-12T06:47:33Z');
-      expect(validValues.length).to.equal(r.body.length);
-    })
-    .should.return200OnGet();
-});
+suite.forElement('documents', 'sites', { payload: listPayload }, (test) => {
 
-it('should support CUDS for sites', () => {
-  let categoryId = -1;
-  return cloud.post(`${test.api}`, sitePayload)
-    .then(r => cloud.get(`${test.api}`))
-    .then(r => cloud.patch(`${test.api}`, sitePayload))
-    .then(r => cloud.delete(`${test.api}`));
-});
+  it.skip('should support CUDS for sites', () => {
+    return cloud.get(`${test.api}`)
+      .then(r => cloud.post(`${test.api}`))
+      .then(r => cloud.patch(`${test.api}`, sitePayload))
+      .then(r => cloud.delete(`${test.api}`));
+  });
 
-suite.forElement('documents', 'sites/lists/{id}/items', { payload: listItemsPayload }, (test) => {
-  test.should.supportCruds();
+  it('should support CRUDS for sites/lists', () => {
+    let listId;
+    const updateListPayload = {
+      "__metadata": {
+        "type": "SP.List"
+      },
+      "BaseTemplate": 100,
+      "Title": "Churros-UpdateListTitle"  
+    };
+    return cloud.post(`${test.api}/lists`, listPayload)
+      .then(r => listId = r.body.Id)
+      .then(r => cloud.get(`${test.api}/lists/${listId}`))
+      .then(r => cloud.get(`${test.api}/lists`))
+      .then(r => cloud.patch(`${test.api}/lists/${listId}`, updateListPayload))
+      .then(r => cloud.delete(`${test.api}/lists/${listId}`));
+  });
+
+  it('should support CRUDS for sites/lists/{id}/items', () => {
+    let listId;
+    let itemId;
+    let fullName;
+    const updateListItemPayload = {
+      "__metadata": {
+        "type": "SP.Data.April02ListItem"
+      },
+      "Title": "Churros-List Item"
+    };
+    return cloud.post(`${test.api}/lists`, listPayload)
+      .then(r => listId = r.body.Id)
+      .then(r => cloud.get(`${test.api}/lists/${listId}`))
+      .then(r => fullName = r.body.ListItemEntityTypeFullName)
+      .then(r => {
+        listItemsPayload.__metadata.type = fullName;
+      })
+      .then(r => cloud.post(`${test.api}/lists/${listId}/items`, listItemsPayload))
+      .then(r => itemId = r.body.Id)
+      .then(r => cloud.get(`${test.api}/lists/${listId}/items/${itemId}`))
+      .then(r => cloud.get(`${test.api}/lists/${listId}/items`))
+      .then(r => {
+        updateListItemPayload.__metadata.type = fullName;
+      })
+      .then(r => cloud.patch(`${test.api}/lists/${listId}/items/${itemId}`, updateListItemPayload))
+      .then(r => cloud.delete(`${test.api}/lists/${listId}/items/${itemId}`));
+  });
 });

--- a/src/test/elements/sharepoint/sub-sites.js
+++ b/src/test/elements/sharepoint/sub-sites.js
@@ -1,0 +1,7 @@
+'use strict';
+
+const suite = require('core/suite');
+
+suite.forElement('documents', 'sub-sites', (test) => {
+  test.should.supportS();
+});


### PR DESCRIPTION
## Highlights
* Added test cases for supported operations of sites and its sub-resources.

## Non-Customer Highlights
* As of now POST and PATCH /sites is blocked due to permission issue so have skipped those test cases.
* Also, the DELETE operation seems like to delete the root site, so need to skip that as well.

## Screenshot
Please include a screenshot of the tests running successfully

## Reference
* [SOBA-yet to raise](Link to SOBA or Other PR for which tests were written, when applicable)
* [RALLY-US10674](https://rally1.rallydev.com/#/144349237612d/detail/userstory/209350374168)

## Closes
* [US10674](https://rally1.rallydev.com/#/144349237612d/detail/userstory/209350374168)
