### PR TITLE
Smartrecruiters : Added churros for GET /users/:id API

### DIFF
--- a/src/test/elements/smartrecruiters/assets/transformations.json
+++ b/src/test/elements/smartrecruiters/assets/transformations.json
@@ -13,6 +13,13 @@
         "vendorPath": "id"
       }]
   },
+    "jobs": {
+    "vendorName": "jobs",
+    "fields": [{
+        "path": "id",
+        "vendorPath": "id"
+      }]
+  },
   "positions": {
     "vendorName": "positions",
     "fields": [{

--- a/src/test/elements/smartrecruiters/users.js
+++ b/src/test/elements/smartrecruiters/users.js
@@ -6,7 +6,7 @@ const expect = chakram.expect;
 
 suite.forElement('humancapital', 'users', {}, (test) => {
 
-  test.should.supportS();
+  test.should.supportSr();
   test.should.supportPagination(1);
   test.withOptions({ qs: { where: `updatedAfter = '2018-02-26T12:50:02.594+0000' ` } })
     .withName('should support Ceql updatedAfter search')


### PR DESCRIPTION
## Highlights
* Added churros  GET /users/:id API
## Screenshot

![churros1](https://user-images.githubusercontent.com/22440353/39692162-b1ad067a-51fd-11e8-8fd1-8c0b648b9392.JPG)
![churros2](https://user-images.githubusercontent.com/22440353/39692171-b590b728-51fd-11e8-8722-238c8649d0d9.JPG)


## Reference
* [SOBA](https://github.com/cloud-elements/soba/pull/8632)
* [RALLY-#${US11686}](https://rally1.rallydev.com/#/144349237612d/detail/userstory/217731463656)

## Closes
* Closes [US11686](https://rally1.rallydev.com/#/144349237612d/detail/userstory/217731463656)
