### PR TITLE
Added testcase for GET /forms/{formId}/leads in Facebook Lead Ads

### DIFF
--- a/src/test/elements/facebookleadads/leads.js
+++ b/src/test/elements/facebookleadads/leads.js
@@ -4,8 +4,9 @@ const suite = require('core/suite');
 const cloud = require('core/cloud');
 
 suite.forElement('marketing', 'leads', null, (test) => {
-  //Currently we have this formId available with Leads, hence hardcoding the same.
-  //Used https://developers.facebook.com/tools/lead-ads-testing to create leads
+  //Used https://developers.facebook.com/tools/lead-ads-testing to create test leads
+  //Otherwise you need to pay for publishing the ad and then create leads under it
+  //Currently we have this formId available with test Leads, hence hardcoding the same.
   //Value of formLeadId will change if you delete the existing lead.
   let formId = 1856949527939272;
   it('should allow R for /hubs/marketing/forms/{formId}/leads', () => {

--- a/src/test/elements/facebookleadads/leads.js
+++ b/src/test/elements/facebookleadads/leads.js
@@ -4,6 +4,14 @@ const suite = require('core/suite');
 const cloud = require('core/cloud');
 
 suite.forElement('marketing', 'leads', null, (test) => {
+  //Currently we have this formId available with Leads, hence hardcoding the same.
+  //Used https://developers.facebook.com/tools/lead-ads-testing to create leads
+  //Value of formLeadId will change if you delete the existing lead.
+  let formId = 1856949527939272;
+  it('should allow R for /hubs/marketing/forms/{formId}/leads', () => {
+    return cloud.get(`/hubs/marketing/forms/${formId}/leads`)
+      .then(r => cloud.withOptions({ qs: { fields: 'created_time,form_id' } }).get(`/hubs/marketing/forms/${formId}/leads`));
+  });
   // As we do not have a GET all API for leads, hardcoding the leadId
   let leadId = 239907496137483;
   it('should allow R for /hubs/marketing/leads', () => {


### PR DESCRIPTION
## Highlights
* Added test case for `GET /forms/{formId}/leads` for Facebook Lead Ads.

## Screenshot
![image](https://user-images.githubusercontent.com/20634723/40923363-4793f6cc-6832-11e8-9b22-4d745dd759f3.png)

## Reference
*  [SOBA](https://github.com/cloud-elements/soba/pull/8826)
*  [US12311](https://rally1.rallydev.com/#/144349237612ud/detail/userstory/225398556000)

## Closes
*   [US12311](https://rally1.rallydev.com/#/144349237612ud/detail/userstory/225398556000)
