### PR TITLE
Maximizer Enhanced with Notes and Documents API

### DIFF
--- a/src/test/elements/maximizer/assets/documents.json
+++ b/src/test/elements/maximizer/assets/documents.json
@@ -1,0 +1,3 @@
+{
+  "Name": "<<name.title>>"
+}

--- a/src/test/elements/maximizer/assets/notes.json
+++ b/src/test/elements/maximizer/assets/notes.json
@@ -1,0 +1,4 @@
+{
+"Type": 0,
+"Text": "<<name.title>>"
+}


### PR DESCRIPTION
## Highlights
* Maximizer -  Added Test cases for `Notes` and `Documents` API

## Checklist
* [x] applicable churros tests are still passing
* [ ] includes a dbdeploy script that is backward-incompatible with one previous Soba minor version

## Screenshot
<img width="1021" alt="screen shot 2018-05-18 at 12 24 46 pm" src="https://user-images.githubusercontent.com/26943831/40249174-ca3b7364-5a97-11e8-9bf7-618a288d19d7.png">

## Related PR
[Soba](https://github.com/cloud-elements/soba/pull/8714)

## Closes
[US12347](https://rally1.rallydev.com/#/144349237612d/detail/userstory/225943888616)