### PR TITLE
Added integration test for the shopify metadata API

### DIFF
--- a/src/test/elements/shopify/metadata.js
+++ b/src/test/elements/shopify/metadata.js
@@ -1,0 +1,28 @@
+'use strict';
+
+//dependencies at the top
+const suite = require('core/suite');
+const expect = require('chakram').expect;
+
+suite.forElement('ecommerce', 'metadata', (test) => {
+
+  test.withApi('/hubs/ecommerce/objects') //using specified api
+    .withValidation(r => expect(r.body).to.include('product')) //validating the response is what we expect
+    .withName('should test objects api') //changes the name of the test
+    .should.return200OnGet();
+
+  const validTitle = (r) => {
+    expect(r).to.have.statusCode(200);
+    expect(r.body.fields).to.not.be.null;
+    expect(r.body.fields).to.be.an('array');
+    let title = r.body.fields.find((obj) => { return obj.vendorPath === 'title'; });
+    expect(title).to.not.be.null;
+    return true;
+  };
+
+  test.withApi('/hubs/ecommerce/objects/product/metadata') //using specified api
+    .withValidation(validTitle) //passing a function to validate response
+    .withName('should include metadata for title') //changes the name of the
+    // test
+    .should.return200OnGet();
+});


### PR DESCRIPTION
## Highlights
* Added integration test for the shopify metadata API

## Screenshot
Please include a screenshot of the tests running successfully
![image](https://user-images.githubusercontent.com/3017448/39735803-8755726c-523a-11e8-86df-a32c3bc8f6fa.png)


## Reference
* https://github.com/cloud-elements/soba/pull/8649
* [RALLY-#US11815](https://rally1.rallydev.com/#/144349238268d/detail/userstory/218785569300)

## Closes
* Closes [#US11815](https://rally1.rallydev.com/#/144349238268d/detail/userstory/218785569300)
