### PR TITLE
InfusionsoftMarketing : Updated testcases for Leads and Accounts

### DIFF
--- a/src/test/elements/infusionsoftmarketing/accounts.js
+++ b/src/test/elements/infusionsoftmarketing/accounts.js
@@ -5,4 +5,5 @@ const payload = require('./assets/accounts');
 
 suite.forElement('marketing', 'accounts', { payload: payload }, (test) => {
   test.should.supportCrud();
+  test.withOptions({qs: { where: 'FirstName=\'Churros\''}}).should.return200OnGet();
 });

--- a/src/test/elements/infusionsoftmarketing/accounts.js
+++ b/src/test/elements/infusionsoftmarketing/accounts.js
@@ -2,8 +2,18 @@
 
 const suite = require('core/suite');
 const payload = require('./assets/accounts');
+const chakram = require('chakram');
+const expect = chakram.expect;
 
 suite.forElement('marketing', 'accounts', { payload: payload }, (test) => {
   test.should.supportCrud();
-  test.withOptions({qs: { where: 'FirstName=\'Churros\''}}).should.return200OnGet();
+  test
+    .withOptions({ qs: { where: 'FirstName=\'Churros\'' } })
+    .withName('should support search by filter')
+    .withValidation(r => {
+      expect(r).to.statusCode(200);
+      const validValues = r.body.filter(obj => obj.State = 'FirstName');
+      expect(validValues.length).to.equal(r.body.length);
+    })
+    .should.return200OnGet();
 });

--- a/src/test/elements/infusionsoftmarketing/accounts.js
+++ b/src/test/elements/infusionsoftmarketing/accounts.js
@@ -12,7 +12,7 @@ suite.forElement('marketing', 'accounts', { payload: payload }, (test) => {
     .withName('should support search by filter')
     .withValidation(r => {
       expect(r).to.statusCode(200);
-      const validValues = r.body.filter(obj => obj.State = 'FirstName');
+      const validValues = r.body.filter(obj => obj.FirstName = 'Churros');
       expect(validValues.length).to.equal(r.body.length);
     })
     .should.return200OnGet();

--- a/src/test/elements/infusionsoftmarketing/leads.js
+++ b/src/test/elements/infusionsoftmarketing/leads.js
@@ -5,4 +5,5 @@ const payload = require('./assets/leads');
 
 suite.forElement('marketing', 'leads', { payload: payload }, (test) => {
   test.should.supportCrud();
+  test.withOptions({qs: { where: 'OpportunityTitle=\'Final\''}}).should.return200OnGet();
 });

--- a/src/test/elements/infusionsoftmarketing/leads.js
+++ b/src/test/elements/infusionsoftmarketing/leads.js
@@ -12,7 +12,7 @@ suite.forElement('marketing', 'leads', { payload: payload }, (test) => {
     .withName('should support search by filter')
     .withValidation(r => {
       expect(r).to.statusCode(200);
-      const validValues = r.body.filter(obj => obj.State = 'OpportunityTitle');
+      const validValues = r.body.filter(obj => obj.OpportunityTitle = 'Final');
       expect(validValues.length).to.equal(r.body.length);
     })
     .should.return200OnGet();

--- a/src/test/elements/infusionsoftmarketing/leads.js
+++ b/src/test/elements/infusionsoftmarketing/leads.js
@@ -2,8 +2,18 @@
 
 const suite = require('core/suite');
 const payload = require('./assets/leads');
+const chakram = require('chakram');
+const expect = chakram.expect;
 
 suite.forElement('marketing', 'leads', { payload: payload }, (test) => {
   test.should.supportCrud();
-  test.withOptions({qs: { where: 'OpportunityTitle=\'Final\''}}).should.return200OnGet();
+  test
+    .withOptions({ qs: { where: 'OpportunityTitle=\'Final\'' } })
+    .withName('should support search by filter')
+    .withValidation(r => {
+      expect(r).to.statusCode(200);
+      const validValues = r.body.filter(obj => obj.State = 'OpportunityTitle');
+      expect(validValues.length).to.equal(r.body.length);
+    })
+    .should.return200OnGet();
 });


### PR DESCRIPTION
## Highlights
Added testcases for following APIs 
- `GET /accounts`
- `GET /leads`

## Screenshot
![churros](https://user-images.githubusercontent.com/20634723/39988907-3a6ea6a2-5786-11e8-8ee5-44850b4a4f4d.PNG)



## Reference
* [SOBA](https://github.com/cloud-elements/soba/pull/8679)
* [US11826](https://rally1.rallydev.com/#/144349237612ud/detail/userstory/218877781528)
* [US11827](https://rally1.rallydev.com/#/144349237612ud/detail/userstory/218877781936)

## Closes
* [US11826](https://rally1.rallydev.com/#/144349237612ud/detail/userstory/218877781528)
* [US11827](https://rally1.rallydev.com/#/144349237612ud/detail/userstory/218877781936)

