### PR TITLE
Added an integration test for metadata for a VDR with a nested object

### DIFF
--- a/src/test/elements/sfdc/assets/objects.json
+++ b/src/test/elements/sfdc/assets/objects.json
@@ -1,4 +1,11 @@
 {
+  "churrosTestNestedObject": {
+    "fields": [{
+      "type": "string",
+      "path": "phone"
+    }],
+    "level": "organization"
+  },
   "churrosTestObject": {
     "fields": [{
         "type": "string",
@@ -11,6 +18,10 @@
       {
         "type": "string",
         "path": "firstName"
+      },
+      {
+        "type": "churrosTestNestedObject",
+        "path": "nestedObject"
       }
     ],
     "level": "organization"
@@ -26,6 +37,11 @@
       {
         "path": "email",
         "vendorPath": "Email",
+        "level": "organization"
+      },
+      {
+        "path": "nestedObject.phone",
+        "vendorPath": "Phone",
         "level": "organization"
       }
     ],

--- a/src/test/elements/sfdc/metadata.js
+++ b/src/test/elements/sfdc/metadata.js
@@ -36,7 +36,7 @@ suite.forElement('crm', 'metadata', (test) => {
   const validVdrMetadata = r => {
     expect(r).to.have.statusCode(200);
     expect(r.body.fields).to.be.an.array;
-    expect(r.body.fields.length).to.equal(2);
+    expect(r.body.fields.length).to.equal(3);
 
     let field = r.body.fields.find((obj) => { return obj.vendorPath === 'Id'; });
     expect(field).to.not.be.null;
@@ -57,7 +57,7 @@ suite.forElement('crm', 'metadata', (test) => {
   const validVdrMetadataForNestedObject = r => {
     expect(r).to.have.statusCode(200);
     expect(r.body.fields).to.be.an.array;
-    expect(r.body.fields.length).to.equal(2);
+    expect(r.body.fields.length).to.equal(3);
 
     let field = r.body.fields.find((obj) => { return obj.vendorPath === 'Phone'; });
     expect(field).to.not.be.null;

--- a/src/test/elements/sfdc/metadata.js
+++ b/src/test/elements/sfdc/metadata.js
@@ -54,6 +54,17 @@ suite.forElement('crm', 'metadata', (test) => {
     expect(field).to.be.undefined;
   };
 
+  const validVdrMetadataForNestedObject = r => {
+    expect(r).to.have.statusCode(200);
+    expect(r.body.fields).to.be.an.array;
+    expect(r.body.fields.length).to.equal(2);
+
+    let field = r.body.fields.find((obj) => { return obj.vendorPath === 'Phone'; });
+    expect(field).to.not.be.null;
+    field = r.body.fields.find((obj) => { return obj.path === 'nestedObject.phone'; });
+    expect(field).to.not.be.null;
+  };
+
   const validateSalutation = (r) => {
     let isPicklist = false;
     r.body.fields.forEach(field => isPicklist =
@@ -89,6 +100,17 @@ suite.forElement('crm', 'metadata', (test) => {
       .then(r => validVdrMetadata(r))
       .then(r => cloud.delete('/organizations/elements/sfdc/transformations/churrosTestObject'))
       .then(r => cloud.delete('/organizations/objects/churrosTestObject/definitions'));
+  });
+
+  it('should support VDR metadata for nested objects', () => {
+    return cloud.post('/organizations/objects/churrosTestNestedObject/definitions', resources.churrosTestNestedObject, () => {})
+      .then(r => cloud.post('/organizations/objects/churrosTestObject/definitions', resources.churrosTestObject, () => {}))
+      .then(r => cloud.post('/organizations/elements/sfdc/transformations/churrosTestObject', resources.churrosTestObjectXform, () => {}))
+      .then(r => cloud.get('/objects/churrosTestObject/metadata'))
+      .then(r => validVdrMetadataForNestedObject(r))
+      .then(r => cloud.delete('/organizations/elements/sfdc/transformations/churrosTestObject'))
+      .then(r => cloud.delete('/organizations/objects/churrosTestObject/definitions'))
+      .then(r => cloud.delete('/organizations/objects/churrosTestNestedObject/definitions'));
   });
 
   test.withApi('/objects/contacts/metadata').withValidation(metaValid).withName(


### PR DESCRIPTION
## Highlights
* The `GET /objects/{objectName}/metadata` API when used for VDRs now returns nested VDR fields

## Screenshot
Please include a screenshot of the tests running successfully
![image](https://user-images.githubusercontent.com/3017448/39607243-1938e8cc-4ef7-11e8-9fc4-c983f2e2e742.png)


## Reference
* https://github.com/cloud-elements/soba/pull/8631
* [RALLY-#US11204](https://rally1.rallydev.com/#/144349238268d/detail/userstory/213580848164)

## Closes
* Closes [US11204](https://rally1.rallydev.com/#/144349238268d/detail/userstory/213580848164)
