### PR TITLE
Chargify - Fixed failing test case of metadata

### DIFF
--- a/src/test/elements/chargify/objectMetadata.js
+++ b/src/test/elements/chargify/objectMetadata.js
@@ -20,7 +20,7 @@ suite.forElement('payment', 'objectMetadata', (test) => {
     .withOptions({ qs: { customFieldsOnly: true } })
     .withValidation(r => {
       expect(r).to.have.statusCode(200);
-      expect(r.body.fields).to.not.be.empty;
+      expect(r.body.fields).to.be.empty;
       const customValues = r.body.fields.filter(field => field.custom && field.custom === true);
       expect(customValues).to.deep.equal(r.body.fields);
     }).should.supportValidation('GET');


### PR DESCRIPTION
## Highlights
* Fixed churros for failing test case of objectMetadata of subscriptions.

## Non-Customer Highlights
* The test was failing because after transformation only `Id` field is returned which is not a custom field and hence an empty response is returned. It was being compared to a non-empty response body.
* One test of transformation is failing on Basic Tests that churros runs but no helpful information available to debug that.

## Screenshot
![image](https://user-images.githubusercontent.com/22442264/40157627-b980c586-59bd-11e8-9d97-bb1aae9a1a2a.png)
![image](https://user-images.githubusercontent.com/22442264/40157635-c470cfea-59bd-11e8-88eb-70104c055bc1.png)

## Closes
* [DE1575](https://rally1.rallydev.com/#/144349237612d/detail/defect/218190606812)
