### PR TITLE
Updated test cases for GET /contacts/{contactId}/activities

### DIFF
--- a/src/test/elements/hubspotcrm/contacts.js
+++ b/src/test/elements/hubspotcrm/contacts.js
@@ -12,7 +12,7 @@ var contactsId = 396139;
 
 suite.forElement('crm', 'contacts', { payload: payload }, (test) => {
   test.should.supportNextPagePagination(2);
-  test.withName('should allow pagination for all contacts with page and nextPage').withOptions({qs: { all: true }}).should.supportNextPagePagination(2);
+  test.withName('should allow pagination for all contacts with page and nextPage').withOptions({ qs: { all: true } }).should.supportNextPagePagination(2);
 
   it('should test CRUD for /contacts and GET /contacts/{id}/activities', () => {
     const updatePayload = {
@@ -29,8 +29,8 @@ suite.forElement('crm', 'contacts', { payload: payload }, (test) => {
       .then(r => cloud.get(`${test.api}/${contactId}/activities`))
       .then(r => cloud.withOptions(options).get(`${test.api}/${contactId}/activities`))
       .then(r => options.qs.nextPage = r.response.headers['elements-next-page-token'])
-      .then(r => cloud.withOptions(options).get(`${test.api}/${contactId}/activities`))
       .then(r => cloud.patch(`${test.api}/${contactId}`, updatePayload))
+      .then(r => cloud.get(`${test.api}/${contactId}/activities`))
       .then(r => cloud.delete(`${test.api}/${contactId}`));
   });
 
@@ -85,7 +85,4 @@ suite.forElement('crm', 'contacts', { payload: payload }, (test) => {
       .then(r => cloud.delete('/organizations/objects/churrosTestObject/definitions'));
   });
   test.should.supportNextPagePagination(1);
-});
-suite.forElement('crm', `contacts/${contactsId}/activities`, { payload: payload }, (test) => {
-  test.should.supportPagination();
 });

--- a/src/test/elements/hubspotcrm/pipelines.js
+++ b/src/test/elements/hubspotcrm/pipelines.js
@@ -9,7 +9,7 @@ suite.forElement('crm', 'pipelines', { payload: payload }, (test) => {
 
   it(`should allow CRUDS for ${test.api}`, () => {
     const updatePayload = {
-      "label": "test123Pipe",
+      "label": "test123PipeLbl",
       "displayOrder": 10,
       "stages": [{
         "label": "test123Pipe"


### PR DESCRIPTION
## Non-customer Highlights
* Updated test cases for `GET /contacts/{contactId}/activities` 

## Screenshot
(node:26004) [DEP0022] DeprecationWarning: os.tmpDir() is deprecated. Use os.tmpdir() instead.

info: Using url: http://localhost:8080
info: Using user: mithila.garud@gslab.com
info: Using oauth username: developer@cloud-elements.com
info: Using api key: da5693c8-48d8-4a54-90b0-9e83eb76a6fc
info: Running tests for element: hubspotcrm
Trying the portal ID: 3919835
info: Provisioned with instance id of 449
(node:26004) [DEP0013] DeprecationWarning: Calling an asynchronous function without callback is deprecated.
  Basic tests
    √ should provision
    √ should GET /objects (234ms)
    - docs
    √ metadata (149ms)
    √ transformations (5231ms)
    - should not allow provisioning with bad credentials

  accounts
    √ should allow paginating with page and pageSize for /hubs/crm/accounts (2910ms)
    √ should test CRUD for /accounts and GET /accounts/{id}/activities (7363ms)
    √ should test accounts poller url (12918ms)

  accounts/285826161/activities
    - should allow paginating with page and nextPage /hubs/crm/accounts/285826161/activities

  activities
    √ should allow CRUD for /hubs/crm/activities (4081ms)

  contacts-search
    √ should test newly added account resource contacts-search (930ms)

  contacts
    √ should allow paginating with page and nextPage /hubs/crm/contacts (1934ms)
    √ should allow pagination for all contacts with page and nextPage (1937ms)
    √ should test CRUD for /contacts and GET /contacts/{id}/activities (8575ms)
    √ should test contacts poller url (13324ms)
    √ should test get for xformed contact (4934ms)
    √ should allow paginating with page and nextPage /hubs/crm/contacts (718ms)

  leads
    √ should allow CRUDS for /hubs/crm/leads (6518ms)
    √ should allow paginating with page and pageSize for /hubs/crm/leads (2765ms)

  opportunities
    √ should allow CRUDS for /hubs/crm/opportunities (5421ms)
    √ should allow paginating with page and pageSize for /hubs/crm/opportunities (2976ms)
    √ should test opportunities poller url (13000ms)

  owners
    √ should allow S for /hubs/crm/owners (718ms)
    √ should allow paginating with page and pageSize for /hubs/crm/owners (2254ms)
    √ should support email search (816ms)

  pipelines
    √ should allow CRUDS for /hubs/crm/pipelines (5015ms)
    √ should allow paginating with page and pageSize for /hubs/crm/pipelines (2363ms)

  polling
    - polling /hubs/crm/accounts
    - polling /hubs/crm/contacts
    - polling /hubs/crm/opportunities

  timeline-event-types
    √ should allow paginating with page and pageSize for /hubs/crm/timeline-event-types (2866ms)
    √ should support CUDS for /hubs/crm/timeline-event-types (3903ms)
    √ it should allow CUD for /timeline-event-types/:id/properties (5562ms)
    √ it should allow CRU for /timeline-event-types/:id/events (5475ms)


  29 passing (3m)
  6 pending

## Reference
* [SOBA](https://github.com/cloud-elements/soba/pull/8601)
* [churros-sauce](https://github.com/cloud-elements/churros-sauce/pull/189)
* [RALLY-#DE1500](https://rally1.rallydev.com/#/144349237612d/detail/defect/216348486624)

## Closes
* Closes [#DE1500](https://rally1.rallydev.com/#/144349237612d/detail/defect/216348486624)
