### PR TITLE
ServiceNow and ServiceNowOAuth: Added new test cases for /items

### DIFF
--- a/src/test/elements/servicenow/agents.js
+++ b/src/test/elements/servicenow/agents.js
@@ -16,7 +16,6 @@ const options = {
       "first_name": "Churros",
       "middle_name": "P.",
       "country": "US",
-      "user_name": "churro.s",
       "email": "claude-update@churros.com",
       "roles": "",
       "last_name": "UPDATE",

--- a/src/test/elements/servicenow/assets/submit_producer.json
+++ b/src/test/elements/servicenow/assets/submit_producer.json
@@ -1,0 +1,6 @@
+{
+  "variables":{
+     "role_delegator_group" : "group",
+    "role_delegator_user" : "user"
+   }	
+}

--- a/src/test/elements/servicenow/contacts.js
+++ b/src/test/elements/servicenow/contacts.js
@@ -16,7 +16,6 @@ const options = {
       "first_name": "Claudey",
       "middle_name": "P.",
       "country": "US",
-      "user_name": "claudey.churros",
       "email": "claudey@churros.com",
       "roles": "",
       "last_name": "UPDATE",

--- a/src/test/elements/servicenow/items.js
+++ b/src/test/elements/servicenow/items.js
@@ -1,0 +1,18 @@
+'use strict';
+
+const suite = require('core/suite');
+const expect = require('chakram').expect;
+const cloud = require('core/cloud');
+const payload = require('./assets/submit_producer');
+
+
+suite.forElement('helpdesk', 'items', (test) => {
+  test.should.return200OnGet();
+  test.should.supportPagination();
+
+  it('should allow C for /hubs/helpdesk/items/{sys_id}/submit_producer', () => {
+    let sys_id = "01205b180a0a0b3000b6efd641d24b75";
+    return cloud.post(`${test.api}/${sys_id}/submit_producer`, payload)
+	  .then(r => expect(r.body).to.not.be.empty);
+  });
+});

--- a/src/test/elements/servicenow/items.js
+++ b/src/test/elements/servicenow/items.js
@@ -13,6 +13,6 @@ suite.forElement('helpdesk', 'items', (test) => {
   it('should allow C for /hubs/helpdesk/items/{sys_id}/submit_producer', () => {
     let sys_id = "01205b180a0a0b3000b6efd641d24b75";
     return cloud.post(`${test.api}/${sys_id}/submit_producer`, payload)
-	  .then(r => expect(r.body).to.not.be.empty);
+	  .then(r =>  expect(r).to.have.statusCode(200));
   });
 });

--- a/src/test/elements/servicenowoauth/agents.js
+++ b/src/test/elements/servicenowoauth/agents.js
@@ -16,7 +16,6 @@ const options = {
       "first_name": "Churros",
       "middle_name": "P.",
       "country": "US",
-      "user_name": "churro.s",
       "email": "claude-update@churros.com",
       "roles": "",
       "last_name": "UPDATE",

--- a/src/test/elements/servicenowoauth/assets/submit_producer.json
+++ b/src/test/elements/servicenowoauth/assets/submit_producer.json
@@ -1,0 +1,6 @@
+{
+  "variables":{
+     "role_delegator_group" : "group",
+    "role_delegator_user" : "user"
+   }	
+}

--- a/src/test/elements/servicenowoauth/contacts.js
+++ b/src/test/elements/servicenowoauth/contacts.js
@@ -16,7 +16,6 @@ const options = {
       "first_name": "Claudey",
       "middle_name": "P.",
       "country": "US",
-      "user_name": "claudey.churros",
       "email": "claudey@churros.com",
       "roles": "",
       "last_name": "UPDATE",

--- a/src/test/elements/servicenowoauth/items.js
+++ b/src/test/elements/servicenowoauth/items.js
@@ -1,0 +1,18 @@
+'use strict';
+
+const suite = require('core/suite');
+const expect = require('chakram').expect;
+const cloud = require('core/cloud');
+const payload = require('./assets/submit_producer');
+
+
+suite.forElement('helpdesk', 'items', (test) => {
+  test.should.return200OnGet();
+  test.should.supportPagination();
+
+  it('should allow C for /hubs/helpdesk/items/{sys_id}/submit_producer', () => {
+    let sys_id = "01205b180a0a0b3000b6efd641d24b75";
+    return cloud.post(`${test.api}/${sys_id}/submit_producer`, payload)
+	  .then(r => expect(r.body).to.not.be.empty);
+  });
+});

--- a/src/test/elements/servicenowoauth/items.js
+++ b/src/test/elements/servicenowoauth/items.js
@@ -13,6 +13,6 @@ suite.forElement('helpdesk', 'items', (test) => {
   it('should allow C for /hubs/helpdesk/items/{sys_id}/submit_producer', () => {
     let sys_id = "01205b180a0a0b3000b6efd641d24b75";
     return cloud.post(`${test.api}/${sys_id}/submit_producer`, payload)
-	  .then(r => expect(r.body).to.not.be.empty);
+      .then(r =>  expect(r).to.have.statusCode(200));
   });
 });


### PR DESCRIPTION
## Highlights
* Added test cases in ServiceNow and ServiceNowOAuth for following APIs : 
- `GET /items`
- `POST /items/{sys_id}/submit_producer`

* Modified test cases in ServiceNow and ServiceNowOAuth for following APIs:
- `PATCH /agents/{id}`
- `PATCH /contacts/{id}`

## Non-customer Highlights
- Payload for `POST /items/{sys_id}/submit_producer` is item specific. So have hard-coded the sys_id of item in churros test case.

## Screenshot
Applicable churros are passing

- For ServiceNow:
![servicenow_churros](https://user-images.githubusercontent.com/37102805/41188329-2c70f764-6bd9-11e8-8e9b-dac860d7d3db.PNG)

- For ServiceNowOAuth:
![servicenowoauth_churros](https://user-images.githubusercontent.com/37102805/41188337-3db6f370-6bd9-11e8-83e4-9dc9aae6a914.PNG)


## Reference
* [SOBA](https://github.com/cloud-elements/soba/pull/8861)
* [US12351](https://rally1.rallydev.com/#/144349237612d/detail/userstory/225944455852)

## Closes
* [US12351](https://rally1.rallydev.com/#/144349237612d/detail/userstory/225944455852)