### PR TITLE
Updated product-families testcase

### DIFF
--- a/src/test/elements/chargify/product-families.js
+++ b/src/test/elements/chargify/product-families.js
@@ -19,7 +19,8 @@ suite.forElement('payment', 'product-families', (test) => {
     return cloud.post(test.api, payload)
       .then(r => cloud.get(test.api))
       .then(r => productFamilyId = r.body[0].id)
-      .then(r => cloud.get(`${test.api}/${productFamilyId}`));
+      .then(r => cloud.get(`${test.api}/${productFamilyId}`))
+	  .then(r => cloud.get(`${test.api}/${productFamilyId}/products`));
   });
   // skipping because no delete API is present for prdocuts resource
   it.skip(`should allow POST for ${test.api}/{productFamilyId}/products`, () => {

--- a/src/test/elements/chargify/product-families.js
+++ b/src/test/elements/chargify/product-families.js
@@ -15,7 +15,7 @@ suite.forElement('payment', 'product-families', (test) => {
     "handle": tools.random()
   };
   test.withOptions({ qs: { where: 'direction=\'desc\'' } }).should.return200OnGet();
-  it(`should allow SR for ${test.api}/{productFamilyId}`, () => {
+  it(`should allow SR for ${test.api}/{productFamilyId} and S for ${test.api}/{productFamilyId}/Products`, () => {
     return cloud.post(test.api, payload)
       .then(r => cloud.get(test.api))
       .then(r => productFamilyId = r.body[0].id)

--- a/src/test/elements/chargify/product-families.js
+++ b/src/test/elements/chargify/product-families.js
@@ -15,7 +15,7 @@ suite.forElement('payment', 'product-families', (test) => {
     "handle": tools.random()
   };
   test.withOptions({ qs: { where: 'direction=\'desc\'' } }).should.return200OnGet();
-  it(`should allow SR for ${test.api}/{productFamilyId} and S for ${test.api}/{productFamilyId}/Products`, () => {
+  it(`should allow SR for ${test.api}/{productFamilyId} and S for ${test.api}/{productFamilyId}/products`, () => {
     return cloud.post(test.api, payload)
       .then(r => cloud.get(test.api))
       .then(r => productFamilyId = r.body[0].id)


### PR DESCRIPTION
## Highlights
* Added  testcase for `GET /product-families/{productFamilyId}/products`


## Screenshot
![image](https://user-images.githubusercontent.com/35288024/39630835-2df5cfc8-4fce-11e8-820c-9934f9af5d5d.png)
![image 1](https://user-images.githubusercontent.com/35288024/39630838-2f4a88dc-4fce-11e8-987f-e0b7a0752319.png)

- For the failing churros testcase a bug was raised [DE1575](https://rally1.rallydev.com/#/144349237612d/detail/defect/218190606812)


## Reference
* [SOBA](https://github.com/cloud-elements/soba/pull/8636)

## Closes
*  [DE1389](https://rally1.rallydev.com/#/144349237612d/detail/defect/213671799188)
