### PR TITLE
Facebook Lead Ads: Added churros tests for newly added resources

### DIFF
--- a/src/test/elements/facebookleadads/assets/context-card.json
+++ b/src/test/elements/facebookleadads/assets/context-card.json
@@ -1,0 +1,9 @@
+{
+    "cover_photo_id": "1261980613946210",
+	"button_text": "Post test button_text",
+    "style": "PARAGRAPH_STYLE",
+    "title": "<<random.word>>",
+    "content": [
+      "Post test - Context card"
+    ]
+}

--- a/src/test/elements/facebookleadads/assets/draft-form.json
+++ b/src/test/elements/facebookleadads/assets/draft-form.json
@@ -1,0 +1,66 @@
+{
+  "allow_organic_lead_retrieval": true,
+  "block_display_for_non_targeted_viewer": true,
+  "is_optimized_for_quality": true,
+  "locale": "EN_US",
+  "question_page_custom_headline": "Question Page Headline",
+  "name": "<<random.word>>",
+  "questions": [
+    {
+      "type": "CUSTOM",
+      "key": "quest1",
+      "label": "quest1",
+      "inline_context": "question 1",
+      "options": [{
+        "key": "option1",
+        "value": "option 1"
+      }]
+    }
+  ],
+  "privacy_policy": {
+    "url": "www.google.com",
+    "link_text": "Google policy 1"
+  },
+  "follow_up_action_url": "www.google.com",
+  "thank_you_page": {
+    "title": "test_title1",
+    "body": "This is custom thank you page",
+    "button_type": "VIEW_WEBSITE",
+    "button_text": "View this website",
+    "website_url": "www.google.com",
+    "business_phone_number": "+1-541-754-3010",
+    "country_code": "US",
+    "short_message": "Test Thank you page",
+    "enable_messenger": true
+  },
+  "custom_disclaimer": {
+    "title": "Custom Disclaimer 1",
+    "body": {
+      "text": "custom disclaimer body text",
+      "url_entities": [
+        {
+          "offset": "1",
+          "length": "20",
+          "url": "www.google.com"
+        }
+      ]
+    },
+    "checkboxes": [
+      {
+        "is_required": true,
+        "is_checked_by_default": true,
+        "text": "I Agree",
+        "key": "i_agree"
+      }
+    ]
+  },
+  "context_card": {
+    "cover_photo_id": "1261929010618037",
+    "button_text": "Post test button",
+    "style": "PARAGRAPH_STYLE",
+    "title": "Post test",
+    "content": [
+      "Post test"
+    ]
+  }
+}

--- a/src/test/elements/facebookleadads/assets/form.json
+++ b/src/test/elements/facebookleadads/assets/form.json
@@ -1,0 +1,67 @@
+{
+  "allow_organic_lead_retrieval": true,
+  "block_display_for_non_targeted_viewer": true,
+  "is_optimized_for_quality": true,
+  "locale": "EN_US",
+  "question_page_custom_headline": "Question Page Headline",
+  "name": "<<random.word>>",
+  "questions": [
+    {
+      "type": "CUSTOM",
+      "key": "quest1",
+      "label": "quest1",
+      "inline_context": "question 1",
+      "options": [{
+        "key": "option1",
+        "value": "option 1"
+      }]
+    }
+  ],
+  "privacy_policy": {
+    "url": "www.google.com",
+    "link_text": "Google policy 1"
+  },
+  "follow_up_action_url": "www.google.com",
+  "thank_you_page": {
+    "title": "test_title1",
+    "body": "This is custom thank you page",
+    "button_type": "VIEW_WEBSITE",
+    "button_text": "View this website",
+    "website_url": "www.google.com",
+    "business_phone_number": "+1-541-754-3010",
+    "country_code": "US",
+    "short_message": "Test Thank you page",
+    "button_description": "View button",
+    "enable_messenger": true
+  },
+  "custom_disclaimer": {
+    "title": "Custom Disclaimer 1",
+    "body": {
+      "text": "custom disclaimer body text",
+      "url_entities": [
+        {
+          "offset": "1",
+          "length": "20",
+          "url": "www.google.com"
+        }
+      ]
+    },
+    "checkboxes": [
+      {
+        "is_required": true,
+        "is_checked_by_default": true,
+        "text": "I Agree",
+        "key": "i_agree"
+      }
+    ]
+  },
+  "context_card": {
+    "cover_photo_id": "1261929010618037",
+    "button_text": "Post test button",
+    "style": "PARAGRAPH_STYLE",
+    "title": "Post test",
+    "content": [
+      "Post test"
+    ]
+  }
+}

--- a/src/test/elements/facebookleadads/assets/legal-content.json
+++ b/src/test/elements/facebookleadads/assets/legal-content.json
@@ -1,0 +1,22 @@
+ {
+    "privacy_policy": {
+      "link_text": "<<random.word>>",
+      "url": "http://www.twitter.com/"
+    },
+    
+    "custom_disclaimer": {
+      "checkboxes": [
+        {
+          "is_required": true,
+          "is_checked_by_default": true,
+          
+          "text": "I Agree",
+          "key": "i_agree"
+        }
+      ],
+      "title": "<<random.word>>",
+      "body": {
+        "text": "Please read the policy very carefully before accepting"
+      }
+    }
+  }

--- a/src/test/elements/facebookleadads/assets/thank-you-card.json
+++ b/src/test/elements/facebookleadads/assets/thank-you-card.json
@@ -1,0 +1,9 @@
+{
+	"title": "<<random.word>>",
+	"body": "This is custom thank you page",
+	"button_type": "VIEW_WEBSITE",
+	"button_text": "View this website",
+	"website_url": "www.google.com",
+	"business_phone_number": "+1-541-754-3010",
+	"country_code": "US"
+}

--- a/src/test/elements/facebookleadads/pages.js
+++ b/src/test/elements/facebookleadads/pages.js
@@ -2,6 +2,12 @@
 
 const suite = require('core/suite');
 const cloud = require('core/cloud');
+const tools = require('core/tools');
+const contextCard = tools.requirePayload(`${__dirname}/assets/context-card.json`);
+const thankYouCard = tools.requirePayload(`${__dirname}/assets/thank-you-card.json`);
+const draftForm = tools.requirePayload(`${__dirname}/assets/draft-form.json`);
+const form = tools.requirePayload(`${__dirname}/assets/form.json`);
+const legalContent = tools.requirePayload(`${__dirname}/assets/legal-content.json`);
 
 suite.forElement('marketing', 'pages', null, (test) => {
   let pageId;
@@ -24,5 +30,44 @@ suite.forElement('marketing', 'pages', null, (test) => {
       .then(r => accessToken = r.body[0].access_token)
       .then(r => cloud.withOptions({ qs: { access_token: accessToken } }).get(`${test.api}/${pageId}/subscribed-apps`))
       .then(r => cloud.withOptions({ qs: { access_token: accessToken } }).post(`${test.api}/${pageId}/subscribed-apps`));
+  });
+
+  it(`should allow CR for ${test.api}/${pageId}/context-cards`, () => {
+    let accessToken;
+    return cloud.get(test.api)
+      .then(r => accessToken = r.body[0].access_token)
+      .then(r => cloud.withOptions({ qs: { page: 1, pageSize: 3 } }).get(`${test.api}/${pageId}/context-cards`))
+      .then(r => cloud.withOptions({ qs: { access_token: accessToken } }).post(`${test.api}/${pageId}/context-cards`,contextCard));
+  });
+
+  it(`should allow C for ${test.api}/${pageId}/thank-you-card`, () => {
+    let accessToken;
+    return cloud.get(test.api)
+      .then(r => accessToken = r.body[0].access_token)
+      .then(r => cloud.withOptions({ qs: { access_token: accessToken } }).post(`${test.api}/${pageId}/thank-you-card`,thankYouCard));
+  });
+
+  it(`should allow CR for ${test.api}/${pageId}/draft-forms`, () => {
+    let accessToken;
+    return cloud.get(test.api)
+      .then(r => accessToken = r.body[0].access_token)
+      .then(r => cloud.withOptions({ qs: { page: 1, pageSize: 3 } }).get(`${test.api}/${pageId}/draft-forms`))
+      .then(r => cloud.withOptions({ qs: { access_token: accessToken } }).post(`${test.api}/${pageId}/draft-forms`,draftForm));
+  });
+
+  it(`should allow CR for ${test.api}/${pageId}/forms`, () => {
+    let accessToken;
+    return cloud.get(test.api)
+      .then(r => accessToken = r.body[0].access_token)
+      .then(r => cloud.withOptions({ qs: { page: 1, pageSize: 3 } }).get(`${test.api}/${pageId}/forms`))
+      .then(r => cloud.withOptions({ qs: { access_token: accessToken } }).post(`${test.api}/${pageId}/forms`,form));
+  });
+
+  it(`should allow CR for ${test.api}/${pageId}/legal-content`, () => {
+    let accessToken;
+    return cloud.get(test.api)
+      .then(r => accessToken = r.body[0].access_token)
+      .then(r => cloud.withOptions({ qs: { page: 1, pageSize: 3 } }).get(`${test.api}/${pageId}/legal-content`))
+      .then(r => cloud.withOptions({ qs: { access_token: accessToken } }).post(`${test.api}/${pageId}/legal-content`,legalContent));
   });
 });


### PR DESCRIPTION
## Highlights
* Added churros tests for forms, draft-forms, context-cards, legal-content and thank-you-card resources.
* Added payloads for each resource.

## Screenshot
![churros_result](https://user-images.githubusercontent.com/25840396/39860565-65cf912c-545b-11e8-9bc3-32580122b2e3.PNG)


## Reference
* [PR8667](https://github.com/cloud-elements/soba/pull/8667)
* [RALLY-#${US11527}](https://rally1.rallydev.com/#/144351344360d/detail/userstory/216002950592)

## Closes
* Closes #${US11527}
