### PR TITLE
Added churros for GET incidents/{id}/comments connectwisehd and connectwisecrm

### DIFF
--- a/src/test/elements/connectwisecrm/incidents.js
+++ b/src/test/elements/connectwisecrm/incidents.js
@@ -18,7 +18,7 @@ suite.forElement('crm', 'incidents', { payload: payload }, (test) => {
       .then(r => incidentId = r.body.id)
       .then(r => cloud.put(`${test.api}/${incidentId}/comments`, commentsPayload))
       .then(r => commentsId = r.body.id)
-	  .then(r => cloud.get(`${test.api}/${incidentId}/comments`))
+      .then(r => cloud.get(`${test.api}/${incidentId}/comments`))
       .then(r => cloud.get(`${test.api}/${incidentId}/comments/${commentsId}`))
       .then(r => cloud.patch(`${test.api}/${incidentId}/comments/${commentsId}`, {noteText: 'Hey, I am Churros, have fun', isPartOfResolution: true}))
       .then(r => cloud.delete(`${test.api}/${incidentId}`));

--- a/src/test/elements/connectwisecrm/incidents.js
+++ b/src/test/elements/connectwisecrm/incidents.js
@@ -11,13 +11,14 @@ suite.forElement('crm', 'incidents', { payload: payload }, (test) => {
   test.withOptions({ qs: { where: 'summary=\'Sample API Posted Issue From Churros\'' } }).should.return200OnGet();
   test.should.supportPagination('id');
 
-  it('should allow CRU for /hubs/crm/incidents/{id}/comments', () => {
+  it('should allow CRUS for /hubs/crm/incidents/{id}/comments', () => {
     let incidentId = -1;
     let commentsId = -1;
     return cloud.post(test.api, payload)
       .then(r => incidentId = r.body.id)
       .then(r => cloud.put(`${test.api}/${incidentId}/comments`, commentsPayload))
       .then(r => commentsId = r.body.id)
+	  .then(r => cloud.get(`${test.api}/${incidentId}/comments`))
       .then(r => cloud.get(`${test.api}/${incidentId}/comments/${commentsId}`))
       .then(r => cloud.patch(`${test.api}/${incidentId}/comments/${commentsId}`, {noteText: 'Hey, I am Churros, have fun', isPartOfResolution: true}))
       .then(r => cloud.delete(`${test.api}/${incidentId}`));

--- a/src/test/elements/connectwisehd/incidents.js
+++ b/src/test/elements/connectwisehd/incidents.js
@@ -18,7 +18,7 @@ suite.forElement('helpdesk', 'incidents', { payload: payload }, (test) => {
       .then(r => incidentId = r.body.id)
       .then(r => cloud.put(`${test.api}/${incidentId}/comments`, commentsPayload))
       .then(r => commentsId = r.body.id)
-	  .then(r => cloud.get(`${test.api}/${incidentId}/comments`))
+      .then(r => cloud.get(`${test.api}/${incidentId}/comments`))
       .then(r => cloud.get(`${test.api}/${incidentId}/comments/${commentsId}`))
       .then(r => cloud.patch(`${test.api}/${incidentId}/comments/${commentsId}`, {noteText: 'Hey, I am Churros, have fun', isPartOfResolution: true}))
       .then(r => cloud.delete(`${test.api}/${incidentId}`));

--- a/src/test/elements/connectwisehd/incidents.js
+++ b/src/test/elements/connectwisehd/incidents.js
@@ -11,13 +11,14 @@ suite.forElement('helpdesk', 'incidents', { payload: payload }, (test) => {
   test.withOptions({ qs: { where: 'summary=\'Sample API Posted Issue From Churros\'' } }).should.return200OnGet();
   test.should.supportPagination('id');
 
-  it('should allow CRU for /hubs/helpdesk/incidents/{id}/comments', () => {
+  it('should allow CRUS for /hubs/helpdesk/incidents/{id}/comments', () => {
     let incidentId = -1;
     let commentsId = -1;
     return cloud.post(test.api, payload)
       .then(r => incidentId = r.body.id)
       .then(r => cloud.put(`${test.api}/${incidentId}/comments`, commentsPayload))
       .then(r => commentsId = r.body.id)
+	  .then(r => cloud.get(`${test.api}/${incidentId}/comments`))
       .then(r => cloud.get(`${test.api}/${incidentId}/comments/${commentsId}`))
       .then(r => cloud.patch(`${test.api}/${incidentId}/comments/${commentsId}`, {noteText: 'Hey, I am Churros, have fun', isPartOfResolution: true}))
       .then(r => cloud.delete(`${test.api}/${incidentId}`));


### PR DESCRIPTION
## Highlights
* Added testcase for `GET /incidents/{id}/comments` for `ConnectWise` and `ConnectWise CRM`

## Screenshot
a) ConnectWise 
![connectwisehd](https://user-images.githubusercontent.com/20634723/39035583-3009fadc-4498-11e8-91b6-64879f45bf7e.PNG)

b) ConnectWise CRM
![connectwisecrm_churros](https://user-images.githubusercontent.com/20634723/39035593-3951c99e-4498-11e8-8f40-5031fe459ceb.PNG)

## Reference
* [SOBA](https://github.com/cloud-elements/soba/pull/8530)
* [US11022](https://rally1.rallydev.com/#/144349237612ud/detail/userstory/212708562068)

## Closes
* [US11022](https://rally1.rallydev.com/#/144349237612ud/detail/userstory/212708562068)
