### PR TITLE
Intacct: Added churros for missing endpoints

### DIFF
--- a/src/test/elements/assets/object.definitions.json
+++ b/src/test/elements/assets/object.definitions.json
@@ -447,6 +447,33 @@
       }
     ]
   },
+  "debit-memos": {
+    "fields": [{
+      "path": "idTransformed",
+      "type": "string"
+    }, {
+      "path": "id",
+      "type": "string"
+    }]
+  },
+  "sales-receipts": {
+    "fields": [{
+      "path": "idTransformed",
+      "type": "string"
+    }, {
+      "path": "id",
+      "type": "string"
+    }]
+  },
+   "deposits": {
+    "fields": [{
+      "path": "idTransformed",
+      "type": "string"
+    }, {
+      "path": "id",
+      "type": "string"
+    }]
+  },
   "credit-terms": {
     "fields": [
       {

--- a/src/test/elements/intacct/assets/creditMemos.json
+++ b/src/test/elements/intacct/assets/creditMemos.json
@@ -1,0 +1,27 @@
+{
+  "customerid": "AGR001",
+  "datecreated": {
+    "year": "2010",
+    "month": "03",
+    "day": "31"
+  },
+  "dateposted": {
+    "year": "2010",
+    "month": "03",
+    "day": "31"
+  },
+  "batchkey": "6",
+  "adjustmentno": "Pymst-207621",
+  "action": "Draft",
+  "invoiceno": "207621",
+  "description": "",
+  "basecurr": "USD",
+  "currency": "USD",
+  "exchratetype": "Test",
+  "aradjustmentitems": {
+    "lineitem":[ {
+      "glaccountno": "4000",
+      "amount": "-150"
+    }]
+  }
+}

--- a/src/test/elements/intacct/assets/customers.json
+++ b/src/test/elements/intacct/assets/customers.json
@@ -1,5 +1,4 @@
 {
-	"recordno": 28,
 	"comments": "WAT",
 	"visibility": {
 		"visibility_type": null

--- a/src/test/elements/intacct/assets/debitMemos.json
+++ b/src/test/elements/intacct/assets/debitMemos.json
@@ -1,0 +1,51 @@
+{
+  "vendorid": "V101",
+  "datecreated": {
+    "year": "2010",
+    "month": "03",
+    "day": "31"
+  },
+  "dateposted": {
+    "year": "2010",
+    "month": "03",
+    "day": "31"
+  },
+          "customfields": {
+          "customfield": [
+            {
+              "customfieldname": "TESTDATer2",
+              "customfieldvalue": "12/10/2002"
+            },
+            {
+              "customfieldname": "TESTTEXTer2",
+              "customfieldvalue": "CustomFieldTextLineItemer2"
+            }
+          ]
+        },
+  "batchkey": "4",
+  "adjustmentno": "Pymst-207621",
+  "action": "Draft",
+  "basecurr": "USD",
+  "currency": "USD",
+  "exchratetype": "Test",
+  "apadjustmentitems": {
+    "lineitem": [
+      {
+        "glaccountno": "4000",
+        "amount": "-150",
+        "customfields": {
+          "customfield": [
+            {
+              "customfieldname": "TESTDATer2",
+              "customfieldvalue": "12/10/2002"
+            },
+            {
+              "customfieldname": "TESTTEXTer2",
+              "customfieldvalue": "CustomFieldTextLineItemer2"
+            }
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/src/test/elements/intacct/assets/deposits.json
+++ b/src/test/elements/intacct/assets/deposits.json
@@ -1,0 +1,19 @@
+{
+   "bankaccountid": "Teampay",
+   "depositdate": {
+      "year": "2018",
+      "month": "04",
+      "day": "30"
+   },
+   "depositid": "Deposit Slip 2015-06-30",
+   "receiptkeys": {
+      "receiptkey": ["2874"]
+   },
+   "description": "Desc",
+   "customfields": {
+      "customfield":[ {
+         "customfieldname": "customfield1",
+         "customfieldvalue": "customvalue1"
+      }]
+   }
+}

--- a/src/test/elements/intacct/assets/expense-report-patch.json
+++ b/src/test/elements/intacct/assets/expense-report-patch.json
@@ -1,12 +1,12 @@
 {
   "employeeid": "1",
   "datecreated": {
-    "year": "2016",
+    "year": "2018",
     "month": "09",
     "day": "09"
   },
   "dateposted": {
-    "year": "2016",
+    "year": "2018",
     "month": "09",
     "day": "09"
   },

--- a/src/test/elements/intacct/assets/expense-reports.json
+++ b/src/test/elements/intacct/assets/expense-reports.json
@@ -38,7 +38,7 @@
         "day": "01"
       },
       "expensedate": {
-        "year": "2015",
+        "year": "2018",
         "month": "09",
         "day": "01"
       },

--- a/src/test/elements/intacct/assets/expense-reports.json
+++ b/src/test/elements/intacct/assets/expense-reports.json
@@ -1,12 +1,12 @@
 {
   "employeeid": "1",
   "datecreated": {
-    "year": "2016",
+    "year": "2018",
     "month": "09",
     "day": "09"
   },
   "dateposted": {
-    "year": "2016",
+    "year": "2018",
     "month": "09",
     "day": "09"
   },

--- a/src/test/elements/intacct/assets/invoices.json
+++ b/src/test/elements/intacct/assets/invoices.json
@@ -1,17 +1,17 @@
 {
   "customerid": "TSY003",
   "datecreated": {
-    "year": "2014",
+    "year": "2018",
     "month": "10",
     "day": "10"
   },
   "dateposted": {
-    "year": "2015",
+    "year": "2018",
     "month": "10",
     "day": "10"
   },
   "datedue": {
-    "year": "2016",
+    "year": "2018",
     "month": "10",
     "day": "10"
   },

--- a/src/test/elements/intacct/assets/sales-orders.json
+++ b/src/test/elements/intacct/assets/sales-orders.json
@@ -1,12 +1,12 @@
 {
   "dateposted": {
     "month": "08",
-    "year": 2010,
+    "year": 2018,
     "day": 30
   },
   "datedue": {
     "month": "08",
-    "year": 2010,
+    "year": 2018,
     "day": 30
   },
   "transactionstate": "Pending",

--- a/src/test/elements/intacct/assets/salesReceipts.json
+++ b/src/test/elements/intacct/assets/salesReceipts.json
@@ -1,0 +1,23 @@
+{
+   "paymentdate": {
+      "year": "2017",
+      "month": "01",
+      "day": "25"
+   },
+   "payee": "Costco",
+   "receiveddate": {
+      "year": "2018",
+      "month": "01",
+      "day": "26"
+   },
+   "paymentmethod": "EFT",
+   "undepglaccountno": "1001",
+   "refid": "1234",
+   "description": "ddd",
+   "receiptitems": {
+      "lineitem":[ {
+         "glaccountno": "4000",
+         "amount": "50.99"
+      }]
+   }
+}

--- a/src/test/elements/intacct/assets/transformations.json
+++ b/src/test/elements/intacct/assets/transformations.json
@@ -201,5 +201,41 @@
       "path": "id",
       "vendorPath": "RECORDNO"
     }]
+  },
+    "credit-memos": {
+    "vendorName": "",
+    "fields": [
+      {
+        "path": "id",
+        "vendorPath": "aradjustmentid"
+      }
+    ]
+  },
+  "debit-memos": {
+    "vendorName": "",
+    "fields": [
+      {
+        "path": "id",
+        "vendorPath": "apadjustmentid"
+      }
+    ]
+  },
+  "sales-receipts": {
+    "vendorName": "",
+    "fields": [
+      {
+        "path": "id",
+        "vendorPath": "OTHERRECEIPTSid"
+      }
+    ]
+  },
+  "deposits": {
+    "vendorName": "",
+    "fields": [
+      {
+        "path": "id",
+        "vendorPath": "RECORDNO"
+      }
+    ]
   }
 }

--- a/src/test/elements/intacct/bills.js
+++ b/src/test/elements/intacct/bills.js
@@ -8,17 +8,17 @@ const vendorPayload = tools.requirePayload(`${__dirname}/assets/vendor.json`);
 const payload = (vendorId) => ({
   "vendorid": vendorId,
   "datecreated": {
-    "year": "2010",
+    "year": "2018",
     "month": "10",
     "day": "13"
   },
   "dateposted": {
-    "year": "2010",
+    "year": "2018",
     "month": "10",
     "day": "13"
   },
   "datedue": {
-    "year": "2010",
+    "year": "2018",
     "month": "10",
     "day": "26"
   },

--- a/src/test/elements/intacct/contracts.js
+++ b/src/test/elements/intacct/contracts.js
@@ -5,6 +5,7 @@ const tools = require('core/tools');
 const payload = tools.requirePayload(`${__dirname}/assets/contracts.json`);
 
 suite.forElement('payment', 'contracts', { payload: payload}, (test) => {
+  //for this resorces we need some specail permissions and account we are using in churros does not have that permissions hence APIs are failing for permission issue.
   test.should.supportCruds();
   test.should.supportNextPagePagination(2);
 });

--- a/src/test/elements/intacct/credit-memos.js
+++ b/src/test/elements/intacct/credit-memos.js
@@ -1,0 +1,19 @@
+'use strict';
+
+const suite = require('core/suite');
+const tools = require('core/tools');
+const expect = require('chakram').expect;
+
+const payload = tools.requirePayload(`${__dirname}/assets/creditMemos.json`);
+
+suite.forElement('finance', 'credit-memos', { payload: payload }, (test) => {
+  test.should.supportCrs();
+  test.should.supportPagination();
+  test.withName('should support customerid=AGR001 Ceql search')
+  .withOptions({ qs: { where: 'customerid= \'AGR001\'' } })
+  .withValidation(r => {
+    expect(r).to.statusCode(200);
+    const validValues = r.body.filter(obj => obj.customerid = 'AGR001');
+    expect(validValues.length).to.equal(r.body.length);
+  }).should.return200OnGet();
+});

--- a/src/test/elements/intacct/debit-memos.js
+++ b/src/test/elements/intacct/debit-memos.js
@@ -1,0 +1,19 @@
+'use strict';
+
+const suite = require('core/suite');
+const tools = require('core/tools');
+const expect = require('chakram').expect;
+
+const payload = tools.requirePayload(`${__dirname}/assets/debitMemos.json`);
+
+suite.forElement('finance', 'debit-memos', { payload: payload }, (test) => {
+  test.should.supportCrs();
+  test.should.supportPagination();
+  test.withName('should support vendorid= V102 Ceql search')
+  .withOptions({ qs: { where: ' vendorid=\'V102\'' } })
+  .withValidation(r => {
+    expect(r).to.statusCode(200);
+    const validValues = r.body.filter(obj => obj.vendorid = 'V102');
+    expect(validValues.length).to.equal(r.body.length);
+  }).should.return200OnGet();
+});

--- a/src/test/elements/intacct/deposits.js
+++ b/src/test/elements/intacct/deposits.js
@@ -1,0 +1,30 @@
+'use strict';
+
+const suite = require('core/suite');
+const tools = require('core/tools');
+const expect = require('chakram').expect;
+const cloud = require('core/cloud');
+
+const payload = tools.requirePayload(`${__dirname}/assets/deposits.json`);
+const SalesPayload = tools.requirePayload(`${__dirname}/assets/salesReceipts.json`);
+suite.forElement('finance', 'deposits', { payload: payload }, (test) => {
+  before(() => cloud.post('/hubs/humancapital/sales-receipts', SalesPayload)
+    .then(r => payload.receiptkeys.receiptkey[0] = r.body.id));
+  test.should.supportSr();
+  it(`should allow CRUDS for ${test.api}`, () => {
+    let Did;
+    return cloud.post(test.api, payload)
+           .then(r=> cloud.get(`${test.api}`)
+           .then(r => Did =r.body[0].id))
+           .then(r => cloud.get(`${test.api}/${Did}`));
+  });
+
+  test.should.supportNextPagePagination(2,false);
+  test.withOptions({ qs: { where: `WHENMODIFIED ='08/13/2016 05:26:37'` } })
+  .withName('should support Ceql WHENMODIFIED search')
+  .withValidation(r => {
+    expect(r).to.statusCode(200);
+    const validValues = r.body.filter(obj => obj.WHENMODIFIED = '08/13/2016 05:26:37');
+    expect(validValues.length).to.equal(r.body.length);
+  }).should.return200OnGet();
+});

--- a/src/test/elements/intacct/deposits.js
+++ b/src/test/elements/intacct/deposits.js
@@ -7,8 +7,9 @@ const cloud = require('core/cloud');
 
 const payload = tools.requirePayload(`${__dirname}/assets/deposits.json`);
 const SalesPayload = tools.requirePayload(`${__dirname}/assets/salesReceipts.json`);
+
 suite.forElement('finance', 'deposits', { payload: payload }, (test) => {
-  before(() => cloud.post('/hubs/humancapital/sales-receipts', SalesPayload)
+  before(() => cloud.post('/hubs/finance/sales-receipts', SalesPayload)
     .then(r => payload.receiptkeys.receiptkey[0] = r.body.id));
   test.should.supportSr();
   it(`should allow CRUDS for ${test.api}`, () => {

--- a/src/test/elements/intacct/sales-receipts.js
+++ b/src/test/elements/intacct/sales-receipts.js
@@ -1,0 +1,19 @@
+'use strict';
+
+const suite = require('core/suite');
+const tools = require('core/tools');
+const expect = require('chakram').expect;
+
+const payload = tools.requirePayload(`${__dirname}/assets/salesReceipts.json`);
+
+suite.forElement('finance', 'sales-receipts', { payload: payload }, (test) => {
+  test.should.supportCrs();
+  test.should.supportNextPagePagination(2,false);
+  test.withOptions({ qs: { where: `WHENMODIFIED ='08/13/2016 05:26:37'` } })
+  .withName('should support Ceql WHENMODIFIED search')
+  .withValidation(r => {
+    expect(r).to.statusCode(200);
+    const validValues = r.body.filter(obj => obj.WHENMODIFIED = '08/13/2016 05:26:37');
+    expect(validValues.length).to.equal(r.body.length);
+  }).should.return200OnGet();
+});

--- a/src/test/elements/intacct/vouchers.js
+++ b/src/test/elements/intacct/vouchers.js
@@ -7,12 +7,12 @@ const cloud = require('core/cloud');
 const payload = (vendorId) => ({
   "vendorid": vendorId,
   "datecreated": {
-    "year": "2010",
+    "year": "2018",
     "month": "03",
     "day": "31"
   },
   "dateposted": {
-    "year": "2014",
+    "year": "2018",
     "month": "03",
     "day": "31"
   },


### PR DESCRIPTION
## Highlights
* Added churros for credit-memos, debit-memos, deposits and sales-receipts APIs 

## Non-Customer Highlights : 
* For contracts object we dont have permission hence it is failing
*  Sales-order API is failing on snapshot and staging also, not have correct values in the payload
## Screenshot
> Churros initialization successful!
PS C:\Users\GS-1259\CE-4656\churros\finalch\churros-sauce> churros test elements/intacct


info: Using url: http://localhost:8080
info: Using user: madhuri.kadam@gslab.com
info: Running tests for element: intacct
info: Provisioned with instance id of 817
  Basic tests
    √ should provision
    √ should GET /objects (457ms)
    - docs
    √ metadata (489ms)
error: Failed to retrieve or validate: /hubs/finance/attachments
error: Failed to retrieve or validate: /hubs/finance/contracts
    1) transformations
    - should not allow provisioning with bad credentials

  bills-payments
    √ should allow SR for /hubs/finance/bills-payments (7145ms)
    √ should support Ceql date search (3596ms)
    √ should allow paginating with page and nextPage /hubs/finance/bills-payments (4569ms)

  bills
    √ should allow CRDS for /hubs/finance/bills (19102ms)
    √ should allow paginating with page and pageSize for /hubs/finance/bills (7654ms)
    √ should support updated > {date} Ceql search (5123ms)

  chargecard-transactions
    √ should allow SR for /hubs/finance/chargecard-transactions (3777ms)
    √ should allow paginating with page and nextPage /hubs/finance/chargecard-transactions (4129ms)
    √ should support Ceql WHENMODIFIED search (1294ms)

  checking-accounts
    √ should allow SR for /hubs/finance/checking-accounts (3665ms)
    √ should allow paginating with page and nextPage /hubs/finance/checking-accounts (5062ms)
    √ should support Ceql WHENMODIFIED search (2487ms)

  classes
    √ should allow CRUDS for /hubs/finance/classes (11444ms)
    √ should allow paginating with page and pageSize for /hubs/finance/classes (6253ms)
    √ should support updated > {date} Ceql search (2244ms)

  contacts
    √ should allow CRDS for /hubs/finance/contacts (8842ms)
    √ should allow PATCH for /hubs/finance/contacts/{id} (4717ms)
    √ should allow paginating with page and pageSize for /hubs/finance/contacts (5414ms)
    √ should support status Ceql search (3051ms)

  contracts
error: Failed to create or validate: /hubs/payment/contracts
    2) should allow CRUDS for /hubs/payment/contracts
error: Failed to retrieve or validate: /hubs/payment/contracts
    3) should allow paginating with page and nextPage /hubs/payment/contracts

  credit-memos
    √ should allow CRS for /hubs/finance/credit-memos (5637ms)
    √ should allow paginating with page and pageSize for /hubs/finance/credit-memos (3873ms)
    √ should support customerid=AGR001 Ceql search (3223ms)

  customers
    √ should allow CRUDS for /hubs/finance/customers (11421ms)
    √ should allow paginating with page and pageSize for /hubs/finance/customers (7151ms)
    √ should support updated > {date} Ceql search (3009ms)

  debit-memos
    √ should allow CRS for /hubs/finance/debit-memos (6117ms)
    √ should allow paginating with page and pageSize for /hubs/finance/debit-memos (4689ms)
    √ should support vendorid= V102 Ceql search (949ms)

  departments
    √ should allow CRUDS for /hubs/finance/departments (8181ms)
    √ should allow paginating with page and pageSize for /hubs/finance/departments (6411ms)
    √ should support updated > {date} Ceql search (2474ms)

  deposits
    √ should allow SR for /hubs/finance/deposits (2211ms)
    √ should allow CRUDS for /hubs/finance/deposits (5848ms)
    √ should allow paginating with page and nextPage /hubs/finance/deposits (2747ms)
    √ should support Ceql WHENMODIFIED search (1880ms)

  employees
    √ should allow CRDS for /hubs/finance/employees (12209ms)
    √ should allow PATCH for /hubs/finance/employees/{id} (11945ms)
    √ should allow paginating with page and pageSize for /hubs/finance/employees (8154ms)
    √ should support updated > {date} Ceql search (4289ms)

  exchange-rate-entries
    √ should allow SR for /hubs/payment/exchange-rate-entries (3604ms)
    √ should allow paginating with page and nextPage /hubs/payment/exchange-rate-entries (2831ms)

  exchange-rate-types
    √ should allow SR for /hubs/payment/exchange-rate-types (3369ms)
    √ should allow paginating with page and nextPage /hubs/payment/exchange-rate-types (2929ms)

  exchange-rates
    - should allow CRS for /hubs/payment/exchange-rates
    - should allow paginating with page and nextPage /hubs/payment/exchange-rates

  expense-reports
    √ should allow CRDS for /hubs/finance/expense-reports (11275ms)
    √ should allow PATCH for /hubs/finance/expense-reports/{id} (7182ms)
    √ should allow paginating with page and pageSize for /hubs/finance/expense-reports (6682ms)
    √ should support Ceql batchKey search (2553ms)

  folders
    √ should allow CRUDS for /hubs/finance/folders (12646ms)
    √ should allow paginating with page and pageSize for /hubs/finance/folders (5125ms)
    √ should support description = {string} Ceql search (1744ms)
    √ should allow CRUDS for /hubs/finance/folders/5agy3oozuw/files (6322ms)
    √ should allow paginating with page and pageSize for /hubs/finance/folders/2hk3c3y1rp/files (5841ms)
    √ should support  description = {string} Ceql search (1217ms)

  invoices
error: Failed to delete /hubs/finance/folders/5agy3oozuw
    √ should allow CRUDS for /hubs/finance/invoices (16084ms)
    √ should allow paginating with page and pageSize for /hubs/finance/invoices (6263ms)
    √ should support updated > {date} Ceql search (3625ms)

  items
    √ should allow CRUDS for /hubs/finance/items (14300ms)
    √ should allow paginating with page and pageSize for /hubs/finance/items (5841ms)
    √ should support updated > {date} Ceql search (3089ms)

  journals
    √ should allow CRUDS for /hubs/finance/journals (9698ms)
    √ should allow paginating with page and pageSize for /hubs/finance/journals (6002ms)
    √ should support updated > {date} Ceql search (2145ms)

  ledger-accounts
    √ should allow CRUDS for /hubs/finance/ledger-accounts (11893ms)
    √ should allow paginating with page and pageSize for /hubs/finance/ledger-accounts (5879ms)
    √ should support updated > {date} Ceql search (2190ms)

  locations
    √ should allow CRUDS for /hubs/finance/locations (10954ms)
    √ should allow paginating with page and pageSize for /hubs/finance/locations (7546ms)
    √ should support updated > {date} Ceql search (2726ms)

  /objects
    √ should support GET /objects/chargecardTransactions/metadata (2142ms)
    √ should support GET /objects/chargecardTransactions/metadata customFieldsOnly parameter (2883ms)
    √ should support GET /objects/billsPayments/metadata (3963ms)
    √ should support GET /objects/billsPayments/metadata customFieldsOnly parameter (2283ms)
    √ should support GET /objects/checkingAccounts/metadata (2550ms)
    √ should support GET /objects/checkingAccounts/metadata customFieldsOnly parameter (2504ms)
    √ should support GET /objects/exchangeRateEntries/metadata (1358ms)
    √ should support GET /objects/exchangeRateEntries/metadata customFieldsOnly parameter (2159ms)
    √ should support GET /objects/exchangeRates/metadata (1196ms)
    √ should support GET /objects/exchangeRates/metadata customFieldsOnly parameter (2420ms)
    √ should support GET /objects/exchangeRateTypes/metadata (1381ms)
    √ should support GET /objects/exchangeRateTypes/metadata customFieldsOnly parameter (1890ms)

  payments
    - should allow CRS for /hubs/finance/payments
    - should allow paginating with page and pageSize for /hubs/finance/payments
    - should support updated > {date} Ceql search
    - should allow C for /hubs/finance/payments/{id}/apply

  ping
    √ should allow GET for /hubs/finance/ping (236ms)

  polling
    - polling /hubs/finance/customers
    - polling /hubs/finance/employees
    - polling /hubs/finance/invoices
    - polling /hubs/finance/items
    - polling /hubs/finance/journals
    - polling /hubs/finance/ledger-accounts
    - polling /hubs/finance/payments
    - polling /hubs/finance/vendors

  projects
    √ should allow CRUDS for /hubs/finance/projects (11786ms)
    √ should allow paginating with page and pageSize for /hubs/finance/projects (6152ms)
    √ should support updated > {date} Ceql search (2971ms)

  purchase-orders
    - should allow CRDS for /hubs/finance/purchase-orders
    - should allow paginating with page and pageSize for /hubs/finance/purchase-orders
    - should support updated > {date} Ceql search

  reporting-periods
    √ should allow GET for /hubs/finance/reporting-periods (2713ms)
    √ should allow paginating with page and pageSize for /hubs/finance/reporting-periods (7372ms)
    √ should support status = {string} Ceql search (2868ms)

  sales-orders
error: Failed to create or validate: /hubs/finance/sales-orders
    4) should allow CRUDS for /hubs/finance/sales-orders
    √ should allow paginating with page and pageSize for /hubs/finance/sales-orders (7120ms)
    √ should support updated > {date} Ceql search (4491ms)

  sales-receipts
    √ should allow CRS for /hubs/finance/sales-receipts (9953ms)
    √ should allow paginating with page and nextPage /hubs/finance/sales-receipts (3791ms)
    √ should support Ceql WHENMODIFIED search (1569ms)

  terms
    √ should allow SR for /hubs/finance/terms (3893ms)
    √ should allow CUD for /hubs/finance/terms (5984ms)
    √ should allow paginating with page and pageSize for /hubs/finance/terms (6844ms)
    √ should support updated > {date} Ceql search (2025ms)

  transactions
    - should allow CRDS for /hubs/finance/transactions
    - should allow GET for /hubs/finance/transactions-entries
    - should allow paginating with page and pageSize for /hubs/finance/transactions
    - should support updated > {date} Ceql search

  vendors
    √ should allow CRDS for /hubs/finance/vendors (12215ms)
    √ should allow paginating with page and pageSize for /hubs/finance/vendors (6682ms)
    √ should support updated > {date} Ceql search (4708ms)
    √ should support paginated search and return less than requested (20880ms)

  vouchers
    √ should allow CRDS for /hubs/finance/vouchers (16326ms)
    √ should allow paginating with page and pageSize for /hubs/finance/vouchers (5662ms)
    √ should support updated > {date} Ceql search (3089ms)

  warehouses
    √ should allow SR for /hubs/finance/warehouses (4002ms)
    √ should allow paginating with page and pageSize for /hubs/finance/warehouses (7381ms)
    √ should support updated > {date} Ceql search (2089ms)


  109 passing (12m)
  23 pending
  4 failing

  1) Basic tests transformations:
     Error: AssertionError: expected 200 to equal 0
      at cloud.delete.catch.then.catch.then.then.catch.then (C:\Users\GS-1259\CE-4656\churros\finalch\churros\src\test\e
lements\assets\basics.js:124:17)
      at _fulfilled (C:\Users\GS-1259\CE-4656\churros\finalch\churros\node_modules\q\q.js:854:54)
      at self.promiseDispatch.done (C:\Users\GS-1259\CE-4656\churros\finalch\churros\node_modules\q\q.js:883:30)
      at Promise.promise.promiseDispatch (C:\Users\GS-1259\CE-4656\churros\finalch\churros\node_modules\q\q.js:816:13)
      at C:\Users\GS-1259\CE-4656\churros\finalch\churros\node_modules\q\q.js:624:44
      at runSingle (C:\Users\GS-1259\CE-4656\churros\finalch\churros\node_modules\q\q.js:137:13)
      at flush (C:\Users\GS-1259\CE-4656\churros\finalch\churros\node_modules\q\q.js:125:13)
      at _combinedTickCallback (internal/process/next_tick.js:67:7)
      at process._tickCallback (internal/process/next_tick.js:98:9)

  2) contracts should allow CRUDS for /hubs/payment/contracts:

      AssertionError: expected status code 400 to equal 200 - { "requestId": "5ae6dfb40ab864963e29d143", "message": "Request failed", "providerMessage": "<?xml version=\"1.0\" encoding=\"UTF-8\"?><response><control><status>success</status><senderid>Cloud Elements</senderid><controlid>EFDWnk2vPu</controlid><uniqueid>false</uniqueid><dtdversion>3.0</dtdversion></control><operation><authentication><status>success</status><userid>admin</userid><companyid>Cloud Elements-DEV</companyid><sessiontimestamp>2018-04-30T02:27:53-07:00</sessiontimestamp></authentication><result><status>failure</status><function>readByQuery</function><controlid>6459906</controlid><errormessage><error><errorno>PL04000005</errorno><description></description><description2>You do not have permission for API operation READ on objects of type contract</description2><correction></correction></error></errormessage></result></operation></response>" }
      + expected - actual

      -false
      +true

      at chakram.addMethod (C:\Users\GS-1259\CE-4656\churros\finalch\churros\src\core\assertions.js:17:3)
      at .<anonymous> (C:\Users\GS-1259\CE-4656\churros\finalch\churros\node_modules\chakram\lib\plugins.js:123:22)
      at ctx.(anonymous function) (C:\Users\GS-1259\CE-4656\churros\finalch\churros\node_modules\chai\lib\chai\utils\add
Method.js:41:25)
      at doAsserterAsyncAndAddThen (C:\Users\GS-1259\CE-4656\churros\finalch\churros\node_modules\chai-as-promised\lib\c
hai-as-promised.js:296:33)
      at .<anonymous> (C:\Users\GS-1259\CE-4656\churros\finalch\churros\node_modules\chai-as-promised\lib\chai-as-promis
ed.js:255:21)
      at ctx.(anonymous function) (C:\Users\GS-1259\CE-4656\churros\finalch\churros\node_modules\chai\lib\chai\utils\ove
rwriteMethod.js:49:33)
      at doAsserterAsyncAndAddThen (C:\Users\GS-1259\CE-4656\churros\finalch\churros\node_modules\chai-as-promised\lib\c
hai-as-promised.js:296:33)
      at .<anonymous> (C:\Users\GS-1259\CE-4656\churros\finalch\churros\node_modules\chai-as-promised\lib\chai-as-promis
ed.js:255:21)
      at ctx.(anonymous function) [as statusCode] (C:\Users\GS-1259\CE-4656\churros\finalch\churros\node_modules\chai\li
b\chai\utils\overwriteMethod.js:49:33)
      at run (C:\Users\GS-1259\CE-4656\churros\finalch\churros\src\core\suite.js:735:133)
      at C:\Users\GS-1259\CE-4656\churros\finalch\churros\src\core\cloud.js:25:7
      at chakram.post.then.r (C:\Users\GS-1259\CE-4656\churros\finalch\churros\src\core\cloud.js:53:44)
      at _fulfilled (C:\Users\GS-1259\CE-4656\churros\finalch\churros\node_modules\q\q.js:854:54)
      at self.promiseDispatch.done (C:\Users\GS-1259\CE-4656\churros\finalch\churros\node_modules\q\q.js:883:30)
      at Promise.promise.promiseDispatch (C:\Users\GS-1259\CE-4656\churros\finalch\churros\node_modules\q\q.js:816:13)
      at C:\Users\GS-1259\CE-4656\churros\finalch\churros\node_modules\q\q.js:624:44
      at runSingle (C:\Users\GS-1259\CE-4656\churros\finalch\churros\node_modules\q\q.js:137:13)
      at flush (C:\Users\GS-1259\CE-4656\churros\finalch\churros\node_modules\q\q.js:125:13)
      at _combinedTickCallback (internal/process/next_tick.js:67:7)
      at process._tickCallback (internal/process/next_tick.js:98:9)

  3) contracts should allow paginating with page and nextPage /hubs/payment/contracts:

      AssertionError: expected status code 400 to equal 200 -  
{ "requestId": "5ae6dfb40ab864963e29d143", "message": "Request failed", "providerMessage": "<?xml version=\"1.0\" encoding=\"UTF-8\"?><response><control><status>success</status><senderid>Cloud Elements</senderid><controlid>EFDWnk2vPu</controlid><uniqueid>false</uniqueid><dtdversion>3.0</dtdversion></control><operation><authentication><status>success</status><userid>admin</userid><companyid>Cloud Elements-DEV</companyid><sessiontimestamp>2018-04-30T02:27:53-07:00</sessiontimestamp></authentication><result><status>failure</status><function>readByQuery</function><controlid>6459906</controlid><errormessage><error><errorno>PL04000005</errorno><description></description><description2>You do not have permission for API operation READ on objects of type contract</description2><correction></correction></error></errormessage></result></operation></response>" }
      + expected - actual

      -false
      +true

      at chakram.addMethod (C:\Users\GS-1259\CE-4656\churros\finalch\churros\src\core\assertions.js:17:3)
      at .<anonymous> (C:\Users\GS-1259\CE-4656\churros\finalch\churros\node_modules\chakram\lib\plugins.js:123:22)
      at ctx.(anonymous function) (C:\Users\GS-1259\CE-4656\churros\finalch\churros\node_modules\chai\lib\chai\utils\add
Method.js:41:25)
      at doAsserterAsyncAndAddThen (C:\Users\GS-1259\CE-4656\churros\finalch\churros\node_modules\chai-as-promised\lib\c
hai-as-promised.js:296:33)
      at .<anonymous> (C:\Users\GS-1259\CE-4656\churros\finalch\churros\node_modules\chai-as-promised\lib\chai-as-promis
ed.js:255:21)
      at ctx.(anonymous function) (C:\Users\GS-1259\CE-4656\churros\finalch\churros\node_modules\chai\lib\chai\utils\ove
rwriteMethod.js:49:33)
      at doAsserterAsyncAndAddThen (C:\Users\GS-1259\CE-4656\churros\finalch\churros\node_modules\chai-as-promised\lib\c
hai-as-promised.js:296:33)
      at .<anonymous> (C:\Users\GS-1259\CE-4656\churros\finalch\churros\node_modules\chai-as-promised\lib\chai-as-promis
ed.js:255:21)
      at ctx.(anonymous function) [as statusCode] (C:\Users\GS-1259\CE-4656\churros\finalch\churros\node_modules\chai\li
b\chai\utils\overwriteMethod.js:49:33)
      at run (C:\Users\GS-1259\CE-4656\churros\finalch\churros\src\core\suite.js:735:133)
      at C:\Users\GS-1259\CE-4656\churros\finalch\churros\src\core\cloud.js:25:7
      at chakram.get.then.r (C:\Users\GS-1259\CE-4656\churros\finalch\churros\src\core\cloud.js:69:44)
      at _fulfilled (C:\Users\GS-1259\CE-4656\churros\finalch\churros\node_modules\q\q.js:854:54)
      at self.promiseDispatch.done (C:\Users\GS-1259\CE-4656\churros\finalch\churros\node_modules\q\q.js:883:30)
      at Promise.promise.promiseDispatch (C:\Users\GS-1259\CE-4656\churros\finalch\churros\node_modules\q\q.js:816:13)
      at C:\Users\GS-1259\CE-4656\churros\finalch\churros\node_modules\q\q.js:624:44
      at runSingle (C:\Users\GS-1259\CE-4656\churros\finalch\churros\node_modules\q\q.js:137:13)
      at flush (C:\Users\GS-1259\CE-4656\churros\finalch\churros\node_modules\q\q.js:125:13)
      at _combinedTickCallback (internal/process/next_tick.js:67:7)
      at process._tickCallback (internal/process/next_tick.js:98:9)

  4) sales-orders should allow CRUDS for /hubs/finance/sales-orders:

      AssertionError: expected status code 400 to equal 200 - {"requestId":"5adf03e7cfe2b74f4afee1fe","message":"Request
 failed","providerMessage":"error - {errorno=PL03000004, description=null, description2=You are not using the default fa
ir value price list. This is not allowed when you choose not to override fair value price list in Order Entry Setup., co
rrection=null}"}
      + expected - actual

      -false
      +true

      at chakram.addMethod (C:\Users\GS-1259\CE-4656\churros\finalch\churros\src\core\assertions.js:17:3)
      at .<anonymous> (C:\Users\GS-1259\CE-4656\churros\finalch\churros\node_modules\chakram\lib\plugins.js:123:22)
      at ctx.(anonymous function) (C:\Users\GS-1259\CE-4656\churros\finalch\churros\node_modules\chai\lib\chai\utils\add
Method.js:41:25)
      at doAsserterAsyncAndAddThen (C:\Users\GS-1259\CE-4656\churros\finalch\churros\node_modules\chai-as-promised\lib\c
hai-as-promised.js:296:33)
      at .<anonymous> (C:\Users\GS-1259\CE-4656\churros\finalch\churros\node_modules\chai-as-promised\lib\chai-as-promis
ed.js:255:21)
      at ctx.(anonymous function) (C:\Users\GS-1259\CE-4656\churros\finalch\churros\node_modules\chai\lib\chai\utils\ove
rwriteMethod.js:49:33)
      at doAsserterAsyncAndAddThen (C:\Users\GS-1259\CE-4656\churros\finalch\churros\node_modules\chai-as-promised\lib\c
hai-as-promised.js:296:33)
      at .<anonymous> (C:\Users\GS-1259\CE-4656\churros\finalch\churros\node_modules\chai-as-promised\lib\chai-as-promis
ed.js:255:21)
      at ctx.(anonymous function) [as statusCode] (C:\Users\GS-1259\CE-4656\churros\finalch\churros\node_modules\chai\li
b\chai\utils\overwriteMethod.js:49:33)
      at C:\Users\GS-1259\CE-4656\churros\finalch\churros\src\core\cloud.js:33:25
      at chakram.post.then.r (C:\Users\GS-1259\CE-4656\churros\finalch\churros\src\core\cloud.js:53:44)
      at _fulfilled (C:\Users\GS-1259\CE-4656\churros\finalch\churros\node_modules\q\q.js:854:54)
      at self.promiseDispatch.done (C:\Users\GS-1259\CE-4656\churros\finalch\churros\node_modules\q\q.js:883:30)
      at Promise.promise.promiseDispatch (C:\Users\GS-1259\CE-4656\churros\finalch\churros\node_modules\q\q.js:816:13)
      at C:\Users\GS-1259\CE-4656\churros\finalch\churros\node_modules\q\q.js:624:44
      at runSingle (C:\Users\GS-1259\CE-4656\churros\finalch\churros\node_modules\q\q.js:137:13)
      at flush (C:\Users\GS-1259\CE-4656\churros\finalch\churros\node_modules\q\q.js:125:13)
      at _combinedTickCallback (internal/process/next_tick.js:67:7)
      at process._tickCallback (internal/process/next_tick.js:98:9)





## Reference
* [SOBA](https://github.com/cloud-elements/soba/pull/8556)
* [RALLY-#${TA14099}](https://rally1.rallydev.com/#/144349237612d/detail/task/215171706340)

## Closes
* Closes [#${US10844}](https://rally1.rallydev.com/#/144349237612d/detail/userstory/210886375752)
