### PR TITLE
Added test for accountsProperties and accountsPropertygroups: Hubspot Marketing

### DIFF
--- a/src/test/elements/hubspot/accounts.js
+++ b/src/test/elements/hubspot/accounts.js
@@ -45,7 +45,7 @@ suite.forElement('marketing', 'accounts', { payload: payload }, (test) => {
     .withName('should allow pagination for accounts/properties with page and nextPage')
     .should.supportNextPagePagination(2);
 
-  it('should allow CRUD for hubs/marketing/accounts/propertygroups', () => {
+  it('should allow CUDS for hubs/marketing/accounts/propertygroups', () => {
     propertygroups.name = propertygroups.name.toLowerCase();
     let id;
     const updatePropertygroups = {

--- a/src/test/elements/hubspot/accounts.js
+++ b/src/test/elements/hubspot/accounts.js
@@ -2,9 +2,18 @@
 
 const suite = require('core/suite');
 const tools = require('core/tools');
+const cloud = require('core/cloud');
+const expect = require('chakram').expect;
 const payload = tools.requirePayload(`${__dirname}/assets/accounts.json`);
+const propertiesPayload = tools.requirePayload(`${__dirname}/assets/accountsProperties.json`);
+const propertygroups = tools.requirePayload(`${__dirname}/assets/accountsPropertygroups.json`);
 
 suite.forElement('marketing', 'accounts', { payload: payload }, (test) => {
+  let propertyGroupName;
+  before(() => cloud.get(`${test.api}/propertygroups`)
+    .then(r => propertyGroupName = r.body[0].name)
+    .then(r => propertiesPayload.groupName = propertyGroupName));
+
   const options = {
     churros: {
       updatePayload: {
@@ -14,4 +23,46 @@ suite.forElement('marketing', 'accounts', { payload: payload }, (test) => {
   };
   test.withOptions(options).should.supportCruds();
   test.should.supportPagination();
+
+  it('should allow CRUDS for hubs/marketing/accounts/properties', () => {
+    propertiesPayload.name = propertiesPayload.name.toLowerCase();
+    let id;
+    const fieldsUpdate = {
+      "groupName": propertyGroupName,
+      "type": "string"
+    };
+    return cloud.post(`${test.api}/properties`, propertiesPayload)
+      .then(r => {
+        id = r.body.name;
+        expect(r.body).to.not.be.empty;
+      })
+      .then(r => cloud.get(`${test.api}/properties`))
+      .then(r => cloud.get(`${test.api}/properties/${id}`))
+      .then(r => cloud.patch(`${test.api}/properties/${id}`, fieldsUpdate))
+      .then(r => cloud.delete(`${test.api}/properties/${id}`));
+  });
+  test.withApi(`${test.api}/properties`)
+    .withName('should allow pagination for accounts/properties with page and nextPage')
+    .should.supportNextPagePagination(2);
+
+  it('should allow CRUD for hubs/marketing/accounts/propertygroups', () => {
+    propertygroups.name = propertygroups.name.toLowerCase();
+    let id;
+    const updatePropertygroups = {
+      "displayName": "test_churros1",
+      "displayOrder": 0,
+      "name": tools.random()
+    };
+    return cloud.post(`${test.api}/propertygroups`, propertygroups)
+      .then(r => {
+        id = r.body.name;
+        expect(r.body).to.not.be.empty;
+      })
+      .then(r => cloud.get(`${test.api}/propertygroups`))
+      .then(r => cloud.patch(`${test.api}/propertygroups/${id}`, updatePropertygroups))
+      .then(r => cloud.delete(`${test.api}/propertygroups/${id}`));
+  });
+  test.withApi(`${test.api}/propertygroups`)
+    .withName('should allow pagination for accounts/propertygroups with page and nextPage')
+    .should.supportNextPagePagination(2);
 });

--- a/src/test/elements/hubspot/assets/accountsProperties.json
+++ b/src/test/elements/hubspot/assets/accountsProperties.json
@@ -1,0 +1,6 @@
+{
+  "name": "hs_<<random.alphaNumeric##8>>",
+  "label": "hs <<random.word>>",
+  "groupName": "",
+  "type": "string"
+}

--- a/src/test/elements/hubspot/assets/accountsPropertygroups.json
+++ b/src/test/elements/hubspot/assets/accountsPropertygroups.json
@@ -1,0 +1,6 @@
+{
+  "displayName": "<<random.word>>",
+  "displayOrder": 0,
+  "hubspotDefined": false,
+  "name": "hs_<<random.alphaNumeric##8>>"
+}


### PR DESCRIPTION
## Highlights
* Added CRUDS for /accounts/properties.
* Added CUDS for /accounts/propertygroups.

## Screenshot
 - Report - [hubspot marketing churros](https://github.com/cloud-elements/churros/files/2013003/hubspot.marketing.churros.txt)
Some of the churros are failing. Raised [DE1708 ](https://rally1.rallydev.com/#/144349237612ud/detail/defect/221095074132?fdp=true) for that.
## Reference
* [SOBA]()
* [RALLY-#US11907](https://rally1.rallydev.com/#/144349237612ud/detail/userstory/219810905356)

## Closes
* Closes [US11907](https://rally1.rallydev.com/#/144349237612ud/detail/userstory/219810905356)
