### PR TITLE
Drop ce_message_log  - Updated Test cases

### DIFF
--- a/src/test/elements/mailjet/assets/transformations.json
+++ b/src/test/elements/mailjet/assets/transformations.json
@@ -1,0 +1,9 @@
+{
+  "messages": {
+    "vendorName": "messages",
+    "fields": [{
+      "path": "id",
+      "vendorPath": "id"
+    }]
+  }
+}

--- a/src/test/elements/mailjet/messages.js
+++ b/src/test/elements/mailjet/messages.js
@@ -13,6 +13,4 @@ suite.forElement('messaging', 'messages', { payload: payload }, (test) => {
       .then(() => tools.sleep(10))		//takes some time for Mailjet to process the POST request
       .then(r => cloud.get(`${test.api}/${messageId}`));
   });
-  test.should.supportS();
-  test.should.supportPagination();
 });

--- a/src/test/elements/sendgrid/messages.js
+++ b/src/test/elements/sendgrid/messages.js
@@ -1,8 +1,13 @@
 'use strict';
 
 const suite = require('core/suite');
+const cloud = require('core/cloud');
+const expect = require('chakram').expect;
 const payload = require('./assets/messages');
 
 suite.forElement('messaging', 'messages', { payload: payload }, (test) => {
-  test.should.supportCrs();
+  it(`should allow C for ${test.api}`, () => {
+    return cloud.post(test.api, payload)
+      .then(r => expect(r.body.from).to.equal('churros@gmail.com'));
+  });
 });


### PR DESCRIPTION
## Highlights
* Remove ce_message_log table 

## Checklist
* [x] applicable churros tests are still passing
* [ ] includes a dbdeploy script that is backward-incompatible with one previous Soba minor version

## Screenshot
<img width="815" alt="screen shot 2018-05-24 at 11 13 34 pm" src="https://user-images.githubusercontent.com/26943831/40526659-92186ef4-5fad-11e8-8958-8451e851bc75.png">
<img width="802" alt="screen shot 2018-05-24 at 11 11 35 pm" src="https://user-images.githubusercontent.com/26943831/40526664-97525164-5fad-11e8-8dca-eec27d3d8bc7.png">

## Related PRs
[Soba](https://github.com/cloud-elements/soba/pull/8771)

## Closes
[US11891](https://rally1.rallydev.com/#/144349237612d/detail/userstory/219740683616)
