### PR TITLE
Eloqua: Updated the testcase for PUT campaigns and custom-objects 

### DIFF
--- a/src/test/elements/eloqua/campaigns.js
+++ b/src/test/elements/eloqua/campaigns.js
@@ -12,7 +12,6 @@ suite.forElement('marketing', 'campaigns', { payload: campaignsPayload }, (test)
     return cloud.post(test.api, campaignsPayload)
       .then(r => {
         campaignId = r.body.id;
-        campaignsPayload.id = campaignId;
       })
       .then(r => cloud.get(`${test.api}/${campaignId}`))
       .then(r => cloud.put(`${test.api}/${campaignId}`, campaignsPayload))

--- a/src/test/elements/eloqua/custom-objects.js
+++ b/src/test/elements/eloqua/custom-objects.js
@@ -19,7 +19,6 @@ suite.forElement('marketing', 'custom-objects', { payload: payload }, (test) => 
       .then(r => cloud.post(test.api, payload))
       .then(r => {
         id = r.body.id;
-        updatePayload.id = id;
       })
       .then(r => cloud.get(`${test.api}/${id}`))
       .then(r => cloud.put(`${test.api}/${id}`, updatePayload))


### PR DESCRIPTION
## Highlights
* Updated the test-case  for PUT campaigns and custom-objects
* We don't need to pass ` id`  field in body parameter for PUT campaigns and custom-objects, now it will take `id` from path parameter. 

## Screenshot

> 
PS C:\Users\GS-1259\CE-4656\churros\finalch\churros> churros -i 927 test elements/eloqua


info: Using url: http://localhost:8080
info: Using user: madhuri.kadam@gslab.com
info: Using oauth username: Atul.Barve
info: Using api key: f4ae3e0d-e5eb-4d44-825d-21cccf81a6b7
info: Running tests for element: eloqua
info: Provisioned with instance id of 927
  Basic tests
    √ should provision
    √ should GET /objects (2906ms)
    - docs
    √ metadata (548ms)
    √ transformations (18953ms)
    - should not allow provisioning with bad credentials

  accounts
    √ should allow CRUDS for /hubs/marketing/accounts (23225ms)
    √ should allow paginating with page and pageSize for /hubs/marketing/accounts (8609ms)
    √ should support searching /hubs/marketing/accounts by Country (2734ms)

  activity-types
    √ should allow GET for /hubs/marketing/activity-types (278ms)
    √ should allow ping for eloqua (247ms)

  bulk
error: Failed to retrieve or validate: /hubs/marketing/bulk/82/status
    √ should support bulk download of a custom object (17364ms)
error: Failed to retrieve or validate: /hubs/marketing/bulk/83/status
    √ should support bulk download of a custom object using a transformation and select fields (14169ms)
error: Failed to retrieve or validate: /hubs/marketing/bulk/84/status
error: Failed to retrieve or validate: /hubs/marketing/bulk/84/status
    √ should support bulk upload of a custom object (12523ms)
error: Failed to retrieve or validate: /hubs/marketing/bulk/85/status
error: Failed to retrieve or validate: /hubs/marketing/bulk/85/status
    √ should support bulk upload of a custom object using a transformation (9912ms)
error: Failed to retrieve or validate: /hubs/marketing/bulk/86/status
error: Failed to retrieve or validate: /hubs/marketing/bulk/86/status
error: Failed to retrieve or validate: /hubs/marketing/bulk/86/status
    √ should fail bulk insert due to a duplicate record (11113ms)

  campaigns
    √ should allow CRUDS for /hubs/marketing/campaigns, PATCH /campaigns/activate/:id and PATCH /campaigns/deactivate/:i
d (24372ms)
    √ should allow UD for /hubs/marketing/campaigns/:id/contacts (25254ms)

  contacts
    √ should allow CRUDS for /hubs/marketing/contacts (36064ms)
    √ should allow paginating with page and pageSize for /hubs/marketing/contacts (11642ms)
    √ should support searching /hubs/marketing/contacts by id (9880ms)
    √ should allow GET for /hubs/marketing/contacts (6416ms)
    √ should allow GET for /hubs/marketing/contacts (4013ms)
    √ should allow GET hubs/marketing/contacts/{contactId}/activities (16257ms)

  content-sections
    √ should allow CRUDS for /hubs/marketing/content-sections (5392ms)
    √ should allow paginating with page and pageSize for /hubs/marketing/content-sections (2721ms)
    √ should support searching /hubs/marketing/content-sections by name (2968ms)

  custom-objects
    √ should allow CRUDS for /hubs/marketing/custom-objects (4708ms)
    √ should allow paginating with page and pageSize for /hubs/marketing/custom-objects (3000ms)
    √ should support searching /hubs/marketing/custom-objects by name (2905ms)

  email-footers
    √ should allow CRUDS for /hubs/marketing/email-footers (4425ms)
    √ should allow paginating with page and pageSize for /hubs/marketing/email-footers (2358ms)
    √ should support searching /hubs/marketing/email-footers by name (2241ms)

  email-headers
    √ should allow CRUDS for /hubs/marketing/email-headers (4061ms)
    √ should allow paginating with page and pageSize for /hubs/marketing/email-headers (2596ms)
    √ should support searching /hubs/marketing/email-headers by name (2441ms)

  emails
    √ should allow CRUDS for /hubs/marketing/emails (4673ms)
    √ should allow paginating with page and pageSize for /hubs/marketing/emails (2065ms)
    √ should support searching /hubs/marketing/emails by name (2907ms)

  extended-resource
    √ should test newly added account resource extended-resource (943ms)

  landing-pages
    √ should allow CRUDS for /hubs/marketing/landing-pages (4630ms)
    √ should allow paginating with page and pageSize for /hubs/marketing/landing-pages (2531ms)
    √ should support searching /hubs/marketing/landing-pages by name (2634ms)

  lists
    √ should allow CRUDS for /hubs/marketing/lists (9129ms)
    √ should allow paginating with page and pageSize for /hubs/marketing/lists (4460ms)
    √ should support searching /hubs/marketing/lists by id (4479ms)
    √ should allow CRUDS for lists/{id}/contacts  (47180ms)

  objectMetadata
    √ should return custom fields only when customFieldsOnly=true for contact (4641ms)

  polling
    - polling /hubs/marketing/contacts
    - polling /hubs/marketing/custom-objects


  46 passing (7m)
  4 pending

PS C:\Users\GS-1259\CE-4656\churros\finalch\churros>

## Reference
* [SOBA](https://github.com/cloud-elements/soba/pull/8697)
* [churros-sauce](Link to Associated Churros-sauce PR, when applicable)
* [RALLY-#${DE1709}](https://rally1.rallydev.com/#/144349237612ud/detail/defect/221100208816)

## Closes
* Closes [#$DE1709](https://rally1.rallydev.com/#/144349237612ud/detail/defect/221100208816)
