### PR TITLE
Netsuite CRM : Enhanced test cases for validating the where clause with IN operator

### DIFF
--- a/src/test/elements/netsuitecrmv2/accounts.js
+++ b/src/test/elements/netsuitecrmv2/accounts.js
@@ -13,6 +13,10 @@ const cloud = require('core/cloud');
 suite.forElement('crm', 'accounts', { payload: payload }, (test) => {
   test.should.supportCruds();
   test.withOptions({ qs: { page: 1, pageSize: 5 } }).should.supportPagination();
+  test.withOptions({ qs: { page: 1,
+                          pageSize: 5,
+                         where : "`custom.multi.scriptId` = 'custentity1' and `custom.multi.value.internalId` = 1"
+                         } }).should.return200OnGet();
   it(`should support S,  with IN operator for /hubs/crm/accounts`, () => {
     let internalIds = [];
     return cloud.withOptions({ qs: {page: 1, pageSize: 5} }).get(`/hubs/crm/accounts`)

--- a/src/test/elements/netsuitecrmv2/accounts.js
+++ b/src/test/elements/netsuitecrmv2/accounts.js
@@ -2,6 +2,7 @@
 
 const suite = require('core/suite');
 const payload = require('core/tools').requirePayload(`${__dirname}/assets/accounts.json`);
+const expect = require('chakram').expect;
 
 // Sample Custom Where Clause for Reference
 //`custom.long.scriptId` = 'custentity_cust_priority' and `custom.long.value` = 50
@@ -15,5 +16,10 @@ suite.forElement('crm', 'accounts', { payload: payload }, (test) => {
                            pageSize: 5,
                            where : "`custom.multi.scriptId` = 'custentity1' and `custom.multi.value.internalId` = 1"
                          } }).should.return200OnGet();
+  test.withOptions({ qs: { where: `internalId in (80,78,11)` }})
+  .withValidation(r => {expect(r).to.statusCode(200);
+  const validValues = r.body.filter(obj => obj.id.indexOf('80','78','11'));
+  expect(validValues.length).to.equal(r.body.length);
+  }).should.return200OnGet();
   test.should.supportCeqlSearch('id');
 });

--- a/src/test/elements/netsuitecrmv2/accounts.js
+++ b/src/test/elements/netsuitecrmv2/accounts.js
@@ -3,6 +3,7 @@
 const suite = require('core/suite');
 const payload = require('core/tools').requirePayload(`${__dirname}/assets/accounts.json`);
 const expect = require('chakram').expect;
+const cloud = require('core/cloud');
 
 // Sample Custom Where Clause for Reference
 //`custom.long.scriptId` = 'custentity_cust_priority' and `custom.long.value` = 50
@@ -12,14 +13,17 @@ const expect = require('chakram').expect;
 suite.forElement('crm', 'accounts', { payload: payload }, (test) => {
   test.should.supportCruds();
   test.withOptions({ qs: { page: 1, pageSize: 5 } }).should.supportPagination();
-  test.withOptions({ qs: { page: 1,
-                           pageSize: 5,
-                           where : "`custom.multi.scriptId` = 'custentity1' and `custom.multi.value.internalId` = 1"
-                         } }).should.return200OnGet();
-  test.withOptions({ qs: { where: `internalId in (80,78,11)` }})
-  .withValidation(r => {expect(r).to.statusCode(200);
-  const validValues = r.body.filter(obj => obj.id.indexOf('80','78','11'));
-  expect(validValues.length).to.equal(r.body.length);
-  }).should.return200OnGet();
+  it(`should support S,  with IN operator for /hubs/crm/accounts`, () => {
+    let internalIds = [];
+    return cloud.withOptions({ qs: {page: 1, pageSize: 5} }).get(`/hubs/crm/accounts`)
+    .then(r => r.body.forEach(function (entry) {
+    if (entry.id)
+      internalIds.push(entry.id);
+    }))
+    .then(r => cloud.withOptions({ qs: { where: `internalId in (${internalIds})`} }).get((test.api), (r) => {
+    expect(r.body.length).to.equal(5);
+    expect(r).to.have.statusCode(200);
+    }));
+  });
   test.should.supportCeqlSearch('id');
 });

--- a/src/test/elements/netsuitecrmv2/accounts.js
+++ b/src/test/elements/netsuitecrmv2/accounts.js
@@ -14,8 +14,8 @@ suite.forElement('crm', 'accounts', { payload: payload }, (test) => {
   test.should.supportCruds();
   test.withOptions({ qs: { page: 1, pageSize: 5 } }).should.supportPagination();
   test.withOptions({ qs: { page: 1,
-                          pageSize: 5,
-                         where : "`custom.multi.scriptId` = 'custentity1' and `custom.multi.value.internalId` = 1"
+                           pageSize: 5,
+                           where : "`custom.multi.scriptId` = 'custentity1' and `custom.multi.value.internalId` = 1"
                          } }).should.return200OnGet();
   it(`should support S,  with IN operator for /hubs/crm/accounts`, () => {
     let internalIds = [];

--- a/src/test/elements/netsuitecrmv2/activities.js
+++ b/src/test/elements/netsuitecrmv2/activities.js
@@ -5,7 +5,7 @@ const payload = require('./assets/activities');
 const expect = require('chakram').expect;
 const cloud = require('core/cloud');
 
-suite.forElement('crm', 'activities', { payload: payload}, (test) => {
+suite.forElement('crm', 'activities', { payload: payload }, (test) => {
   test.should.supportCruds();
   test.withOptions({ qs: { page: 1, pageSize: 5 } }).should.return200OnGet();
   it(`should support S, with IN operator for /hubs/crm/activities`, () => {

--- a/src/test/elements/netsuitecrmv2/activities.js
+++ b/src/test/elements/netsuitecrmv2/activities.js
@@ -3,16 +3,22 @@
 const suite = require('core/suite');
 const payload = require('./assets/activities');
 const expect = require('chakram').expect;
+const cloud = require('core/cloud');
 
-
-suite.forElement('crm', 'activities', { payload: payload }, (test) => {
+suite.forElement('crm', 'activities', { payload: payload}, (test) => {
   test.should.supportCruds();
   test.withOptions({ qs: { page: 1, pageSize: 5 } }).should.return200OnGet();
-  test.withOptions({ qs: { where: `internalId in (80,78,1,00)` }})
-  .withValidation(r => {
-    expect(r).to.statusCode(200);
-    const validValues = r.body.filter(obj => obj.id.indexOf('80','78','1','00'));
-    expect(validValues.length).to.equal(r.body.length);
-  }).should.return200OnGet();
+  it(`should support S, with IN operator for /hubs/crm/activities`, () => {
+    let internalIds = [];
+    return cloud.withOptions({ qs: {page: 1, pageSize: 5} }).get(`/hubs/crm/activities`)
+    .then(r => r.body.forEach(function (entry) {
+    if (entry.id)
+      internalIds.push(entry.id);
+    }))
+    .then(r => cloud.withOptions({ qs: { where: `internalId in (${internalIds})`} }).get((test.api), (r) => {
+    expect(r.body.length).to.equal(5);
+    expect(r).to.have.statusCode(200);
+    }));
+  });
   test.should.supportCeqlSearch('id');
 });

--- a/src/test/elements/netsuitecrmv2/activities.js
+++ b/src/test/elements/netsuitecrmv2/activities.js
@@ -2,9 +2,17 @@
 
 const suite = require('core/suite');
 const payload = require('./assets/activities');
+const expect = require('chakram').expect;
+
 
 suite.forElement('crm', 'activities', { payload: payload }, (test) => {
   test.should.supportCruds();
   test.withOptions({ qs: { page: 1, pageSize: 5 } }).should.return200OnGet();
+  test.withOptions({ qs: { where: `internalId in (80,78,1,00)` }})
+  .withValidation(r => {
+    expect(r).to.statusCode(200);
+    const validValues = r.body.filter(obj => obj.id.indexOf('80','78','1','00'));
+    expect(validValues.length).to.equal(r.body.length);
+  }).should.return200OnGet();
   test.should.supportCeqlSearch('id');
 });

--- a/src/test/elements/netsuitecrmv2/contacts.js
+++ b/src/test/elements/netsuitecrmv2/contacts.js
@@ -2,9 +2,15 @@
 
 const suite = require('core/suite');
 const payload = require('core/tools').requirePayload(`${__dirname}/assets/contacts.json`);
+const expect = require('chakram').expect;
 
 suite.forElement('crm', 'contacts', { payload: payload }, (test) => {
   test.should.supportCruds();
   test.withOptions({ qs: { page: 1, pageSize: 5 } }).should.return200OnGet();
+  test.withOptions({ qs: { where: `internalId in (4,6,1)`}})
+  .withValidation(r => {expect(r).to.statusCode(200);
+  const validValues = r.body.filter(obj => obj.id.indexOf('4','6','1'));
+  expect(validValues.length).to.equal(r.body.length);
+  }).should.return200OnGet();
   test.should.supportCeqlSearch('id');
 });

--- a/src/test/elements/netsuitecrmv2/contacts.js
+++ b/src/test/elements/netsuitecrmv2/contacts.js
@@ -3,14 +3,22 @@
 const suite = require('core/suite');
 const payload = require('core/tools').requirePayload(`${__dirname}/assets/contacts.json`);
 const expect = require('chakram').expect;
+const cloud = require('core/cloud');
 
 suite.forElement('crm', 'contacts', { payload: payload }, (test) => {
   test.should.supportCruds();
   test.withOptions({ qs: { page: 1, pageSize: 5 } }).should.return200OnGet();
-  test.withOptions({ qs: { where: `internalId in (4,6,1)`}})
-  .withValidation(r => {expect(r).to.statusCode(200);
-  const validValues = r.body.filter(obj => obj.id.indexOf('4','6','1'));
-  expect(validValues.length).to.equal(r.body.length);
-  }).should.return200OnGet();
-  test.should.supportCeqlSearch('id');
+  it(`should support S, with IN operator for /hubs/crm/contacts`, () => {
+    let internalIds = [];
+    return cloud.withOptions({ qs: {page: 1, pageSize: 5} }).get(`/hubs/crm/contacts`)
+    .then(r => r.body.forEach(function (entry) {
+    if (entry.id)
+      internalIds.push(entry.id);
+    }))
+    .then(r => cloud.withOptions({ qs: { where: `internalId in (${internalIds})`} }).get((test.api), (r) => {
+    expect(r.body.length).to.equal(5);
+    expect(r).to.have.statusCode(200);
+    }));
+  });
+ test.should.supportCeqlSearch('id');
 });

--- a/src/test/elements/netsuitecrmv2/folders.js
+++ b/src/test/elements/netsuitecrmv2/folders.js
@@ -4,15 +4,22 @@ const suite = require('core/suite');
 const tools = require('core/tools');
 const payload = tools.requirePayload(`${__dirname}/assets/folders.json`);
 const expect = require('chakram').expect;
+const cloud = require('core/cloud');
 
 suite.forElement('crm', 'folders', { payload: payload }, (test) => {
   test.should.supportCruds();
   test.withOptions({ qs: { page: 1, pageSize: 5 } }).should.supportPagination();
-  test.withOptions({ qs: { where: `internalId in (4,6,999)` }})
-  .withValidation(r => {
-    expect(r).to.statusCode(200);
-    const validValues = r.body.filter(obj => obj.id.indexOf('4','6','999'));
-  expect(validValues.length).to.equal(r.body.length);
-  }).should.return200OnGet();
+  it(`should support S, with IN operator for /hubs/crm/folders`, () => {
+    let internalIds = [];
+    return cloud.withOptions({ qs: {page: 1, pageSize: 5} }).get(`/hubs/crm/folders`)
+    .then(r => r.body.forEach(function (entry) {
+    if (entry.id)
+      internalIds.push(entry.id);
+    }))
+    .then(r => cloud.withOptions({ qs: { where: `internalId in (${internalIds})`} }).get((test.api), (r) => {
+    expect(r.body.length).to.equal(5);
+    expect(r).to.have.statusCode(200);
+    }));
+  });
   test.should.supportCeqlSearch('id');
 });

--- a/src/test/elements/netsuitecrmv2/folders.js
+++ b/src/test/elements/netsuitecrmv2/folders.js
@@ -3,9 +3,16 @@
 const suite = require('core/suite');
 const tools = require('core/tools');
 const payload = tools.requirePayload(`${__dirname}/assets/folders.json`);
+const expect = require('chakram').expect;
 
 suite.forElement('crm', 'folders', { payload: payload }, (test) => {
   test.should.supportCruds();
   test.withOptions({ qs: { page: 1, pageSize: 5 } }).should.supportPagination();
+  test.withOptions({ qs: { where: `internalId in (4,6,999)` }})
+  .withValidation(r => {
+    expect(r).to.statusCode(200);
+    const validValues = r.body.filter(obj => obj.id.indexOf('4','6','999'));
+  expect(validValues.length).to.equal(r.body.length);
+  }).should.return200OnGet();
   test.should.supportCeqlSearch('id');
 });

--- a/src/test/elements/netsuitecrmv2/leads.js
+++ b/src/test/elements/netsuitecrmv2/leads.js
@@ -3,14 +3,23 @@
 const suite = require('core/suite');
 const payload =  require('core/tools').requirePayload(`${__dirname}/assets/leads.json`);
 const expect = require('chakram').expect;
+const cloud = require('core/cloud');
+
 
 suite.forElement('crm', 'leads', { payload: payload }, (test) => {
   test.should.supportCruds();
   test.withOptions({ qs: { page: 1, pageSize: 5 } }).should.return200OnGet();
-  test.withOptions({ qs: { where: `internalId in (4,6,1)`}})
-  .withValidation(r => {expect(r).to.statusCode(200);
-  const validValues = r.body.filter(obj => obj.id.indexOf('4','6','1'));
-  expect(validValues.length).to.equal(r.body.length);
-  }).should.return200OnGet();
+  it(`should support S, with IN operator for /hubs/crm/leads`, () => {
+    let internalIds = [];
+    return cloud.withOptions({ qs: {page: 1, pageSize: 5} }).get(`/hubs/crm/leads`)
+    .then(r => r.body.forEach(function (entry) {
+    if (entry.id)
+      internalIds.push(entry.id);
+    }))
+    .then(r => cloud.withOptions({ qs: { where: `internalId in (${internalIds})`} }).get((test.api), (r) => {
+    expect(r.body.length).to.equal(5);
+    expect(r).to.have.statusCode(200);
+    }));
+  });
   test.should.supportCeqlSearch('id');
   });

--- a/src/test/elements/netsuitecrmv2/leads.js
+++ b/src/test/elements/netsuitecrmv2/leads.js
@@ -5,7 +5,6 @@ const payload =  require('core/tools').requirePayload(`${__dirname}/assets/leads
 const expect = require('chakram').expect;
 const cloud = require('core/cloud');
 
-
 suite.forElement('crm', 'leads', { payload: payload }, (test) => {
   test.should.supportCruds();
   test.withOptions({ qs: { page: 1, pageSize: 5 } }).should.return200OnGet();

--- a/src/test/elements/netsuitecrmv2/leads.js
+++ b/src/test/elements/netsuitecrmv2/leads.js
@@ -2,9 +2,15 @@
 
 const suite = require('core/suite');
 const payload =  require('core/tools').requirePayload(`${__dirname}/assets/leads.json`);
+const expect = require('chakram').expect;
 
 suite.forElement('crm', 'leads', { payload: payload }, (test) => {
   test.should.supportCruds();
   test.withOptions({ qs: { page: 1, pageSize: 5 } }).should.return200OnGet();
+  test.withOptions({ qs: { where: `internalId in (4,6,1)`}})
+  .withValidation(r => {expect(r).to.statusCode(200);
+  const validValues = r.body.filter(obj => obj.id.indexOf('4','6','1'));
+  expect(validValues.length).to.equal(r.body.length);
+  }).should.return200OnGet();
   test.should.supportCeqlSearch('id');
-});
+  });

--- a/src/test/elements/netsuitecrmv2/opportunities.js
+++ b/src/test/elements/netsuitecrmv2/opportunities.js
@@ -3,15 +3,23 @@
 const suite = require('core/suite');
 const payload = require('./assets/opportunities');
 const expect = require('chakram').expect;
+const cloud = require('core/cloud');
+
 
 suite.forElement('crm', 'opportunities', { payload: payload }, (test) => {
   test.should.supportCruds();
   test.withOptions({ qs: { page: 1, pageSize: 5 } }).should.return200OnGet();
-  test.withOptions({ qs: { where: `internalId in (336,338,1)` }})
-  .withValidation(r => {
-    expect(r).to.statusCode(200);
-    const validValues = r.body.filter(obj => obj.id.indexOf('336','338','1'));
-    expect(validValues.length).to.equal(r.body.length);
+  it(`should support S, with IN operator for /hubs/crm/opportunities`, () => {
+    let internalIds = [];
+    return cloud.withOptions({ qs: {page: 1, pageSize: 5} }).get(`/hubs/crm/opportunities`)
+    .then(r => r.body.forEach(function (entry) {
+    if (entry.id)
+      internalIds.push(entry.id);
+    }))
+    .then(r => cloud.withOptions({ qs: { where: `internalId in (${internalIds})`} }).get((test.api), (r) => {
+    expect(r.body.length).to.equal(5);
+    expect(r).to.have.statusCode(200);
+    }));
   });
   test.should.supportCeqlSearch('id');
 });

--- a/src/test/elements/netsuitecrmv2/opportunities.js
+++ b/src/test/elements/netsuitecrmv2/opportunities.js
@@ -5,7 +5,6 @@ const payload = require('./assets/opportunities');
 const expect = require('chakram').expect;
 const cloud = require('core/cloud');
 
-
 suite.forElement('crm', 'opportunities', { payload: payload }, (test) => {
   test.should.supportCruds();
   test.withOptions({ qs: { page: 1, pageSize: 5 } }).should.return200OnGet();

--- a/src/test/elements/netsuitecrmv2/opportunities.js
+++ b/src/test/elements/netsuitecrmv2/opportunities.js
@@ -2,9 +2,16 @@
 
 const suite = require('core/suite');
 const payload = require('./assets/opportunities');
+const expect = require('chakram').expect;
 
 suite.forElement('crm', 'opportunities', { payload: payload }, (test) => {
   test.should.supportCruds();
   test.withOptions({ qs: { page: 1, pageSize: 5 } }).should.return200OnGet();
+  test.withOptions({ qs: { where: `internalId in (336,338,1)` }})
+  .withValidation(r => {
+    expect(r).to.statusCode(200);
+    const validValues = r.body.filter(obj => obj.id.indexOf('336','338','1'));
+    expect(validValues.length).to.equal(r.body.length);
+  });
   test.should.supportCeqlSearch('id');
 });

--- a/src/test/elements/netsuitecrmv2/prospects.js
+++ b/src/test/elements/netsuitecrmv2/prospects.js
@@ -2,9 +2,16 @@
 
 const suite = require('core/suite');
 const payload = require('core/tools').requirePayload(`${__dirname}/assets/prospects.json`);
+const expect = require('chakram').expect;
 
 suite.forElement('crm', 'prospects', { payload: payload }, (test) => {
   test.should.supportCruds();
   test.withOptions({ qs: { page: 1, pageSize: 5 } }).should.supportPagination();
+  test.withOptions({ qs: { where: `internalId in (80,78,1)` }})
+  .withValidation(r => {
+  expect(r).to.statusCode(200);
+  const validValues = r.body.filter(obj => obj.id.indexOf('80','78','1'));
+  expect(validValues.length).to.equal(r.body.length);
+  }).should.return200OnGet();
   test.should.supportCeqlSearch('id');
 });

--- a/src/test/elements/netsuitecrmv2/prospects.js
+++ b/src/test/elements/netsuitecrmv2/prospects.js
@@ -5,7 +5,6 @@ const payload = require('core/tools').requirePayload(`${__dirname}/assets/prospe
 const expect = require('chakram').expect;
 const cloud = require('core/cloud');
 
-
 suite.forElement('crm', 'prospects', { payload: payload }, (test) => {
   test.should.supportCruds();
   test.withOptions({ qs: { page: 1, pageSize: 5 } }).should.supportPagination();

--- a/src/test/elements/netsuitecrmv2/prospects.js
+++ b/src/test/elements/netsuitecrmv2/prospects.js
@@ -3,15 +3,23 @@
 const suite = require('core/suite');
 const payload = require('core/tools').requirePayload(`${__dirname}/assets/prospects.json`);
 const expect = require('chakram').expect;
+const cloud = require('core/cloud');
+
 
 suite.forElement('crm', 'prospects', { payload: payload }, (test) => {
   test.should.supportCruds();
   test.withOptions({ qs: { page: 1, pageSize: 5 } }).should.supportPagination();
-  test.withOptions({ qs: { where: `internalId in (80,78,1)` }})
-  .withValidation(r => {
-  expect(r).to.statusCode(200);
-  const validValues = r.body.filter(obj => obj.id.indexOf('80','78','1'));
-  expect(validValues.length).to.equal(r.body.length);
-  }).should.return200OnGet();
+  it(`should support S, with IN operator for /hubs/crm/prospects`, () => {
+    let internalIds = [];
+    return cloud.withOptions({ qs: {page: 1, pageSize: 5} }).get(`/hubs/crm/prospects`)
+    .then(r => r.body.forEach(function (entry) {
+    if (entry.id)
+      internalIds.push(entry.id);
+    }))
+    .then(r => cloud.withOptions({ qs: { where: `internalId in (${internalIds})`} }).get((test.api), (r) => {
+    expect(r.body.length).to.equal(5);
+    expect(r).to.have.statusCode(200);
+    }));
+  });
   test.should.supportCeqlSearch('id');
 });


### PR DESCRIPTION
## Highlights
* Enhanced test cases for validating the where clause with IN operator
* We can query for objects like: `where=internalId in (1,2,3,4,45)`  - This will return all the records of the object whose `internalId` match with any of the Ids provided. If some of the provided ids are invalid, the request is still processed for the valid Ids.
* `where` clause is supported in following resources:
`accounts`
`activities`
`contacts`
`folders`
`leads`
`opportunities`
`prospects`

## Screenshot
* Churros
To test my changes I have ran test cases for only supported objects.
![churrosprospects](https://user-images.githubusercontent.com/29943090/41890908-71528dbc-792f-11e8-8408-ac27b2747d10.PNG)
![churrosaccount](https://user-images.githubusercontent.com/29943090/41890909-717ac052-792f-11e8-9b4f-6c9a3d2b77ec.PNG)
![churrosactivities](https://user-images.githubusercontent.com/29943090/41890910-71c43e62-792f-11e8-9f06-c42be3a8ea99.PNG)
![churroscontacts](https://user-images.githubusercontent.com/29943090/41890911-71ed84c0-792f-11e8-8114-3970ba499a61.PNG)
![churrosfolders](https://user-images.githubusercontent.com/29943090/41890912-723de352-792f-11e8-989a-07e3e86fd73e.PNG)
![churrosleads](https://user-images.githubusercontent.com/29943090/41890913-7286aab0-792f-11e8-8a5f-07c6e1f6381a.PNG)
![churrosopportunities](https://user-images.githubusercontent.com/29943090/41890914-72cadb54-792f-11e8-95ad-d17df9f50a14.PNG)

## Reference
* [SOBA](https://github.com/cloud-elements/soba/pull/8926)
* [RALLY-#${US12539}](https://rally1.rallydev.com/#/144349237612d/detail/userstory/227735062352)

## Closes
* Closes #${US12539}
