### PR TITLE
Evernote enhanced with /revisions API Testcases

### DIFF
--- a/src/test/elements/evernote/files.js
+++ b/src/test/elements/evernote/files.js
@@ -3,8 +3,7 @@
 const suite = require('core/suite');
 const cloud = require('core/cloud');
 const tools = require('core/tools');
-const chakram = require('chakram');
-const expect = chakram.expect;
+const expect = require('chakram').expect;
 const foldersPayload = require('./assets/folders');
 
 suite.forElement('documents', 'files', (test) => {

--- a/src/test/elements/evernote/files.js
+++ b/src/test/elements/evernote/files.js
@@ -3,6 +3,8 @@
 const suite = require('core/suite');
 const cloud = require('core/cloud');
 const tools = require('core/tools');
+const chakram = require('chakram');
+const expect = chakram.expect;
 const foldersPayload = require('./assets/folders');
 
 suite.forElement('documents', 'files', (test) => {
@@ -34,5 +36,27 @@ suite.forElement('documents', 'files', (test) => {
       .then(r => cloud.get(`${test.api}/${fileId}/metadata`))
       .then(r => cloud.patch(`${test.api}/${fileId}/metadata`, filesPayload))
       .then(r => cloud.delete(`${test.api}/${fileId}`));
+  });
+
+  it('should allow RS for documents/files/:id/revisions', () => {
+    const fileId = 'd59f5f2f-0137-4393-9469-e72f1443cd9f';
+    let revisionId;
+    return cloud.get(`${test.api}/${fileId}/revisions`)
+      .then(r => {
+        expect(r.body[0]).to.contain.key('id');
+        revisionId = r.body[0].id;
+      })
+      .then(() => cloud.get(`${test.api}/${fileId}/revisions/${revisionId}`));
+  });
+
+  it('should allow RS for documents/files/revisions by path', () => {
+    let options = { qs: { path: '/Dont_Delete_Churros_Test_NoteBook/d59f5f2f-0137-4393-9469-e72f1443cd9f' } };
+    let revisionId;
+    return cloud.withOptions(options).get(`${test.api}/revisions`)
+      .then(r => {
+        expect(r.body[0]).to.contain.key('id');
+        revisionId = r.body[0].id;
+      })
+      .then(() => cloud.withOptions(options).get(`${test.api}/revisions/${revisionId}`));
   });
 });


### PR DESCRIPTION
## Highlights
* Evernote Added `/revisions API` Testcases

## Checklist
* [x] applicable churros tests are still passing
* [ ] includes a dbdeploy script that is backward-incompatible with one previous Soba minor version

## Screenshot
![screen shot 2018-05-08 at 12 57 43 pm](https://user-images.githubusercontent.com/26943831/39774661-1a4a1ef2-52c1-11e8-9907-655c3d589014.png)

## Related PRs
[Soba](https://github.com/cloud-elements/soba/pull/8657)

## Closes
[US10699](https://rally1.rallydev.com/#/144349237612d/detail/userstory/209348138184)