### PR TITLE
Updated the formula upgrade to v3 integration to match a soba change

### DIFF
--- a/src/test/platform/formulas/assets/formulas/complex-to-upgrade.json
+++ b/src/test/platform/formulas/assets/formulas/complex-to-upgrade.json
@@ -86,6 +86,7 @@
           "retry": "false",
           "elementInstanceId": "${trigger_instance}",
           "method": "GET",
+          "path": " ",
           "query": "${steps.setup_page_parameters}"
         }
       },
@@ -123,6 +124,7 @@
           "path": "${looper}",
           "retry": "false",
           "elementInstanceId": "${config.trigger_instance}",
+          "query": "",
           "method": "GET"
         }
       },

--- a/src/test/platform/formulas/formulas.js
+++ b/src/test/platform/formulas/formulas.js
@@ -75,7 +75,7 @@ suite.forPlatform('formulas', opts, (test) => {
       .then(r => validateResults(formulaId, r, fullResponse));
   });
 
-    it('should allow adding and removing "scheduled" trigger to a formula', () => {
+  it('should allow adding and removing "scheduled" trigger to a formula', () => {
     const f = common.genFormula({});
     const t = common.genTrigger({});
 
@@ -260,10 +260,24 @@ suite.forPlatform('formulas', opts, (test) => {
 
       const get = formula.steps.filter(s => s.name === 'get_contacts')[0];
       expect(get.properties.elementInstanceId).to.equal('${config.trigger_instance}');
+      expect(get.properties.path).to.satisfy(function(value) {
+        if (value === undefined || value === '') {
+          return true;
+        } else {
+          return false;
+        }
+      });
 
       const retrieve = formula.steps.filter(s => s.name === 'retrieve_contact')[0];
       expect(retrieve.properties.api).to.equal('/hubs/crm/contacts/${steps.looper.entry}');
-      expect(retrieve.properties.path).to.equal(undefined);
+      expect(retrieve.properties.path).to.be.undefined;
+      expect(retrieve.properties.query).to.satisfy(function(value) {
+        if (value === undefined || value === '') {
+          return true;
+        } else {
+          return false;
+        }
+      });
     };
 
     const validatorRollback = (formula) => {
@@ -384,8 +398,10 @@ suite.forPlatform('formulas', opts, (test) => {
 
     let formulaId;
     return cloud.post(test.api, f, schema)
-      .then(r => { expect(r.body.debugLoggingEnabled).to.equal(true);
-        formulaId = r.body.id; })
+      .then(r => {
+        expect(r.body.debugLoggingEnabled).to.equal(true);
+        formulaId = r.body.id;
+      })
       .then(r => cloud.patch(`${test.api}/${formulaId}`, patchBody))
       .then(r => expect(r.body.debugLoggingEnabled).to.equal(false))
       .then(r => cloud.delete(`${test.api}/${formulaId}`))
@@ -404,8 +420,10 @@ suite.forPlatform('formulas', opts, (test) => {
 
     let formulaId;
     return cloud.post(test.api, f, schema)
-      .then(r => { expect(r.body.debugLoggingEnabled).to.equal(true);
-        formulaId = r.body.id; })
+      .then(r => {
+        expect(r.body.debugLoggingEnabled).to.equal(true);
+        formulaId = r.body.id;
+      })
       .then(r => cloud.patch(`${test.api}/${formulaId}`, patchBody, (r) => {
         expect(r).to.have.statusCode(400);
         expect(r.body.message).to.contain('Execution debug logging can be disabled only for formula engine v3');


### PR DESCRIPTION
## Highlights
* When a formula was upgraded to v3, empty step property values, or those with just spaces in the string were being translated to "${}", which is invalid.
* Fixed this issue in `soba` and made the corresponding change in `churros` to test for this fix.

## Screenshot
![image](https://user-images.githubusercontent.com/3017448/40393314-1c572106-5ddc-11e8-92ae-4966fcd3e198.png)

## Reference
* https://github.com/cloud-elements/soba/pull/8753
* [RALLY-#DE1478](https://rally1.rallydev.com/#/144349238268d/detail/defect/216031226988)

## Closes
* Closes #[DE1478](https://rally1.rallydev.com/#/144349238268d/detail/defect/216031226988)
