### PR TITLE
Stripe : Added tests for POST, PATCH and DELETE subscription APIs

### DIFF
--- a/src/test/elements/stripe/assets/orders.json
+++ b/src/test/elements/stripe/assets/orders.json
@@ -12,18 +12,14 @@
     "name": "Jenny Rosen"
   },
   "currency": "usd",
-  "items": [{
+  "items": [
+    {
       "parent": "sku_8UEPIi3s4MWMsa",
       "amount": 1000,
       "quantity": 1,
       "description": "hoverboard",
       "currency": "usd",
       "type": "sku"
-    },
-    {
-      "amount": 0,
-      "description": "Taxes (included)",
-      "currency": "usd"
     }
   ],
   "email": "jenny@ros.en"

--- a/src/test/elements/stripe/assets/subscriptions.json
+++ b/src/test/elements/stripe/assets/subscriptions.json
@@ -1,0 +1,16 @@
+{
+  " billing": "charge_automatically",
+  "customer": "cus_CxJBOeifhp5V2f",
+  "items": [
+    {
+      "plan": "plan_ChEvY5ZTAjB2mv",
+      "quantity": 1
+    }
+  ],
+  "metadata": {
+    "key": "asqqw"
+  },
+  "prorate": true,
+  "source": {},
+  "tax_percent": 10
+}

--- a/src/test/elements/stripe/assets/transformations.json
+++ b/src/test/elements/stripe/assets/transformations.json
@@ -97,5 +97,14 @@
         "vendorPath": "id"
       }
     ]
+  },
+  "subscriptions": {
+    "vendorName": "subscriptions",
+    "fields": [
+      {
+        "path": "id",
+        "vendorPath": "id"
+      }
+    ]
   }
 }

--- a/src/test/elements/stripe/subscriptions.js
+++ b/src/test/elements/stripe/subscriptions.js
@@ -4,6 +4,7 @@ const suite = require('core/suite');
 const tools = require('core/tools');
 const cloud = require('core/cloud');
 const customer = require('./assets/customers');
+const payload = require('./assets/subscriptions');
 
 const createSubscription = (planId) => ({
   "plan": "gold"
@@ -19,11 +20,18 @@ const plan = () => ({
   "id": tools.random()
 });
 
-suite.forElement('payment', 'subscriptions', (test) => {
+suite.forElement('payment', 'subscriptions', { payload: payload }, (test) => {
   let customerId, planId;
 
+  const opts = {
+    churros: {
+      updatePayload: {
+        quantity: 2
+      }
+    }
+  };
   test.should.supportNextPagePagination(2);
-  test.should.supportSr();
+  test.withOptions(opts).should.supportCruds();
 
   before(() => cloud.post(`/hubs/payment/customers`, customer)
     .then(r => customerId = r.body.id)


### PR DESCRIPTION
## Highlights
* Added tests for POST, PATCH and DELETE subscription APIs
* Fixed churros errors for `orders`

## Screenshot
![stripeintteractions](https://user-images.githubusercontent.com/37102802/40715751-3c3e5a04-6424-11e8-9117-536bbbbf20fc.PNG)
[StripeChurros.txt](https://github.com/cloud-elements/churros/files/2053792/StripeChurros.txt)

## Reference
* [RALLY-#${DE1777}](https://rally1.rallydev.com/#/144349237612d/detail/defect/223133123660)

## Closes
* [DE1777](https://rally1.rallydev.com/#/144349237612d/detail/defect/223133123660)
