### PR TITLE
Hootsuite : Added churros test for interactions

### DIFF
--- a/src/test/elements/hootsuite/interactions.js
+++ b/src/test/elements/hootsuite/interactions.js
@@ -1,0 +1,18 @@
+'use strict';
+
+const suite = require('core/suite');
+const expect = require('chakram').expect;
+
+suite.forElement('social', 'interactions', (test) => {
+  test.withOptions({ qs: { where: 'socialNetworkType=\'Twitter\' and socialNetworkId=82295100 and targetSocialNetworkId=876713392311902208' } })
+    .withName('should support search by filter')
+    .withValidation(r => {
+      expect(r).to.statusCode(200);
+      const validValues = r.body.filter(obj => obj.socialNetworkType = 'Twitter');
+      expect(validValues.length).to.equal(r.body.length);
+    })
+    .should.return200OnGet();
+
+    test.withOptions({ qs: { where: 'socialNetworkType=\'Twitter\' and socialNetworkId=82295100 and targetSocialNetworkId=876713392311902208' } })
+    .should.supportNextPagePagination(2);
+});


### PR DESCRIPTION
## Highlights
* Added churros test for `interactions` to check for GET API response and pagination

## Screenshot
![hsinteractions](https://user-images.githubusercontent.com/37102802/40607560-7b79ec3c-6286-11e8-8037-b4a3fa8b1287.PNG)
[HootsuiteChurros.txt](https://github.com/cloud-elements/churros/files/2044476/HootsuiteChurros.txt)

## Reference
* [SOBA](https://github.com/cloud-elements/soba/pull/8782)
* [RALLY-#${DE1790}](https://rally1.rallydev.com/#/144349237612d/detail/defect/223623145816)

## Closes
* [DE1790](https://rally1.rallydev.com/#/144349237612d/detail/defect/223623145816)

## Note
Closed duplicate PR [https://github.com/cloud-elements/churros/pull/1583](https://github.com/cloud-elements/churros/pull/1583)
