### PR TITLE
Enhanced - Acton  with /object/listsContacts/metadata test cases

### DIFF
--- a/src/test/elements/acton/lists.js
+++ b/src/test/elements/acton/lists.js
@@ -7,6 +7,7 @@ const contactPayload = tools.requirePayload(`${__dirname}/assets/contacts.json`)
 const contactUpdatePayload = tools.requirePayload(`${__dirname}/assets/contactsUpdate.json`);
 const fs = require('fs');
 const cloud = require('core/cloud');
+const expect = require('chakram').expect;
 
 suite.forElement('marketing', 'lists', { payload: payload }, (test) => {
 
@@ -77,6 +78,15 @@ suite.forElement('marketing', 'lists', { payload: payload }, (test) => {
       .then(fi => filteredLists = fi)
       .then(() => cloud.post(`/hubs/marketing/lists/${filteredLists[0].id}/contacts`, contactPayload))
       .then(contacts => cloud.get(`/hubs/marketing/lists/${filteredLists[0].id}/contacts/${contacts.body[0].id}`));
+  });
+
+  it('it should support GET a /objects/listsContacts/metadata', () => {
+    let filteredLists;
+    return cloud.get('/hubs/marketing/lists')
+      .then(r => filteredLists = r.body.filter(r => r.id))
+      .then(() => cloud.post(`/hubs/marketing/lists/${filteredLists[0].id}/contacts`, contactPayload))
+      .then(r => cloud.withOptions({ qs: { discoveryId: `${filteredLists[0].id}`} }).get(`/hubs/marketing/objects/listsContacts/metadata`))
+      .then(r => expect(r.body.fields).to.not.be.empty);
   });
 
   it('it should support PATCH a contact inside a list', () => {


### PR DESCRIPTION
## Highlights
* Added Testcase related to `/objects/{listsContacts}/metadata` to dynamically generate metadata based on listId.

## Checklist
* [x] applicable churros tests are still passing
* [ ] includes a dbdeploy script that is backward-incompatible with one previous Soba minor version

## Screenshot
![screen shot 2018-04-23 at 12 14 27 pm](https://user-images.githubusercontent.com/26943831/39142488-7501926c-46f0-11e8-99c7-025685967b4e.png)

[Soba](https://github.com/cloud-elements/soba/pull/8484)

## Closes
[DE1153](https://rally1.rallydev.com/#/144349237612d/detail/defect/206739677860)
[DE1152](https://rally1.rallydev.com/#/144349237612d/detail/defect/206738611664)