### PR TITLE
Dropbox v2: Added test case for /files/revoke-link-access endpoint 

### DIFF
--- a/src/test/elements/dropboxv2/assets/revokelinkaccess.json
+++ b/src/test/elements/dropboxv2/assets/revokelinkaccess.json
@@ -1,0 +1,3 @@
+{
+"url" : "https://www.dropbox.com/s/duybyrtybvfyzoo/testme.txt?dl=0"
+}

--- a/src/test/elements/dropboxv2/files.js
+++ b/src/test/elements/dropboxv2/files.js
@@ -3,6 +3,8 @@
 const cloud = require('core/cloud');
 const suite = require('core/suite');
 const tools = require('core/tools');
+const expect = require('chakram').expect;
+const revokelinkaccessPayload = require('./assets/revokelinkaccess.json');
 
 suite.forElement('documents', 'files', (test) => {
 
@@ -26,5 +28,14 @@ suite.forElement('documents', 'files', (test) => {
       .then(r => revisionId = r.body[0].id)
       .then(() => cloud.withOptions({ qs: query }).get(`${test.api}/revisions/${revisionId}`));
   });
+
+  it('it should allow C for documents/files/revoke-link-access', () => {
+      return cloud.get(`${test.api}/${jpgFileBody.id}/links`)
+      .then(r => revokelinkaccessPayload.url = r.body.providerViewLink)
+      .then(r => cloud.post(`${test.api}/revoke-link-access`, revokelinkaccessPayload))
+      .then(r => expect(r.body).to.be.empty);
+  });
+
+
 
 });


### PR DESCRIPTION
## Highlights
* Added test case for `/files/revoke-link-access` endpoint 
* Users can now revoke the shared links for files through the element API docs

## Screenshot
![image](https://user-images.githubusercontent.com/29943090/41398289-81742692-6fd4-11e8-89bc-9604fa5210cf.png)
![image](https://user-images.githubusercontent.com/29943090/41398320-9ab5f28e-6fd4-11e8-80d7-565121e12abe.png)

## Reference
* [SOBA](https://github.com/cloud-elements/soba/pull/8882)
* [RALLY-#${US12546}](https://rally1.rallydev.com/#/144349237612d/detail/userstory/227740091500)

## Closes
* [US12546](https://rally1.rallydev.com/#/144349237612d/detail/userstory/227740091500)
