### PR TITLE
Updated Docusign envelopes testcase

### DIFF
--- a/src/test/elements/docusign/assets/envelopes.documentsNew.json
+++ b/src/test/elements/docusign/assets/envelopes.documentsNew.json
@@ -1,0 +1,4 @@
+{
+  "documentId": "5",
+  "name": "Test.pdf"
+}

--- a/src/test/elements/docusign/assets/envelopes.patchDocumentNew.json
+++ b/src/test/elements/docusign/assets/envelopes.patchDocumentNew.json
@@ -1,0 +1,3 @@
+{
+  "name": "Test.pdf"
+}

--- a/src/test/elements/docusign/assets/model_envelopedocuments_patch.json
+++ b/src/test/elements/docusign/assets/model_envelopedocuments_patch.json
@@ -1,0 +1,31 @@
+{
+    "documentId": "2",
+    "remoteUrl": "",
+    "name": "comp.pdf",
+    "password": "pwd",
+    "transformPdfFields": "true",
+    "fileExtension": "pdf",
+    "matchBoxes": [
+      {
+        "pageNumber": 1,
+        "xPosition": 2,
+        "yPosition": 3,
+        "width": 4,
+        "height": 5
+      }
+    ],
+    "order": "1",
+    "pages": "4",
+    "documentFields": [],
+    "encryptedWithKeyManager": "false",
+    "documentBase64": "",
+    "applyAnchorTabs": "true",
+    "display": "inline",
+    "includeInDownload": "true",
+    "signerMustAcknowledge": "no_interaction",
+    "templateLocked": "false",
+    "templateRequired": "false",
+    "documentGroup": "",
+    "fileFormatHint": "pdf",
+    "authoritativeCopy": true
+}

--- a/src/test/elements/docusign/assets/model_envelopedocuments_put.json
+++ b/src/test/elements/docusign/assets/model_envelopedocuments_put.json
@@ -1,0 +1,31 @@
+{
+    "documentId": "2",
+    "remoteUrl": "",
+    "name": "process.pdf",
+    "password": "pwd",
+    "transformPdfFields": "true",
+    "fileExtension": "pdf",
+    "matchBoxes": [
+      {
+        "pageNumber": 1,
+        "xPosition": 2,
+        "yPosition": 3,
+        "width": 4,
+        "height": 5
+      }
+    ],
+    "order": "1",
+    "pages": "2",
+    "documentFields": [],
+    "encryptedWithKeyManager": "false",
+    "documentBase64": "",
+    "applyAnchorTabs": "true",
+    "display": "inline",
+    "includeInDownload": "true",
+    "signerMustAcknowledge": "no_interaction",
+    "templateLocked": "false",
+    "templateRequired": "false",
+    "documentGroup": "",
+    "fileFormatHint": "pdf",
+    "authoritativeCopy": true
+}

--- a/src/test/elements/docusign/assets/model_envelopes_post.json
+++ b/src/test/elements/docusign/assets/model_envelopes_post.json
@@ -1,0 +1,61 @@
+{
+  "documents": [
+    {
+      "documentId": "3",
+      "uri": "/envelopes/44efc9e6-915e-4b1d-9b54-801410d6922d/documents/1",
+      "remoteUrl": "",
+      "name": "minlist.pdf",
+      "password": "pwd",
+      "transformPdfFields": "true",
+      "fileExtension": "pdf",
+      "matchBoxes": [
+        {
+          "pageNumber": 1,
+          "xPosition": 2,
+          "yPosition": 3,
+          "width": 4,
+          "height": 5
+        }
+      ],
+      "order": "asc",
+      "pages": "3",
+      "documentFields": [],
+      "encryptedWithKeyManager": "false",
+      "documentBase64": "",
+      "applyAnchorTabs": "true",
+      "display": "inline",
+      "includeInDownload": "true",
+      "signerMustAcknowledge": "no_interaction",
+      "templateLocked": "false",
+      "templateRequired": "false",
+      "documentGroup": "",
+      "fileFormatHint": "pdf",
+      "authoritativeCopy": true
+    }
+  ],
+  "customFields": {
+    "textCustomFields": [
+      {
+        "fieldId": "1",
+        "name": "textcustom",
+        "show": "true",
+        "required": "true",
+        "value": "textcustomval",
+        "configurationType": "salesforce"
+      }
+    ],
+    "listCustomFields": [
+      {
+        "listItems": [
+          "2"
+        ],
+        "fieldId": "2",
+        "name": "listcustom",
+        "show": "true",
+        "required": "true",
+        "value": "listcustomval",
+        "configurationType": "salesforce"
+      }
+    ]
+  }
+}

--- a/src/test/elements/docusign/envelopes.js
+++ b/src/test/elements/docusign/envelopes.js
@@ -13,6 +13,8 @@ const recipient = require('./assets/envelopes.recipient.json');
 const tab = require('./assets/recipients.tab.json');
 const documents = require('./assets/envelopes.documents.json');
 const patchDocument = require('./assets/envelopes.patchDocument.json');
+const documentsNew = require('./assets/envelopes.documentsNew.json');
+const patchDocumentNew = require('./assets/envelopes.patchDocumentNew.json');
 
 suite.forElement('esignature', 'envelopes', (test) => {
   it(`should support CRU on ${test.api}`, () => {
@@ -35,6 +37,8 @@ suite.forElement('esignature', 'envelopes', (test) => {
     let documentId;
     const putDocuments = { formData: { document: JSON.stringify(documents), file: fs.createReadStream(documentPath) } };
     const patchDocuments = { formData: { document: JSON.stringify(patchDocument), file: fs.createReadStream(documentPath) } };
+	const putDocumentsNew = { formData: { document: JSON.stringify(documentsNew), file: fs.createReadStream(documentPath) } };
+    const patchDocumentsNew = { formData: { document: JSON.stringify(patchDocumentNew), file: fs.createReadStream(documentPath) } };
 
     return cloud.withOptions(opts).postFile(test.api, path)
       .then(r => envelopeId = r.body.envelopeId)
@@ -42,9 +46,13 @@ suite.forElement('esignature', 'envelopes', (test) => {
         (r) => expect(r).to.have.schemaAnd200(documentsSchema)))
       .then(r => cloud.withOptions(putDocuments).put(`${test.api}/${envelopeId}/documents`, undefined,
         (r) => expect(r).to.have.schemaAnd200(documentsSchema)))
+	  .then(r => cloud.withOptions(putDocumentsNew).put(`${test.api}/${envelopeId}/documents`, undefined,
+        (r) => expect(r).to.have.schemaAnd200(documentsSchema)))
       .then(r => cloud.get(`${test.api}/${envelopeId}/documents`))
       .then(r => documentId = r.body[0].documentId)
       .then(r => cloud.withOptions(patchDocuments).patch(`${test.api}/${envelopeId}/documents/${documentId}`, undefined,
+        (r) => expect(r).to.have.schemaAnd200(documentsSchema)))
+      .then(r => cloud.withOptions(patchDocumentsNew).patch(`${test.api}/${envelopeId}/documents/${documentId}`, undefined,
         (r) => expect(r).to.have.schemaAnd200(documentsSchema)))
       .then(r => cloud.get(`${test.api}/${envelopeId}/documents/${documentId}`)
       .then(r => cloud.delete(`${test.api}/${envelopeId}/documents/${documentId}`)));


### PR DESCRIPTION
## Highlights
* Added testcase for `PUT /envelopes/{id}/documents` and `PATCH /envelopes/{id}/documents/{documentId}`.

## Screenshot
![churros](https://user-images.githubusercontent.com/35288024/39924308-dc9e4af2-5544-11e8-9618-d7bcc29fee83.JPG)


## Reference
* [SOBA](https://github.com/cloud-elements/soba/pull/8678)

## Closes
* [DE1639](https://rally1.rallydev.com/#/144349237612d/detail/defect/219372907756)
