### PR TITLE
Eloqua: Removed customFields test cases for account object

### DIFF
--- a/src/test/elements/eloqua/objectMetadata.js
+++ b/src/test/elements/eloqua/objectMetadata.js
@@ -9,8 +9,4 @@ suite.forElement('marketing', 'objectMetadata', (test) => {
     return cloud.withOptions({ qs:{  customFieldsOnly: true } }).get(`/objects/contact/metadata`)
     .then(r => expect(r.body.fields.filter(o => o.custom === true)).to.deep.equal(r.body.fields));
   });
-  it('should return custom fields only when customFieldsOnly=true for account' , () => {
-    return cloud.withOptions({ qs: { customFieldsOnly: true } }).get(`/objects/account/metadata`)
-    .then(r => expect(r.body.fields.filter(o => o.custom === true)).to.deep.equal(r.body.fields));
-  });
 });


### PR DESCRIPTION
## Highlights
* Removed customFields test cases for `account` object from objectMetadata test suite, because account object doesn't return any customFields in response and also doesn't specify anything about `customField:true/false`.
## Screenshot
```
PS C:\Users\gs-1108\Documents\GitHub\churros> churros test elements/eloqua

(node:16448) [DEP0022] DeprecationWarning: os.tmpDir() is deprecated. Use os.tmpdir() instead.

info: Using url: http://localhost:8080
info: Using user: pore@gslab.com
info: Using oauth username: Atul.Barve
info: Using api key: f4ae3e0d-e5eb-4d44-825d-21cccf81a6b7
info: Running tests for element: eloqua
info: Provisioned with instance id of 511
(node:16448) [DEP0013] DeprecationWarning: Calling an asynchronous function without callback is deprecated.
  Basic tests
    √ should provision
    √ should GET /objects (44650ms)
    - docs
    √ metadata (4324ms)
    √ transformations (130915ms)
    - should not allow provisioning with bad credentials

  accounts
    √ should allow CRUDS for /hubs/marketing/accounts (14983ms)
    √ should allow paginating with page and pageSize for /hubs/marketing/accounts (7016ms)
    √ should support searching /hubs/marketing/accounts by Country (1723ms)

  activity-types
    √ should allow GET for /hubs/marketing/activity-types (1430ms)
    √ should allow ping for eloqua (1424ms)

  bulk
error: Failed to retrieve or validate: /hubs/marketing/bulk/8/status
error: Failed to retrieve or validate: /hubs/marketing/bulk/8/status
    √ should support bulk download of a custom object (32059ms)
error: Failed to retrieve or validate: /hubs/marketing/bulk/9/status
    √ should support bulk download of a custom object using a transformation and select fields (26224ms)
error: Failed to retrieve or validate: /hubs/marketing/bulk/10/status
error: Failed to retrieve or validate: /hubs/marketing/bulk/10/status
error: Failed to retrieve or validate: /hubs/marketing/bulk/10/status
    √ should support bulk upload of a custom object (26339ms)
error: Failed to retrieve or validate: /hubs/marketing/bulk/11/status
error: Failed to retrieve or validate: /hubs/marketing/bulk/11/status
    √ should support bulk upload of a custom object using a transformation (15070ms)
error: Failed to retrieve or validate: /hubs/marketing/bulk/12/status
error: Failed to retrieve or validate: /hubs/marketing/bulk/12/status
error: Failed to retrieve or validate: /hubs/marketing/bulk/12/status
    √ should fail bulk insert due to a duplicate record (17121ms)

  campaigns
    √ should allow GET for /hubs/marketing/campaigns (60884ms)

  contacts
    √ should allow CRUDS for /hubs/marketing/contacts (71373ms)
    √ should allow paginating with page and pageSize for /hubs/marketing/contacts (27173ms)
    √ should support searching /hubs/marketing/contacts by id (20714ms)
    √ should allow GET for /hubs/marketing/contacts (11002ms)
    √ should allow GET for /hubs/marketing/contacts (7817ms)
    √ should allow GET hubs/marketing/contacts/{contactId}/activities (54033ms)

  content-sections
    √ should allow CRUDS for /hubs/marketing/content-sections (11117ms)
    √ should allow paginating with page and pageSize for /hubs/marketing/content-sections (5402ms)
    √ should support searching /hubs/marketing/content-sections by name (5483ms)

  custom-objects
    √ should allow CRUDS for /hubs/marketing/custom-objects (9902ms)
    √ should allow paginating with page and pageSize for /hubs/marketing/custom-objects (7166ms)
    √ should support searching /hubs/marketing/custom-objects by name (6196ms)

  email-footers
    √ should allow CRUDS for /hubs/marketing/email-footers (9973ms)
    √ should allow paginating with page and pageSize for /hubs/marketing/email-footers (5516ms)
    √ should support searching /hubs/marketing/email-footers by name (6770ms)

  email-headers
    √ should allow CRUDS for /hubs/marketing/email-headers (11737ms)
    √ should allow paginating with page and pageSize for /hubs/marketing/email-headers (5547ms)
    √ should support searching /hubs/marketing/email-headers by name (6666ms)

  emails
    √ should allow CRUDS for /hubs/marketing/emails (11436ms)
    √ should allow paginating with page and pageSize for /hubs/marketing/emails (5293ms)
    √ should support searching /hubs/marketing/emails by name (7000ms)

  extended-resource
    √ should test newly added account resource extended-resource (4991ms)

  landing-pages
    √ should allow CRUDS for /hubs/marketing/landing-pages (13649ms)
    √ should allow paginating with page and pageSize for /hubs/marketing/landing-pages (5393ms)
    √ should support searching /hubs/marketing/landing-pages by name (6074ms)

  lists
    √ should allow CRUDS for /hubs/marketing/lists (17414ms)
    √ should allow paginating with page and pageSize for /hubs/marketing/lists (8055ms)
    √ should support searching /hubs/marketing/lists by id (7920ms)
    √ should allow CRUDS for lists/{id}/contacts  (81136ms)

  objectMetadata
    √ should return custom fields only when customFieldsOnly=true for contact (9578ms)

  polling
    - polling /hubs/marketing/contacts
    - polling /hubs/marketing/custom-objects


  45 passing (16m)
  4 pending

```
## Reference
* [RALLY-#${DE1350}](https://rally1.rallydev.com/#/144349237612d/detail/defect/211257365744)

## Closes
* [DE1350](https://rally1.rallydev.com/#/144349237612d/detail/defect/211257365744)
