### PR TITLE
GoogleDrive - Updated testcases to support Quote and Backslash in folder name

### DIFF
--- a/src/test/elements/googledrive/assets/folders.json
+++ b/src/test/elements/googledrive/assets/folders.json
@@ -1,3 +1,3 @@
 {
-"path":"/quote'Andbackslash\\InFolderName"
+"path":"/TestDrive"
 }

--- a/src/test/elements/googledrive/assets/folders.json
+++ b/src/test/elements/googledrive/assets/folders.json
@@ -1,3 +1,3 @@
 {
-"path":"/TestDrive"
+"path":"/quote'Andbackslash\\InFolderName"
 }

--- a/src/test/elements/googledrive/assets/quotefolders.json
+++ b/src/test/elements/googledrive/assets/quotefolders.json
@@ -1,0 +1,3 @@
+{
+"path":"/quote'Andbackslash\\InFolderName"
+}

--- a/src/test/elements/googledrive/folders.js
+++ b/src/test/elements/googledrive/folders.js
@@ -6,6 +6,7 @@ const tools = require('core/tools');
 const expect = require('chakram').expect;
 const faker = require('faker');
 const payload = require('./assets/folders');
+const quoteFolderPayload = require('./assets/quotefolders');
 const updatePayload = {
   path: `/${tools.random()}`
 };
@@ -121,7 +122,7 @@ suite.forElement('documents', 'folders', { payload: payload }, (test) => {
 
   it(`should allow POST /folders with quote'Andbackslash\\InFolderName`, () => {
     let path;
-    return cloud.post(`${test.api}`, payload)
+    return cloud.post(`${test.api}`, quoteFolderPayload)
       .then(r => path = r.body.path)
       .then(r => cloud.withOptions({ qs: { path: `${path}` } }).delete(`${test.api}`));
   });

--- a/src/test/elements/googledrive/folders.js
+++ b/src/test/elements/googledrive/folders.js
@@ -11,7 +11,7 @@ const updatePayload = {
 };
 
 suite.forElement('documents', 'folders', { payload: payload }, (test) => {
-  let directoryPath = faker.random.uuid()+`quote'Andbackslash\\InFileName`,
+  let directoryPath = faker.random.uuid(),
     directoryId;
   let jpgFile = __dirname + '/assets/Penguins.jpg';
   let pngFile = __dirname + '/assets/Dice.png';

--- a/src/test/elements/googledrive/folders.js
+++ b/src/test/elements/googledrive/folders.js
@@ -119,4 +119,11 @@ suite.forElement('documents', 'folders', { payload: payload }, (test) => {
 
   test.withOptions({ qs: { path: '/' } }).withApi('/folders/contents').should.supportPagination('id');
 
+  it(`should allow POST /folders with quote'Andbackslash\\InFolderName`, () => {
+    let path;
+    return cloud.post(`${test.api}`, payload)
+      .then(r => path = r.body.path)
+      .then(r => cloud.withOptions({ qs: { path: `${path}` } }).delete(`${test.api}`))
+  });
+
 });

--- a/src/test/elements/googledrive/folders.js
+++ b/src/test/elements/googledrive/folders.js
@@ -11,7 +11,7 @@ const updatePayload = {
 };
 
 suite.forElement('documents', 'folders', { payload: payload }, (test) => {
-  let directoryPath = faker.random.uuid(),
+  let directoryPath = faker.random.uuid()+`quote'Andbackslash\\InFileName`,
     directoryId;
   let jpgFile = __dirname + '/assets/Penguins.jpg';
   let pngFile = __dirname + '/assets/Dice.png';

--- a/src/test/elements/googledrive/folders.js
+++ b/src/test/elements/googledrive/folders.js
@@ -123,7 +123,7 @@ suite.forElement('documents', 'folders', { payload: payload }, (test) => {
     let path;
     return cloud.post(`${test.api}`, payload)
       .then(r => path = r.body.path)
-      .then(r => cloud.withOptions({ qs: { path: `${path}` } }).delete(`${test.api}`))
+      .then(r => cloud.withOptions({ qs: { path: `${path}` } }).delete(`${test.api}`));
   });
 
 });


### PR DESCRIPTION
## Highlights
* Google Drive - Updated Test cases to support Quote and Backslash in FolderName

## Checklist
* [x] applicable churros tests are still passing
* [ ] includes a dbdeploy script that is backward-incompatible with one previous Soba minor version

## Screenshot
![screen shot 2018-05-01 at 4 15 50 pm](https://user-images.githubusercontent.com/26943831/39501674-d80698d4-4d81-11e8-915b-88118aa7159f.png)


## Related PRs
[Soba](https://github.com/cloud-elements/soba/pull/8610)

## Closes
[DE1438](https://rally1.rallydev.com/#/144349237612d/detail/defect/214838047168)