### PR TITLE
Marketo: Added leads test suite

### DIFF
--- a/src/test/elements/marketo/assets/leads.json
+++ b/src/test/elements/marketo/assets/leads.json
@@ -1,0 +1,7 @@
+{
+  "person": {
+    "lastName": "<<name.lastName>>",
+    "firstName": "<<name.firstName>>",
+    "email": "<<internet.email>>"
+  }
+}

--- a/src/test/elements/marketo/leads.js
+++ b/src/test/elements/marketo/leads.js
@@ -20,7 +20,7 @@ suite.forElement('marketing', 'leads', { payload: payload }, (test) => {
       .then(r => cloud.get(`${test.api}/${id}`))
       .then(r => cloud.patch(`${test.api}/${id}`, updatedPayload))
       .then(r => cloud.withOptions({ qs: { where: `id in ( ${id} )` } }).get(test.api))
-      .then(r => expect(r.body).to.have.lengthOf(1))
+      .then(r => expect(r.body).to.have.lengthOf(1) && expect(r.body[0].person.id).to.equal(id))
       .then(r => cloud.delete(`${test.api}/${id}`));
   });
 

--- a/src/test/elements/marketo/leads.js
+++ b/src/test/elements/marketo/leads.js
@@ -3,7 +3,6 @@
 const suite = require('core/suite');
 const tools = require('core/tools');
 const cloud = require('core/cloud');
-const expect = require('chakram').expect;
 const payload = tools.requirePayload(`${__dirname}/assets/leads.json`);
 const updatedPayload = tools.requirePayload(`${__dirname}/assets/leads.json`);
 const interactionPayload = {

--- a/src/test/elements/marketo/leads.js
+++ b/src/test/elements/marketo/leads.js
@@ -1,15 +1,35 @@
 'use strict';
 
 const suite = require('core/suite');
+const tools = require('core/tools');
 const cloud = require('core/cloud');
+const expect = require('chakram').expect;
+const payload = tools.requirePayload(`${__dirname}/assets/leads.json`);
+const updatedPayload = tools.requirePayload(`${__dirname}/assets/leads.json`);
+const interactionPayload = {
+  "id": tools.randomInt(),
+  "token": tools.randomInt()
+};
 
-suite.forElement('marketing', 'programs', (test) => {
-  it('should allow R for programs/{id}/leads', () => {
-    let program;
-    return cloud.get(test.api)
-      .then(r => program = r.body[0])
-      .then(r => cloud.get(`${test.api}/${program.id}`));
+suite.forElement('marketing', 'leads', { payload: payload }, (test) => {
+  it('should allow CRUDS for /leads', () => {
+    let id;
+    return cloud.post(test.api, payload)
+      .then(r => id = r.body.person.id)
+      .then(r => cloud.get(`${test.api}/${id}`))
+      .then(r => cloud.patch(`${test.api}/${id}`, updatedPayload))
+      .then(r => cloud.withOptions({ qs: { where: `id in ( ${id} )` } }).get(test.api))
+      .then(r => cloud.delete(`${test.api}/${id}`));
+  });
+
+  it('should allow POST /leads/:id/merge and POST /leads/:id/interactions', () => {
+    let id, id2;
+    return cloud.post(test.api, payload)
+      .then(r => id = r.body.person.id)
+      .then(r => cloud.post(`${test.api}/${id}/interactions`, interactionPayload))
+      .then(r => cloud.post(test.api, updatedPayload))
+      .then(r => id2 = r.body.person.id)
+      .then(r => cloud.post(`${test.api}/${id}/merge`, { leadIds: [id2] }))
+      .then(r => cloud.delete(`${test.api}/${id}`));
   });
 });
-
-

--- a/src/test/elements/marketo/leads.js
+++ b/src/test/elements/marketo/leads.js
@@ -1,6 +1,8 @@
 'use strict';
 
 const suite = require('core/suite');
+const chakram = require('chakram');
+const expect = chakram.expect;
 const tools = require('core/tools');
 const cloud = require('core/cloud');
 const payload = tools.requirePayload(`${__dirname}/assets/leads.json`);
@@ -18,6 +20,7 @@ suite.forElement('marketing', 'leads', { payload: payload }, (test) => {
       .then(r => cloud.get(`${test.api}/${id}`))
       .then(r => cloud.patch(`${test.api}/${id}`, updatedPayload))
       .then(r => cloud.withOptions({ qs: { where: `id in ( ${id} )` } }).get(test.api))
+      .then(r => expect(r.body).to.have.lengthOf(1))
       .then(r => cloud.delete(`${test.api}/${id}`));
   });
 


### PR DESCRIPTION
## Highlights
* Added Test suite for `/leads` resource
  - GET `/leads`
  - POST `/leads`
  - DELETE `/leads/{id}`
  - GET `/leads/{id}`
  - PATCH `/leads/{id}`
  - POST `/leads/{leadId}/interactions`
  - POST `/leads/{leadId}/merge`

## Screenshot
![image](https://user-images.githubusercontent.com/34128818/39251388-c2dba0b4-48c0-11e8-9c49-77b626250bcc.png)

## Reference
* [SOBA](https://github.com/cloud-elements/soba/pull/8567)
* [DE1472](https://rally1.rallydev.com/#/144349237612d/detail/defect/215750227576)
* [US11328](https://rally1.rallydev.com/#/144349237612d/detail/userstory/214796117868)

## Closes
* [DE1472](https://rally1.rallydev.com/#/144349237612d/detail/defect/215750227576)
* [US11328](https://rally1.rallydev.com/#/144349237612d/detail/userstory/214796117868)
