### PR TITLE
Added tests for the Helium version of the GET /objects API and invoking this during element instance instantiation

### DIFF
--- a/src/test/elements/magentov20/metadata.js
+++ b/src/test/elements/magentov20/metadata.js
@@ -1,0 +1,100 @@
+'use strict';
+
+const suite = require('core/suite');
+const expect = require('chakram').expect;
+const cloud = require('core/cloud');
+const tools = require('core/tools');
+const props = require('core/props');
+
+suite.forElement('ecommerce', 'metadata', (test) => {
+  const validEmail = (r) => {
+    expect(r).to.have.statusCode(200);
+    expect(r.body.fields).to.not.be.null;
+    expect(r.body.fields).to.be.an('array');
+    let email = r.body.fields.find((obj) => {
+      return obj.vendorPath === 'email';
+    });
+    expect(email).to.not.be.null;
+    expect(email.createable).to.exist.and.to.be.true;
+    expect(email.updateable).to.exist.and.to.be.true;
+    return true;
+  };
+
+  const validObjects = (r) => {
+    expect(r).to.have.statusCode(200);
+    expect(r.body).to.not.be.null;
+    expect(r.body).to.be.an('array');
+
+    let ceObject = r.body.find((obj) => {
+      return obj.name === 'customers';
+    });
+    expect(ceObject).to.not.be.null;
+    expect(ceObject.vendorName).to.not.be.null;
+    expect(ceObject.vendorName).to.equal('customers');
+    expect(ceObject.type).to.not.be.null;
+    expect(ceObject.type).to.equal('ceCanonical');
+  };
+
+  const validateInstanceWithObjects = (r) => {
+    expect(r).to.have.statusCode(200);
+    expect(r.body).to.not.be.null;
+    expect(r.body).to.be.an('object');
+
+    expect(r.body.objects).to.exist;
+    expect(r.body.objects).to.not.be.null;
+    expect(r.body.objects).to.be.an('array');
+    let vendorObject = r.body.objects.find((obj) => {
+      return obj.vendorName === 'customers';
+    });
+    expect(vendorObject).to.not.be.null;
+    expect(vendorObject.name).to.not.be.null;
+    expect(vendorObject.name).to.equal('customers');
+    expect(vendorObject.type).to.not.be.null;
+    expect(vendorObject.type).to.equal('ceCanonical');
+  };
+
+  test.withApi('/objects')
+    .withValidation(r => {
+      (expect(r).to.have.statusCode(200) && expect(r.body).to.include('invoices'));
+    })
+    .withName('should test objects api')
+    .should.return200OnGet();
+
+  test.withApi('/objects/customers/metadata')
+    .withValidation(validEmail)
+    .withName('should have email property with filterable, createable, and updateable metadata')
+    .should.return200OnGet();
+
+  it('should test objects helium api', () => {
+    return cloud.withOptions({
+        headers: {
+          "Elements-Version": "Helium"
+        }
+      }).get('/objects')
+      .then(r => validObjects(r));
+  });
+
+  it('should retrieve objects for instance when specified', () => {
+    let config = props.all('magentov20');
+    let newInstanceId;
+
+    return cloud.post('/instances', {
+        "name": "churros-" + tools.random(),
+        "element": {
+          "key": "magentov20"
+        },
+        "configuration": {
+          "site": config.site,
+          "user": config.user,
+          "username": config.username,
+          "password": config.password,
+          "filter.response.nulls": "true"
+        },
+        "retrieveObjectsAfterInstantiation": true
+      })
+      .then(r => newInstanceId = r.body.id)
+      .then(r => validateInstanceWithObjects(r))
+      .then(r => cloud.delete(`/instances/${newInstanceId}`))
+      .catch(() => cloud.delete(`/instances/${newInstanceId}`));
+  });
+});

--- a/src/test/elements/netsuitefinancev2/metadata.js
+++ b/src/test/elements/netsuitefinancev2/metadata.js
@@ -3,6 +3,8 @@
 const suite = require('core/suite');
 const expect = require('chakram').expect;
 const cloud = require('core/cloud');
+const tools = require('core/tools');
+const props = require('core/props');
 const resources = require('./assets/objects');
 
 suite.forElement('finance', 'metadata', (test) => {
@@ -10,7 +12,9 @@ suite.forElement('finance', 'metadata', (test) => {
     expect(r).to.have.statusCode(200);
     expect(r.body.fields).to.not.be.null;
     expect(r.body.fields).to.be.an('array');
-    let email = r.body.fields.find((obj) => { return obj.vendorPath === 'email'; });
+    let email = r.body.fields.find((obj) => {
+      return obj.vendorPath === 'email';
+    });
     expect(email).to.not.be.null;
     expect(email.filterable).to.exist;
     expect(email.createable).to.exist.and.to.be.true;
@@ -18,8 +22,52 @@ suite.forElement('finance', 'metadata', (test) => {
     return true;
   };
 
+  const validObjects = (r) => {
+    expect(r).to.have.statusCode(200);
+    expect(r.body).to.not.be.null;
+    expect(r.body).to.be.an('array');
+
+    let vendorObject = r.body.find((obj) => {
+      return obj.vendorName === 'Contact';
+    });
+    expect(vendorObject).to.not.be.null;
+    expect(vendorObject.name).to.not.be.null;
+    expect(vendorObject.name).to.equal('Contact');
+    expect(vendorObject.type).to.not.be.null;
+    expect(vendorObject.type).to.equal('vendor');
+
+    let ceObject = r.body.find((obj) => {
+      return obj.name === 'payments';
+    });
+    expect(ceObject).to.not.be.null;
+    expect(ceObject.vendorName).to.not.be.null;
+    expect(ceObject.vendorName).to.equal('Payment');
+    expect(ceObject.type).to.not.be.null;
+    expect(ceObject.type).to.equal('ceCanonical');
+  };
+
+  const validateInstanceWithObjects = (r) => {
+    expect(r).to.have.statusCode(200);
+    expect(r.body).to.not.be.null;
+    expect(r.body).to.be.an('object');
+
+    expect(r.body.objects).to.exist;
+    expect(r.body.objects).to.not.be.null;
+    expect(r.body.objects).to.be.an('array');
+    let vendorObject = r.body.objects.find((obj) => {
+      return obj.vendorName === 'Contact';
+    });
+    expect(vendorObject).to.not.be.null;
+    expect(vendorObject.name).to.not.be.null;
+    expect(vendorObject.name).to.equal('Contact');
+    expect(vendorObject.type).to.not.be.null;
+    expect(vendorObject.type).to.equal('vendor');
+  };
+
   test.withApi('/objects')
-    .withValidation(r => { (expect(r).to.have.statusCode(200) && expect(r.body).to.include('Customer')); })
+    .withValidation(r => {
+      (expect(r).to.have.statusCode(200) && expect(r.body).to.include('Customer'));
+    })
     .withName('should test objects api')
     .should.return200OnGet();
 
@@ -38,6 +86,15 @@ suite.forElement('finance', 'metadata', (test) => {
     .withName('should have filterable, createable and updateable metadata for email for camel case resource')
     .should.return200OnGet();
 
+  it('should test objects helium api', () => {
+    return cloud.withOptions({
+        headers: {
+          "Elements-Version": "Helium"
+        }
+      }).get('/objects')
+      .then(r => validObjects(r));
+  });
+
   it('should have email property with filterable, createable, and updateable metadata for VDR', () => {
     return cloud.post('/organizations/objects/churrosTestObject/definitions', resources.churrosTestObject, () => {})
       .then(r => cloud.post('/organizations/elements/netsuitefinancev2/transformations/churrosTestObject', resources.churrosTestObjectXform, () => {}))
@@ -45,5 +102,33 @@ suite.forElement('finance', 'metadata', (test) => {
       .then(r => validEmail(r))
       .then(r => cloud.delete('/organizations/elements/netsuitefinancev2/transformations/churrosTestObject'))
       .then(r => cloud.delete('/organizations/objects/churrosTestObject/definitions'));
+  });
+
+  it('should retrieve objects for instance when specified', () => {
+    let config = props.all('netsuitefinancev2');
+    let newInstanceId;
+
+    return cloud.post('/instances', {
+        "name": "churros-" + tools.random(),
+        "element": {
+          "key": "netsuitefinancev2"
+        },
+        "configuration": {
+          "netsuite.sandbox": "false",
+          "netsuite.single.session": config['netsuite.single.session'],
+          "authentication.type": config['authentication.type'],
+          "netsuite.sso.roleId": config['netsuite.sso.roleId'],
+          "filter.response.nulls": "true",
+          "user.username": config['user.username'],
+          "netsuite.accountId": config['netsuite.accountId'],
+          "user.password": config['user.password'],
+          "netsuite.appId": config['netsuite.appId']
+        },
+        "retrieveObjectsAfterInstantiation": true
+      })
+      .then(r => newInstanceId = r.body.id)
+      .then(r => validateInstanceWithObjects(r))
+      .then(r => cloud.delete(`/instances/${newInstanceId}`))
+      .catch(() => cloud.delete(`/instances/${newInstanceId}`));
   });
 });


### PR DESCRIPTION
## Highlights
* Added a test for the `Helium` (2.0) version of the `GET /objects` API for the Netsuite Finance v2 and Magento V2 elements.
* Added a test to retrieve an element instance's objects via the `Helium` API during element instantiation for the Netsuite Finance v2 and Magento V2 elements.

## Screenshot
![image](https://user-images.githubusercontent.com/3017448/41502538-72032356-7179-11e8-9e9b-6b129efc604e.png)
![image](https://user-images.githubusercontent.com/3017448/41502540-7905c71c-7179-11e8-8413-57253482fa4e.png)
![image](https://user-images.githubusercontent.com/3017448/41513010-07178008-7252-11e8-9310-6e02d352d30e.png)



## Reference
* https://github.com/cloud-elements/soba/pull/8891
* [RALLY-#US12336](https://rally1.rallydev.com/#/144349238268d/detail/userstory/225707181892)

## Closes
* Closes #[US12336](https://rally1.rallydev.com/#/144349238268d/detail/userstory/225707181892)
