### PR TITLE
Docusign - Enhanced with /envelopes/{id}/documents/{documentId} Testcases

### DIFF
--- a/src/test/elements/docusign/envelopes.js
+++ b/src/test/elements/docusign/envelopes.js
@@ -27,7 +27,7 @@ suite.forElement('esignature', 'envelopes', (test) => {
       .then(r => cloud.get(`${test.api}/${envelopeId}/custom_fields`));
   });
 
-  it(`should support C on ${test.api}, SRU ${test.api}/:id/documents`, () => {
+  it(`should support C on ${test.api}, SRUD ${test.api}/:id/documents`, () => {
     let envelopeId = "-1";
     let path = __dirname + '/assets/MrRobotPdf.pdf';
     let documentPath = __dirname + '/assets/Test.pdf';
@@ -46,7 +46,8 @@ suite.forElement('esignature', 'envelopes', (test) => {
       .then(r => documentId = r.body[0].documentId)
       .then(r => cloud.withOptions(patchDocuments).patch(`${test.api}/${envelopeId}/documents/${documentId}`, undefined,
         (r) => expect(r).to.have.schemaAnd200(documentsSchema)))
-      .then(r => cloud.get(`${test.api}/${envelopeId}/documents/${documentId}`));
+      .then(r => cloud.get(`${test.api}/${envelopeId}/documents/${documentId}`)
+      .then(r => cloud.delete(`${test.api}/${envelopeId}/documents/${documentId}`)));
   });
 
   it(`should support Ceql search on ${test.api} and S on ${test.api}/:id/documents/certificates`, () => {


### PR DESCRIPTION
## Highlights
* Docusign - Added test cases for
`/envelopes/{id}/documents/{documentId}`

## Checklist
* [x] applicable churros tests are still passing
* [ ] includes a dbdeploy script that is backward-incompatible with one previous Soba minor version

## Screenshot
![screen shot 2018-04-26 at 12 07 18 pm](https://user-images.githubusercontent.com/26943831/39321468-c65e1ba4-494c-11e8-99a3-1104a7bc24c3.png)


## Related PRs
[soba](https://github.com/cloud-elements/soba/pull/8579)

## Closes
[US11535](https://rally1.rallydev.com/#/144349237612d/detail/userstory/216064319720)