### PR TITLE
Hootsuite: Added /interactions API test suite

### DIFF
--- a/src/test/elements/hootsuite/interactions.js
+++ b/src/test/elements/hootsuite/interactions.js
@@ -1,0 +1,10 @@
+'use strict';
+
+const suite = require('core/suite');
+const cloud = require('core/cloud');
+
+suite.forElement('social', 'interactions', (test) => {
+  
+  it(`should allow GET for ${test.api}`, () => {
+    return cloud.withOptions({ qs: { where: "socialNetworkType='Twitter' and socialNetworkId=82295100 and targetSocialNetworkId=876713392311902208" } }).get(`${test.api}`)});
+});


### PR DESCRIPTION
## Highlights
* Added `/interactions` GET API Testsuite
**NOTE:** The pagination test cases is not added since it is in broken state from vendor side, and i have already raise support ticket, once that is resolved I'll add the testcases.
```
[Ticket #1009719] Pagination broken for /interactions API

Lydia Thomas (Hootsuite Platform Team)

Apr 30, 00:59 PDT

Hello, 

Yes we got a response on this, there are two underlying issues, the first being that at the time of the request you made there were only ten interactions, anyway- there are now more so please try again and you should get the cursors. 

The limit number is a known issue and we have a ticket to fix it, it always returns the default 10. 

Thank you very much, please let me know how you get on with it. 

Lydia 
```

## Screenshot
![image](https://user-images.githubusercontent.com/34128818/39429381-5a3f4a24-4ca8-11e8-8d88-26f4df34b2f4.png)


## Reference
* [SOBA](https://github.com/cloud-elements/soba/pull/8603)
* [RALLY-#${US11276}](https://rally1.rallydev.com/#/144349237612d/detail/userstory/214543937372)

## Closes
* [US11276](https://rally1.rallydev.com/#/144349237612d/detail/userstory/214543937372)
