### PR TITLE
Added test cases for void and capture invoices APIs on MagentoV2

### DIFF
--- a/src/test/elements/magentov20/invoices.js
+++ b/src/test/elements/magentov20/invoices.js
@@ -33,11 +33,11 @@ suite.forElement('ecommerce', 'invoices', { payload: payload }, (test) => {
         it(`should allow C for /hubs/ecommerce/invoices/{entity_id}/emails`, () => {
           return cloud.post(`/hubs/ecommerce/invoices/${entity_id}/emails`);
         });
-
+        //Skipped since this requires an invoices to be set to Authorize only payment method, which can be done through UI
         it.skip(`should allow C for /hubs/ecommerce/invoices/{entity_id}/capture`, () => {
           return cloud.post(`/hubs/ecommerce/invoices/${entity_id}/capture`);
         });
-
+        //Skipped since this requires an invoices to be set to Authorize only payment method, which can be done through UI
         it.skip(`should allow D for /hubs/ecommerce/invoices/{entity_id}`, () => {
           return cloud.delete(`/hubs/ecommerce/invoices/${entity_id}`);
         });

--- a/src/test/elements/magentov20/invoices.js
+++ b/src/test/elements/magentov20/invoices.js
@@ -33,4 +33,12 @@ suite.forElement('ecommerce', 'invoices', { payload: payload }, (test) => {
         it(`should allow C for /hubs/ecommerce/invoices/{entity_id}/emails`, () => {
           return cloud.post(`/hubs/ecommerce/invoices/${entity_id}/emails`);
         });
+
+        it.skip(`should allow C for /hubs/ecommerce/invoices/{entity_id}/capture`, () => {
+          return cloud.post(`/hubs/ecommerce/invoices/${entity_id}/capture`);
+        });
+
+        it.skip(`should allow D for /hubs/ecommerce/invoices/{entity_id}`, () => {
+          return cloud.delete(`/hubs/ecommerce/invoices/${entity_id}`);
+        });
       });

--- a/src/test/elements/magentov20/invoices.js
+++ b/src/test/elements/magentov20/invoices.js
@@ -33,11 +33,11 @@ suite.forElement('ecommerce', 'invoices', { payload: payload }, (test) => {
         it(`should allow C for /hubs/ecommerce/invoices/{entity_id}/emails`, () => {
           return cloud.post(`/hubs/ecommerce/invoices/${entity_id}/emails`);
         });
-        //Skipped since this requires an invoices to be set to Authorize only payment method, which can be done through UI
+        //Skipped since this requires an invoice to be set to Authorize only payment method, which can be done through UI
         it.skip(`should allow C for /hubs/ecommerce/invoices/{entity_id}/capture`, () => {
           return cloud.post(`/hubs/ecommerce/invoices/${entity_id}/capture`);
         });
-        //Skipped since this requires an invoices to be set to Authorize only payment method, which can be done through UI
+        //Skipped since this requires an invoice to be set to Authorize only payment method, which can be done through UI
         it.skip(`should allow D for /hubs/ecommerce/invoices/{entity_id}`, () => {
           return cloud.delete(`/hubs/ecommerce/invoices/${entity_id}`);
         });


### PR DESCRIPTION
## Highlights
* Added churros test for capture and void endpoints for `invoices`
* The test are skipped since it requires an `invoice` to be set to `Authorize only` payment method, which can be done through Magento UI
        

## Screenshot
* Churros for complete element is failing. [DE1913](https://rally1.rallydev.com/#/144349237612d/detail/defect/227844434644?fdp=true)
![image](https://user-images.githubusercontent.com/29943090/41142090-128d5300-6b12-11e8-92d0-7fa66a0b74b9.png)


## Reference
* [SOBA](https://github.com/cloud-elements/soba/pull/8853)
* [RALLY-#${US11824}]https://rally1.rallydev.com/#/144349237612d/detail/userstory/218877926500)

## Closes
* [US11824](https://rally1.rallydev.com/#/144349237612d/detail/userstory/218877926500)
