### PR TITLE
NetsuiteERPv2: Fixed churros failing test cases

### DIFF
--- a/src/test/elements/netsuiteerpv2/assets/credit-memos.json
+++ b/src/test/elements/netsuiteerpv2/assets/credit-memos.json
@@ -23,7 +23,7 @@
   },
   "isTaxable": false,
   "subsidiary": {
-    "internalId": "1",
+    "internalId": "3",
     "name": "Honeycomb Mfg."
   },
   "toBeEmailed": false,
@@ -33,20 +33,18 @@
   },
   "tranDate": "2015-02-19T02:00:00-06:00",
   "location": {
-    "internalId": "3",
-    "name": "02: Boston : Overstock"
+    "internalId": "6813",
+    "name": "01: San Francisco : San Fran 3"
   },
   "itemList": {
     "item": [{
       "item": {
-        "internalId": "38"
+        "internalId": "1116"
       },
-      "amount": 32.3,
-      "quantity": 2,
+      "amount": 4.99,
+      "quantity": 1,
       "line": 1,
-      "orderLine": 1,
-      "description": "Seven Deadly Zins 2003",
-      "isTaxable": true
+      "orderLine": 1
     }],
     "replaceAll": false
   },
@@ -58,8 +56,8 @@
     "addrText": "US"
   },
   "entity": {
-    "internalId": "-5",
-    "name": "Alex Wolfe"
+    "internalId": "36860",
+    "name": "11John Q Test"
   },
-  "status": "Open"
+  "status": "Fully Applied"
 }

--- a/src/test/elements/netsuiteerpv2/assets/states.json
+++ b/src/test/elements/netsuiteerpv2/assets/states.json
@@ -1,4 +1,4 @@
 {
- "shortname": "MH",
- "fullName":"MH<<address.state>>"
+ "shortname": "CH",
+ "fullName":"CH<<address.state>>"
 }


### PR DESCRIPTION
## Highlights
* Fixed failing testcases related to `/credit-memos` and `/states` API's
* Fixed failing testcases for `/location` API's by cleaning up locations from UI

## Screenshot
```
PS C:\Users\gs-1108\Documents\GitHub\churros> churros test elements/netsuiteerpv2

(node:24156) [DEP0022] DeprecationWarning: os.tmpDir() is deprecated. Use os.tmpdir() instead.

info: Using url: https://staging.cloud-elements.com
info: Using user: abhay.pore@gslab.com
info: Running tests for element: netsuiteerpv2
info: Provisioned with instance id of 100084
(node:24156) [DEP0013] DeprecationWarning: Calling an asynchronous function without callback is deprecated.
  Basic tests
    √ should provision
    √ should GET /objects (1167ms)
    - docs
    √ metadata (1107ms)
error: Failed to retrieve or validate: /hubs/erp/custom-records
    √ transformations (1038176ms)
    - should not allow provisioning with bad credentials

  accounts
error: Failed to delete /hubs/erp/accounts/1286799
    1) should allow CRUDS for /hubs/erp/accounts
    √ should allow GET for /hubs/erp/accounts (2103ms)
error: Failed to create or validate: /hubs/erp/accounts
    2) should support searching /hubs/erp/accounts by id

  activities
    √ should allow CRUDS for /hubs/erp/activities (24962ms)
    √ should allow GET for /hubs/erp/activities (4124ms)
    √ should support searching /hubs/erp/activities by id (7332ms)

  billing-accounts
error: Failed to create or validate: /hubs/erp/billing-accounts
    3) should allow CRUDS for /hubs/erp/billing-accounts
    √ should allow paginating with page and pageSize for /hubs/erp/billing-accounts (4491ms)

  bills
    √ should allow CRUDS for /hubs/erp/bills (37594ms)
    √ should allow paginating with page and pageSize for /hubs/erp/bills (9353ms)
    √ should support searching /hubs/erp/bills by id (11522ms)

  budgets
    - should allow SRUD for hubs/erp/budgets and CEQL search
    - should allow paginating with page and pageSize for /hubs/erp/budgets

  campaigns
    √ should allow CRUDS for /hubs/erp/campaigns (18300ms)
    √ should allow paginating with page and pageSize for /hubs/erp/campaigns (10466ms)
    √ should support Ceql date search (2074ms)

  cases
    √ should allow CRUDS for /hubs/erp/cases (67867ms)
    √ should allow GET for /hubs/erp/cases (2585ms)
    √ should support searching /hubs/erp/cases by id (14383ms)
    √ should allow GET /hubs/erp/cases/:id/messages  (12193ms)

  cash-sales
    √ should allow CRUDS for /hubs/erp/cash-sales (56377ms)
    √ should allow GET for /hubs/erp/cash-sales (33101ms)
    √ should support searching /hubs/erp/cash-sales by id (14477ms)

  checks
    √ should allow CRUDS for /hubs/erp/checks (19443ms)
    √ should support searching /hubs/erp/checks by memo (12970ms)

  classifications
    √ should allow CRUDS for /hubs/erp/classifications (10869ms)
    √ should allow paginating with page and pageSize for /hubs/erp/classifications (4746ms)
    √ should support searching /hubs/erp/classifications by name (6906ms)

  contacts
error: Failed to delete /hubs/erp/contacts/1286899
    4) should allow CRUDS for /hubs/erp/contacts
    √ should allow GET for /hubs/erp/contacts (8390ms)
error: Failed to create or validate: /hubs/erp/contacts
    5) should support searching /hubs/erp/contacts by id

  credit-memos
    √ should allow CRUDS for /hubs/erp/credit-memos (65682ms)
    √ should allow GET for /hubs/erp/credit-memos (11674ms)
    √ should support searching /hubs/erp/credit-memos by id (11501ms)

  credit-terms
    √ should allow SR for /hubs/erp/credit-terms  (6673ms)

  currencies
    √ should allow CRUDS for /hubs/erp/currencies (45377ms)
    √ should allow paginating with page and pageSize for /hubs/erp/currencies (93988ms)

  currency-rates
    √ should allow CRDS for /hubs/erp/currency-rates (6151ms)
    √ should allow paginating with page and pageSize for /hubs/erp/currency-rates (6076ms)
    √ should support Ceql date search (4158ms)

  custom-fields
    √ should allow GET for /hubs/erp/custom-fields (15195ms)
    √ should allow paginating with page and nextPage /hubs/erp/custom-fields (17606ms)

  custom-record-fields
    √ should allow paginating with page and pageSize for custom-record-types/476/custom-record-fields (5308ms)

  custom-record-types
    √ should allow paginating with page and pageSize for /hubs/erp/custom-record-types (5283ms)

  custom-records
    √ should allow CRUDS for custom-record-types/476/custom-records (17755ms)

  customer-refunds
    √ should allow CRUS for /hubs/erp/customer-refunds (52479ms)
    √ should allow paginating with page and pageSize for /hubs/erp/customer-refunds (10640ms)
    √ should support Ceql date search (3928ms)

  customer-statuses
    √ should allow CRUDS for /hubs/erp/customer-statuses (10924ms)
    √ should allow paginating with page and pageSize for /hubs/erp/customer-statuses (4454ms)
    √ should CEQL search (4690ms)

  customers
error: Failed to delete /hubs/erp/customers/1286801
    6) should allow CRUDS for /hubs/erp/customers
    √ should allow paginating with page and pageSize for /hubs/erp/customers (9840ms)
error: Failed to create or validate: /hubs/erp/customers
    7) should support searching /hubs/erp/customers by id
    √ should allow GET for /hubs/erp/customers (5134ms)

  custom-record-types
    √ should allow paginating with page and pageSize for /hubs/erp/custom-record-types (4545ms)
    √ should allow CRUDS /hubs/erp/customrecords (11620ms)

  departments
    √ should allow CRUDS for /hubs/erp/departments (12246ms)
    √ should allow paginating with page and pageSize for /hubs/erp/departments (4259ms)
    √ should support searching /hubs/erp/departments by name (7394ms)

  deposits
    √ should allow CRUDS for /hubs/erp/deposits (58484ms)
    √ should allow paginating with page and pageSize for /hubs/erp/deposits (17889ms)
    √ should support Ceql date search (11610ms)

  employees
error: Failed to create or validate: /hubs/erp/employees
    8) should allow CRUDS for /hubs/erp/employees
    √ should allow GET for /hubs/erp/employees (5221ms)
error: Failed to create or validate: /hubs/erp/employees
    9) should support searching /hubs/erp/employees by id

  estimates
    √ should allow CRUDS for /hubs/erp/estimates (78703ms)
    √ should allow GET for /hubs/erp/estimates (16711ms)
    √ should support searching /hubs/erp/estimates by id (19590ms)

  expense-reports
    √ should allow paginating with page and pageSize for /hubs/erp/expense-reports (14345ms)
    √ should allow CRUDS /hubs/erp/expense-reports (56070ms)

  files
    √ should support CRD for /hubs/erp/files (8257ms)
    √ should support UD /:objectName/:id/file/:id to a lead (17063ms)

  folders
    √ should allow CRUDS for /hubs/erp/folders (13540ms)
    √ should allow paginating with page and pageSize for /hubs/erp/folders (5357ms)
    √ should support searching /hubs/erp/folders by id (5415ms)

  inventory-adjustments
    √ should allow CRUDS for /hubs/erp/inventory-adjustments (27351ms)
    √ should allow paginating with page and pageSize for /hubs/erp/inventory-adjustments (46291ms)
    √ should support Ceql date search (3588ms)

  inventory-transfers
    √ should allow CRUDS for /hubs/erp/inventory-transfers (26208ms)
    √ should allow paginating with page and pageSize for /hubs/erp/inventory-transfers (8821ms)
    √ should support Ceql date search (6090ms)

  invoices
    √ should allow CRUDS for /hubs/erp/invoices (84427ms)
    √ should allow GET for /hubs/erp/invoices (17115ms)
    √ should support searching /hubs/erp/invoices by id (12573ms)

  item-receipts
    √ should allow CUD for hubs/erp/item-receipts (44545ms)
    √ should allow SR for /hubs/erp/item-receipts (8901ms)
    √ should allow paginating with page and pageSize for /hubs/erp/item-receipts (26521ms)
    √ should support Ceql date search (4093ms)

  journal-entries
    √ should allow CRUDS for /hubs/erp/journal-entries (20008ms)
    √ should allow GET for /hubs/erp/journal-entries (3265ms)
    √ should support searching /hubs/erp/journal-entries by id (9018ms)

  leads
error: Failed to delete /hubs/erp/leads/1286803
    10) should allow CRUDS for /hubs/erp/leads
    √ should allow GET for /hubs/erp/leads (2150ms)
error: Failed to create or validate: /hubs/erp/leads
    11) should support searching /hubs/erp/leads by id

  ledger-accounts
    √ should allow CRUDS for /hubs/erp/ledger-accounts (20426ms)
    √ should allow GET for /hubs/erp/ledger-accounts (2670ms)
    √ should allow GET for /hubs/erp/ledger-accounts (3739ms)

  locations
    √ should allow CRUDS for /hubs/erp/locations (24959ms)
    √ should allow paginating with page and pageSize for /hubs/erp/locations (15995ms)
    √ should support searching /hubs/erp/locations by name (7229ms)

  lookups
    √ should allow GET for /hubs/erp/lookups/:fieldName  (59130ms)

  lot-numbered-assembly-items
    √ should allow CRUDS for /hubs/erp/lot-numbered-assembly-items (80582ms)
    √ should allow paginating with page and pageSize for /hubs/erp/lot-numbered-assembly-items (54907ms)
    √ should support searching /hubs/erp/lot-numbered-assembly-items by id (26852ms)

  lot-numbered-inventory-items
    √ should allow CRUDS for /hubs/erp/lot-numbered-inventory-items (108864ms)
    √ should allow paginating with page and pageSize for /hubs/erp/lot-numbered-inventory-items (31331ms)
    √ should support searching /hubs/erp/lot-numbered-inventory-items by id (31108ms)

  non-inventory-resale-items
    √ should allow CRUDS for /hubs/erp/non-inventory-resale-items (76571ms)
    √ should allow paginating with page and pageSize for /hubs/erp/non-inventory-resale-items (17935ms)
    √ should support searching /hubs/erp/non-inventory-resale-items by id (22086ms)

  opportunities
    √ should allow CRUDS for /hubs/erp/opportunities (82833ms)
    √ should allow GET for /hubs/erp/opportunities (6155ms)
    √ should support searching /hubs/erp/opportunities by id (13886ms)

  payment-methods
    √ should allow SR for /hubs/erp/payment-methods  (8496ms)

  payments
    √ should allow CRUDS for /hubs/erp/payments (79893ms)
    √ should allow GET for /hubs/erp/payments (23893ms)
    √ should support searching /hubs/erp/payments by id (11833ms)

  payroll-items
    √ should allow CRUDS for /hubs/erp/payroll-items (18610ms)
    √ should allow paginating with page and pageSize for /hubs/erp/payroll-items (7026ms)

  phone-calls
    √ should allow CRUDS for /hubs/erp/phone-calls (24566ms)
    √ should allow paginating with page and pageSize for /hubs/erp/phone-calls (8577ms)
    √ should support searching /hubs/erp/phone-calls by title (3504ms)

  ping
    √ should allow GET for /hubs/erp/ping (1012ms)

  polling
    - polling /hubs/erp/customers
    - polling /hubs/erp/employees
    - polling /hubs/erp/estimates
    - polling /hubs/erp/invoices
    - polling /hubs/erp/payments
    - polling /hubs/erp/journal-entries
    - polling /hubs/erp/products
    - polling /hubs/erp/purchase-orders
    - polling /hubs/erp/vendor-payments
    - polling /hubs/erp/vendors
    - polling /hubs/erp/accounts
    - polling /hubs/erp/contacts
    - polling /hubs/erp/leads
    - polling /hubs/erp/activities
    - polling /hubs/erp/opportunities
    - polling /hubs/erp/time-activities

  posting-periods
    √ should allow SR for /hubs/erp/posting-periods (3895ms)
    √ should allow GET for /hubs/erp/posting-periods (3434ms)
    √ should allow GET for /hubs/erp/posting-periods (1597ms)

  products
    √ should allow CRUDS for /hubs/erp/products (49639ms)
    √ should allow GET for /hubs/erp/products (2352ms)
    √ should support searching /hubs/erp/products by id (20010ms)

  projects
error: Failed to delete /hubs/erp/projects/1286805
    12) should allow CRUDS for /hubs/erp/projects
    √ should allow paginating with page and pageSize for /hubs/erp/projects (9227ms)
error: Failed to create or validate: /hubs/erp/projects
    13) should support searching /hubs/erp/projects by id

  prospects
error: Failed to delete /hubs/erp/prospects/1287000
    14) should allow CRUDS for /hubs/erp/prospects
    √ should allow paginating with page and pageSize for /hubs/erp/prospects (12506ms)
error: Failed to create or validate: /hubs/erp/prospects
    15) should support searching /hubs/erp/prospects by id

  purchase-orders
    √ should allow CRUDS for /hubs/erp/purchase-orders (66305ms)
    √ should allow GET for /hubs/erp/purchase-orders (6463ms)
    √ should support searching /hubs/erp/purchase-orders by id (16594ms)

  return-authorizations
    √ should allow CRUDS for /hubs/erp/return-authorizations (50046ms)
    √ should allow GET for /hubs/erp/return-authorizations (14204ms)
    √ should support searching /hubs/erp/return-authorizations by id (10298ms)

  sales-orders
    √ should allow CRUDS for /hubs/erp/sales-orders (81010ms)
    √ should allow GET for /hubs/erp/sales-orders (12256ms)
    √ should support searching /hubs/erp/sales-orders by id (12235ms)

  saved-searches
    √ should allow GET for /hubs/erp/saved-searches (2224ms)

  serialized-inventory-items
    √ should allow CRUDS for /hubs/erp/serialized-inventory-items (36279ms)
    √ should allow paginating with page and pageSize for /hubs/erp/serialized-inventory-items (16660ms)
    √ should support searching /hubs/erp/serialized-inventory-items by id (17382ms)

  service-resale-items
    √ should allow CRUDS for /hubs/erp/service-resale-items (43052ms)
    √ should allow paginating with page and pageSize for /hubs/erp/service-resale-items (12112ms)
    √ should support searching /hubs/erp/service-resale-items by id (15275ms)

  states
    √ should allow CRUDS for /hubs/erp/states (12630ms)
    √ should allow paginating with page and pageSize for /hubs/erp/states (10911ms)

  subsidiaries
    - should allow CRUDS for /hubs/erp/subsidiaries
    - should support searching /hubs/erp/subsidiaries by email

  tax-codes
    √ should allow SR for /hubs/erp/tax-codes  (14233ms)

  tax-rates
    √ should allow SR for /hubs/erp/tax-rates  (253589ms)

  time-activities
    √ should allow CRUDS for /hubs/erp/time-activities (23487ms)
    √ should allow GET for /hubs/erp/time-activities (3410ms)
    √ should support searching /hubs/erp/time-activities by id (6630ms)

  transaction-summaries
    √ should allow GET for /hubs/erp/transaction-summaries (3958ms)

  transfer-orders
    √ should allow CRUDS for /hubs/erp/transfer-orders (72270ms)
    √ should allow paginating with page and pageSize for /hubs/erp/transfer-orders (27124ms)
    √ should support Ceql date search (9122ms)

  vendor-credits
    √ should allow CRUDS for /hubs/erp/vendor-credits (84861ms)
    √ should allow paginating with page and pageSize for /hubs/erp/vendor-credits (26115ms)
    √ should support searching /hubs/erp/vendor-credits by id (13295ms)

  vendor-payments
    √ should allow CRUDS for /hubs/erp/vendor-payments (40801ms)
    √ should allow paginating with page and pageSize for /hubs/erp/vendor-payments (12877ms)
    √ should support searching /hubs/erp/vendor-payments by id (11274ms)

  vendors
error: Failed to delete /hubs/erp/vendors/1287002
    16) should allow CRUDS for /hubs/erp/vendors
    √ should allow GET for /hubs/erp/vendors (5282ms)
error: Failed to create or validate: /hubs/erp/vendors
    17) should support searching /hubs/erp/vendors by id

  work-orders
    √ should allow CRUDS for /hubs/erp/work-orders (49176ms)
    √ should allow paginating with page and pageSize for /hubs/erp/work-orders (23867ms)
    √ should support Ceql date search (7630ms)


  160 passing (2h)
  22 pending
  17 failing

  1) accounts should allow CRUDS for /hubs/erp/accounts:

      AssertionError [ERR_ASSERTION]: expected status code 400 to equal 200 - {"requestId":"5b325996e4b0a6f6dac53d7f","message":"Bad request: An unexpected error occurred. Error ID: jivubenq1wcgqk8ef0p7f,"}
      + expected - actual

      -false
      +true

      at Assertion.chakram.addMethod (C:\Users\gs-1108\Documents\GitHub\churros\src\core\assertions.js:17:3)
      at Assertion.<anonymous> (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\chakram\lib\plugins.js:123:22)
      at Assertion.ctx.(anonymous function) (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\chai\lib\chai\utils\addMethod.js:41:25)
      at doAsserterAsyncAndAddThen (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\chai-as-promised\lib\chai-as-promised.js:296:33)
      at Assertion.<anonymous> (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\chai-as-promised\lib\chai-as-promised.js:255:21)
      at Assertion.ctx.(anonymous function) (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\chai\lib\chai\utils\overwriteMethod.js:49:33)
      at doAsserterAsyncAndAddThen (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\chai-as-promised\lib\chai-as-promised.js:296:33)
      at Assertion.<anonymous> (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\chai-as-promised\lib\chai-as-promised.js:255:21)
      at Assertion.ctx.(anonymous function) [as statusCode] (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\chai\lib\chai\utils\overwriteMethod.js:49:33)
      at C:\Users\gs-1108\Documents\GitHub\churros\src\core\cloud.js:33:25
      at chakram.delete.then.r (C:\Users\gs-1108\Documents\GitHub\churros\src\core\cloud.js:121:44)
      at _fulfilled (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\q\q.js:854:54)
      at self.promiseDispatch.done (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\q\q.js:883:30)
      at Promise.promise.promiseDispatch (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\q\q.js:816:13)
      at C:\Users\gs-1108\Documents\GitHub\churros\node_modules\q\q.js:624:44
      at runSingle (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\q\q.js:137:13)
      at flush (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\q\q.js:125:13)
      at _combinedTickCallback (internal/process/next_tick.js:131:7)
      at process._tickCallback (internal/process/next_tick.js:180:9)

  2) accounts should support searching /hubs/erp/accounts by id:

      AssertionError [ERR_ASSERTION]: expected status code 400 to equal 200 - {"requestId":"5b325a4fe4b00acadaf19b16","message":"Bad request: A customer record with this ID already exists. You must enter a unique customer ID for each record you create. To correct this record, click <a href='javascript:history.go(-1);';>back</a> and enter a new customer ID in the Customer field. Then, click Submit.,"}
      + expected - actual

      -false
      +true

      at Assertion.chakram.addMethod (C:\Users\gs-1108\Documents\GitHub\churros\src\core\assertions.js:17:3)
      at Assertion.<anonymous> (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\chakram\lib\plugins.js:123:22)
      at Assertion.ctx.(anonymous function) (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\chai\lib\chai\utils\addMethod.js:41:25)
      at doAsserterAsyncAndAddThen (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\chai-as-promised\lib\chai-as-promised.js:296:33)
      at Assertion.<anonymous> (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\chai-as-promised\lib\chai-as-promised.js:255:21)
      at Assertion.ctx.(anonymous function) (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\chai\lib\chai\utils\overwriteMethod.js:49:33)
      at doAsserterAsyncAndAddThen (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\chai-as-promised\lib\chai-as-promised.js:296:33)
      at Assertion.<anonymous> (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\chai-as-promised\lib\chai-as-promised.js:255:21)
      at Assertion.ctx.(anonymous function) [as statusCode] (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\chai\lib\chai\utils\overwriteMethod.js:49:33)
      at C:\Users\gs-1108\Documents\GitHub\churros\src\core\cloud.js:33:25
      at chakram.post.then.r (C:\Users\gs-1108\Documents\GitHub\churros\src\core\cloud.js:53:44)
      at _fulfilled (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\q\q.js:854:54)
      at self.promiseDispatch.done (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\q\q.js:883:30)
      at Promise.promise.promiseDispatch (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\q\q.js:816:13)
      at C:\Users\gs-1108\Documents\GitHub\churros\node_modules\q\q.js:624:44
      at runSingle (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\q\q.js:137:13)
      at flush (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\q\q.js:125:13)
      at _combinedTickCallback (internal/process/next_tick.js:131:7)
      at process._tickCallback (internal/process/next_tick.js:180:9)

  3) billing-accounts should allow CRUDS for /hubs/erp/billing-accounts:

      AssertionError [ERR_ASSERTION]: expected status code 400 to equal 200 - {"requestId":"5b325a76e4b00acadaf19bb0","message":"Bad request: The ''Billing Accounts'' feature is not enabled in your NetSuite account.,"}
      + expected - actual

      -false
      +true

      at Assertion.chakram.addMethod (C:\Users\gs-1108\Documents\GitHub\churros\src\core\assertions.js:17:3)
      at Assertion.<anonymous> (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\chakram\lib\plugins.js:123:22)
      at Assertion.ctx.(anonymous function) (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\chai\lib\chai\utils\addMethod.js:41:25)
      at doAsserterAsyncAndAddThen (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\chai-as-promised\lib\chai-as-promised.js:296:33)
      at Assertion.<anonymous> (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\chai-as-promised\lib\chai-as-promised.js:255:21)
      at Assertion.ctx.(anonymous function) (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\chai\lib\chai\utils\overwriteMethod.js:49:33)
      at doAsserterAsyncAndAddThen (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\chai-as-promised\lib\chai-as-promised.js:296:33)
      at Assertion.<anonymous> (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\chai-as-promised\lib\chai-as-promised.js:255:21)
      at Assertion.ctx.(anonymous function) [as statusCode] (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\chai\lib\chai\utils\overwriteMethod.js:49:33)
      at run (C:\Users\gs-1108\Documents\GitHub\churros\src\core\suite.js:799:133)
      at C:\Users\gs-1108\Documents\GitHub\churros\src\core\cloud.js:25:7
      at chakram.post.then.r (C:\Users\gs-1108\Documents\GitHub\churros\src\core\cloud.js:53:44)
      at _fulfilled (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\q\q.js:854:54)
      at self.promiseDispatch.done (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\q\q.js:883:30)
      at Promise.promise.promiseDispatch (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\q\q.js:816:13)
      at C:\Users\gs-1108\Documents\GitHub\churros\node_modules\q\q.js:624:44
      at runSingle (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\q\q.js:137:13)
      at flush (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\q\q.js:125:13)
      at _combinedTickCallback (internal/process/next_tick.js:131:7)
      at process._tickCallback (internal/process/next_tick.js:180:9)

  4) contacts should allow CRUDS for /hubs/erp/contacts:

      AssertionError [ERR_ASSERTION]: expected status code 400 to equal 200 - {"requestId":"5b325be5e4b017acfcaf08a1","message":"Bad request: An unexpected error occurred. Error ID: jivuo2ct1r0y09652wdfg,"}
      + expected - actual

      -false
      +true

      at Assertion.chakram.addMethod (C:\Users\gs-1108\Documents\GitHub\churros\src\core\assertions.js:17:3)
      at Assertion.<anonymous> (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\chakram\lib\plugins.js:123:22)
      at Assertion.ctx.(anonymous function) (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\chai\lib\chai\utils\addMethod.js:41:25)
      at doAsserterAsyncAndAddThen (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\chai-as-promised\lib\chai-as-promised.js:296:33)
      at Assertion.<anonymous> (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\chai-as-promised\lib\chai-as-promised.js:255:21)
      at Assertion.ctx.(anonymous function) (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\chai\lib\chai\utils\overwriteMethod.js:49:33)
      at doAsserterAsyncAndAddThen (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\chai-as-promised\lib\chai-as-promised.js:296:33)
      at Assertion.<anonymous> (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\chai-as-promised\lib\chai-as-promised.js:255:21)
      at Assertion.ctx.(anonymous function) [as statusCode] (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\chai\lib\chai\utils\overwriteMethod.js:49:33)
      at C:\Users\gs-1108\Documents\GitHub\churros\src\core\cloud.js:33:25
      at chakram.delete.then.r (C:\Users\gs-1108\Documents\GitHub\churros\src\core\cloud.js:121:44)
      at _fulfilled (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\q\q.js:854:54)
      at self.promiseDispatch.done (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\q\q.js:883:30)
      at Promise.promise.promiseDispatch (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\q\q.js:816:13)
      at C:\Users\gs-1108\Documents\GitHub\churros\node_modules\q\q.js:624:44
      at runSingle (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\q\q.js:137:13)
      at flush (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\q\q.js:125:13)
      at _combinedTickCallback (internal/process/next_tick.js:131:7)
      at process._tickCallback (internal/process/next_tick.js:180:9)

  5) contacts should support searching /hubs/erp/contacts by id:

      AssertionError [ERR_ASSERTION]: expected status code 400 to equal 200 - {"requestId":"5b325ca3e4b017acfcaf0b84","message":"Bad request: A contact record with this name already exists. Every contact record must have a unique name.,"}
      + expected - actual

      -false
      +true

      at Assertion.chakram.addMethod (C:\Users\gs-1108\Documents\GitHub\churros\src\core\assertions.js:17:3)
      at Assertion.<anonymous> (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\chakram\lib\plugins.js:123:22)
      at Assertion.ctx.(anonymous function) (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\chai\lib\chai\utils\addMethod.js:41:25)
      at doAsserterAsyncAndAddThen (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\chai-as-promised\lib\chai-as-promised.js:296:33)
      at Assertion.<anonymous> (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\chai-as-promised\lib\chai-as-promised.js:255:21)
      at Assertion.ctx.(anonymous function) (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\chai\lib\chai\utils\overwriteMethod.js:49:33)
      at doAsserterAsyncAndAddThen (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\chai-as-promised\lib\chai-as-promised.js:296:33)
      at Assertion.<anonymous> (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\chai-as-promised\lib\chai-as-promised.js:255:21)
      at Assertion.ctx.(anonymous function) [as statusCode] (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\chai\lib\chai\utils\overwriteMethod.js:49:33)
      at C:\Users\gs-1108\Documents\GitHub\churros\src\core\cloud.js:33:25
      at chakram.post.then.r (C:\Users\gs-1108\Documents\GitHub\churros\src\core\cloud.js:53:44)
      at _fulfilled (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\q\q.js:854:54)
      at self.promiseDispatch.done (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\q\q.js:883:30)
      at Promise.promise.promiseDispatch (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\q\q.js:816:13)
      at C:\Users\gs-1108\Documents\GitHub\churros\node_modules\q\q.js:624:44
      at runSingle (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\q\q.js:137:13)
      at flush (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\q\q.js:125:13)
      at _combinedTickCallback (internal/process/next_tick.js:131:7)
      at process._tickCallback (internal/process/next_tick.js:180:9)

  6) customers should allow CRUDS for /hubs/erp/customers:

      AssertionError [ERR_ASSERTION]: expected status code 400 to equal 200 - {"requestId":"5b325e63e4b0a6f6dac54d74","message":"Bad request: An unexpected error occurred. Error ID: jivv1qyxhjbb6wi9akhw,"}
      + expected - actual

      -false
      +true

      at Assertion.chakram.addMethod (C:\Users\gs-1108\Documents\GitHub\churros\src\core\assertions.js:17:3)
      at Assertion.<anonymous> (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\chakram\lib\plugins.js:123:22)
      at Assertion.ctx.(anonymous function) (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\chai\lib\chai\utils\addMethod.js:41:25)
      at doAsserterAsyncAndAddThen (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\chai-as-promised\lib\chai-as-promised.js:296:33)
      at Assertion.<anonymous> (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\chai-as-promised\lib\chai-as-promised.js:255:21)
      at Assertion.ctx.(anonymous function) (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\chai\lib\chai\utils\overwriteMethod.js:49:33)
      at doAsserterAsyncAndAddThen (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\chai-as-promised\lib\chai-as-promised.js:296:33)
      at Assertion.<anonymous> (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\chai-as-promised\lib\chai-as-promised.js:255:21)
      at Assertion.ctx.(anonymous function) [as statusCode] (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\chai\lib\chai\utils\overwriteMethod.js:49:33)
      at C:\Users\gs-1108\Documents\GitHub\churros\src\core\cloud.js:33:25
      at chakram.delete.then.r (C:\Users\gs-1108\Documents\GitHub\churros\src\core\cloud.js:121:44)
      at _fulfilled (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\q\q.js:854:54)
      at self.promiseDispatch.done (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\q\q.js:883:30)
      at Promise.promise.promiseDispatch (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\q\q.js:816:13)
      at C:\Users\gs-1108\Documents\GitHub\churros\node_modules\q\q.js:624:44
      at runSingle (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\q\q.js:137:13)
      at flush (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\q\q.js:125:13)
      at _combinedTickCallback (internal/process/next_tick.js:131:7)
      at process._tickCallback (internal/process/next_tick.js:180:9)

  7) customers should support searching /hubs/erp/customers by id:

      AssertionError [ERR_ASSERTION]: expected status code 400 to equal 200 - {"requestId":"5b325f23e4b017acfcaf1347","message":"Bad request: A customer record with this ID already exists. You must enter a unique customer ID for each record you create. To correct this record, click <a href='javascript:history.go(-1);';>back</a> and enter a new customer ID in the Customer field. Then, click Submit.,"}
      + expected - actual

      -false
      +true

      at Assertion.chakram.addMethod (C:\Users\gs-1108\Documents\GitHub\churros\src\core\assertions.js:17:3)
      at Assertion.<anonymous> (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\chakram\lib\plugins.js:123:22)
      at Assertion.ctx.(anonymous function) (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\chai\lib\chai\utils\addMethod.js:41:25)
      at doAsserterAsyncAndAddThen (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\chai-as-promised\lib\chai-as-promised.js:296:33)
      at Assertion.<anonymous> (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\chai-as-promised\lib\chai-as-promised.js:255:21)
      at Assertion.ctx.(anonymous function) (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\chai\lib\chai\utils\overwriteMethod.js:49:33)
      at doAsserterAsyncAndAddThen (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\chai-as-promised\lib\chai-as-promised.js:296:33)
      at Assertion.<anonymous> (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\chai-as-promised\lib\chai-as-promised.js:255:21)
      at Assertion.ctx.(anonymous function) [as statusCode] (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\chai\lib\chai\utils\overwriteMethod.js:49:33)
      at C:\Users\gs-1108\Documents\GitHub\churros\src\core\cloud.js:33:25
      at chakram.post.then.r (C:\Users\gs-1108\Documents\GitHub\churros\src\core\cloud.js:53:44)
      at _fulfilled (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\q\q.js:854:54)
      at self.promiseDispatch.done (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\q\q.js:883:30)
      at Promise.promise.promiseDispatch (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\q\q.js:816:13)
      at C:\Users\gs-1108\Documents\GitHub\churros\node_modules\q\q.js:624:44
      at runSingle (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\q\q.js:137:13)
      at flush (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\q\q.js:125:13)
      at _combinedTickCallback (internal/process/next_tick.js:131:7)
      at process._tickCallback (internal/process/next_tick.js:180:9)

  8) employees should allow CRUDS for /hubs/erp/employees:

      AssertionError [ERR_ASSERTION]: expected status code 400 to equal 200 - {"requestId":"5b325fabe4b0a6f6dac551cb","message":"Bad request: There is already an employee with external access to this account using that entity name. All employees with external access must have a unique entity name for login purposes. Go <a href=\"javascript:history.go(-1);\";>back</a>, change the entity name and resubmi
      + expected - actual

      -false
      +true

      at Assertion.chakram.addMethod (C:\Users\gs-1108\Documents\GitHub\churros\src\core\assertions.js:17:3)
      at Assertion.<anonymous> (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\chakram\lib\plugins.js:123:22)
      at Assertion.ctx.(anonymous function) (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\chai\lib\chai\utils\addMethod.js:41:25)
      at doAsserterAsyncAndAddThen (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\chai-as-promised\lib\chai-as-promised.js:296:33)
      at Assertion.<anonymous> (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\chai-as-promised\lib\chai-as-promised.js:255:21)
      at Assertion.ctx.(anonymous function) (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\chai\lib\chai\utils\overwriteMethod.js:49:33)
      at doAsserterAsyncAndAddThen (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\chai-as-promised\lib\chai-as-promised.js:296:33)
      at Assertion.<anonymous> (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\chai-as-promised\lib\chai-as-promised.js:255:21)
      at Assertion.ctx.(anonymous function) [as statusCode] (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\chai\lib\chai\utils\overwriteMethod.js:49:33)
      at run (C:\Users\gs-1108\Documents\GitHub\churros\src\core\suite.js:799:133)
      at C:\Users\gs-1108\Documents\GitHub\churros\src\core\cloud.js:25:7
      at chakram.post.then.r (C:\Users\gs-1108\Documents\GitHub\churros\src\core\cloud.js:53:44)
      at _fulfilled (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\q\q.js:854:54)
      at self.promiseDispatch.done (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\q\q.js:883:30)
      at Promise.promise.promiseDispatch (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\q\q.js:816:13)
      at C:\Users\gs-1108\Documents\GitHub\churros\node_modules\q\q.js:624:44
      at runSingle (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\q\q.js:137:13)
      at flush (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\q\q.js:125:13)
      at _combinedTickCallback (internal/process/next_tick.js:131:7)
      at process._tickCallback (internal/process/next_tick.js:180:9)

  9) employees should support searching /hubs/erp/employees by id:

      AssertionError [ERR_ASSERTION]: expected status code 400 to equal 200 - {"requestId":"5b325fb3e4b00acadaf1ad42","message":"Bad request: There is already an employee with external access to this account using that entity name. All employees with external access must have a unique entity name for login purposes. Go <a href=\"javascript:history.go(-1);\";>back</a>, change the entity name and resubmi
      + expected - actual

      -false
      +true

      at Assertion.chakram.addMethod (C:\Users\gs-1108\Documents\GitHub\churros\src\core\assertions.js:17:3)
      at Assertion.<anonymous> (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\chakram\lib\plugins.js:123:22)
      at Assertion.ctx.(anonymous function) (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\chai\lib\chai\utils\addMethod.js:41:25)
      at doAsserterAsyncAndAddThen (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\chai-as-promised\lib\chai-as-promised.js:296:33)
      at Assertion.<anonymous> (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\chai-as-promised\lib\chai-as-promised.js:255:21)
      at Assertion.ctx.(anonymous function) (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\chai\lib\chai\utils\overwriteMethod.js:49:33)
      at doAsserterAsyncAndAddThen (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\chai-as-promised\lib\chai-as-promised.js:296:33)
      at Assertion.<anonymous> (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\chai-as-promised\lib\chai-as-promised.js:255:21)
      at Assertion.ctx.(anonymous function) [as statusCode] (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\chai\lib\chai\utils\overwriteMethod.js:49:33)
      at C:\Users\gs-1108\Documents\GitHub\churros\src\core\cloud.js:33:25
      at chakram.post.then.r (C:\Users\gs-1108\Documents\GitHub\churros\src\core\cloud.js:53:44)
      at _fulfilled (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\q\q.js:854:54)
      at self.promiseDispatch.done (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\q\q.js:883:30)
      at Promise.promise.promiseDispatch (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\q\q.js:816:13)
      at C:\Users\gs-1108\Documents\GitHub\churros\node_modules\q\q.js:624:44
      at runSingle (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\q\q.js:137:13)
      at flush (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\q\q.js:125:13)
      at _combinedTickCallback (internal/process/next_tick.js:131:7)
      at process._tickCallback (internal/process/next_tick.js:180:9)

  10) leads should allow CRUDS for /hubs/erp/leads:

      AssertionError [ERR_ASSERTION]: expected status code 400 to equal 200 - {"requestId":"5b32621fe4b0a6f6dac559a0","message":"Bad request: An unexpected error occurred. Error ID: jivvm8xgfy36qdnh7c1o,"}
      + expected - actual

      -false
      +true

      at Assertion.chakram.addMethod (C:\Users\gs-1108\Documents\GitHub\churros\src\core\assertions.js:17:3)
      at Assertion.<anonymous> (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\chakram\lib\plugins.js:123:22)
      at Assertion.ctx.(anonymous function) (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\chai\lib\chai\utils\addMethod.js:41:25)
      at doAsserterAsyncAndAddThen (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\chai-as-promised\lib\chai-as-promised.js:296:33)
      at Assertion.<anonymous> (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\chai-as-promised\lib\chai-as-promised.js:255:21)
      at Assertion.ctx.(anonymous function) (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\chai\lib\chai\utils\overwriteMethod.js:49:33)
      at doAsserterAsyncAndAddThen (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\chai-as-promised\lib\chai-as-promised.js:296:33)
      at Assertion.<anonymous> (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\chai-as-promised\lib\chai-as-promised.js:255:21)
      at Assertion.ctx.(anonymous function) [as statusCode] (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\chai\lib\chai\utils\overwriteMethod.js:49:33)
      at C:\Users\gs-1108\Documents\GitHub\churros\src\core\cloud.js:33:25
      at chakram.delete.then.r (C:\Users\gs-1108\Documents\GitHub\churros\src\core\cloud.js:121:44)
      at _fulfilled (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\q\q.js:854:54)
      at self.promiseDispatch.done (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\q\q.js:883:30)
      at Promise.promise.promiseDispatch (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\q\q.js:816:13)
      at C:\Users\gs-1108\Documents\GitHub\churros\node_modules\q\q.js:624:44
      at runSingle (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\q\q.js:137:13)
      at flush (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\q\q.js:125:13)
      at _combinedTickCallback (internal/process/next_tick.js:131:7)
      at process._tickCallback (internal/process/next_tick.js:180:9)

  11) leads should support searching /hubs/erp/leads by id:

      AssertionError [ERR_ASSERTION]: expected status code 400 to equal 200 - {"requestId":"5b3262d8e4b09e774dc99681","message":"Bad request: A customer record with this ID already exists. You must enter a unique customer ID for each record you create. To correct this record, click <a href='javascript:history.go(-1);';>back</a> and enter a new customer ID in the Customer field. Then, click Submit.,"}
      + expected - actual

      -false
      +true

      at Assertion.chakram.addMethod (C:\Users\gs-1108\Documents\GitHub\churros\src\core\assertions.js:17:3)
      at Assertion.<anonymous> (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\chakram\lib\plugins.js:123:22)
      at Assertion.ctx.(anonymous function) (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\chai\lib\chai\utils\addMethod.js:41:25)
      at doAsserterAsyncAndAddThen (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\chai-as-promised\lib\chai-as-promised.js:296:33)
      at Assertion.<anonymous> (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\chai-as-promised\lib\chai-as-promised.js:255:21)
      at Assertion.ctx.(anonymous function) (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\chai\lib\chai\utils\overwriteMethod.js:49:33)
      at doAsserterAsyncAndAddThen (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\chai-as-promised\lib\chai-as-promised.js:296:33)
      at Assertion.<anonymous> (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\chai-as-promised\lib\chai-as-promised.js:255:21)
      at Assertion.ctx.(anonymous function) [as statusCode] (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\chai\lib\chai\utils\overwriteMethod.js:49:33)
      at C:\Users\gs-1108\Documents\GitHub\churros\src\core\cloud.js:33:25
      at chakram.post.then.r (C:\Users\gs-1108\Documents\GitHub\churros\src\core\cloud.js:53:44)
      at _fulfilled (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\q\q.js:854:54)
      at self.promiseDispatch.done (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\q\q.js:883:30)
      at Promise.promise.promiseDispatch (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\q\q.js:816:13)
      at C:\Users\gs-1108\Documents\GitHub\churros\node_modules\q\q.js:624:44
      at runSingle (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\q\q.js:137:13)
      at flush (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\q\q.js:125:13)
      at _combinedTickCallback (internal/process/next_tick.js:131:7)
      at process._tickCallback (internal/process/next_tick.js:180:9)

  12) projects should allow CRUDS for /hubs/erp/projects:

      AssertionError [ERR_ASSERTION]: expected status code 400 to equal 200 - {"requestId":"5b3266b5e4b017acfcaf2dc4","message":"Bad request: An unexpected error occurred. Error ID: jivwbej5syhv7rl5sj4,"}
      + expected - actual

      -false
      +true

      at Assertion.chakram.addMethod (C:\Users\gs-1108\Documents\GitHub\churros\src\core\assertions.js:17:3)
      at Assertion.<anonymous> (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\chakram\lib\plugins.js:123:22)
      at Assertion.ctx.(anonymous function) (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\chai\lib\chai\utils\addMethod.js:41:25)
      at doAsserterAsyncAndAddThen (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\chai-as-promised\lib\chai-as-promised.js:296:33)
      at Assertion.<anonymous> (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\chai-as-promised\lib\chai-as-promised.js:255:21)
      at Assertion.ctx.(anonymous function) (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\chai\lib\chai\utils\overwriteMethod.js:49:33)
      at doAsserterAsyncAndAddThen (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\chai-as-promised\lib\chai-as-promised.js:296:33)
      at Assertion.<anonymous> (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\chai-as-promised\lib\chai-as-promised.js:255:21)
      at Assertion.ctx.(anonymous function) [as statusCode] (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\chai\lib\chai\utils\overwriteMethod.js:49:33)
      at C:\Users\gs-1108\Documents\GitHub\churros\src\core\cloud.js:33:25
      at chakram.delete.then.r (C:\Users\gs-1108\Documents\GitHub\churros\src\core\cloud.js:121:44)
      at _fulfilled (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\q\q.js:854:54)
      at self.promiseDispatch.done (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\q\q.js:883:30)
      at Promise.promise.promiseDispatch (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\q\q.js:816:13)
      at C:\Users\gs-1108\Documents\GitHub\churros\node_modules\q\q.js:624:44
      at runSingle (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\q\q.js:137:13)
      at flush (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\q\q.js:125:13)
      at _combinedTickCallback (internal/process/next_tick.js:131:7)
      at process._tickCallback (internal/process/next_tick.js:180:9)

  13) projects should support searching /hubs/erp/projects by id:

      AssertionError [ERR_ASSERTION]: expected status code 400 to equal 200 - {"requestId":"5b326775e4b017acfcaf2fec","message":"Bad request: This record already exists,"}
      + expected - actual

      -false
      +true

      at Assertion.chakram.addMethod (C:\Users\gs-1108\Documents\GitHub\churros\src\core\assertions.js:17:3)
      at Assertion.<anonymous> (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\chakram\lib\plugins.js:123:22)
      at Assertion.ctx.(anonymous function) (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\chai\lib\chai\utils\addMethod.js:41:25)
      at doAsserterAsyncAndAddThen (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\chai-as-promised\lib\chai-as-promised.js:296:33)
      at Assertion.<anonymous> (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\chai-as-promised\lib\chai-as-promised.js:255:21)
      at Assertion.ctx.(anonymous function) (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\chai\lib\chai\utils\overwriteMethod.js:49:33)
      at doAsserterAsyncAndAddThen (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\chai-as-promised\lib\chai-as-promised.js:296:33)
      at Assertion.<anonymous> (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\chai-as-promised\lib\chai-as-promised.js:255:21)
      at Assertion.ctx.(anonymous function) [as statusCode] (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\chai\lib\chai\utils\overwriteMethod.js:49:33)
      at C:\Users\gs-1108\Documents\GitHub\churros\src\core\cloud.js:33:25
      at chakram.post.then.r (C:\Users\gs-1108\Documents\GitHub\churros\src\core\cloud.js:53:44)
      at _fulfilled (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\q\q.js:854:54)
      at self.promiseDispatch.done (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\q\q.js:883:30)
      at Promise.promise.promiseDispatch (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\q\q.js:816:13)
      at C:\Users\gs-1108\Documents\GitHub\churros\node_modules\q\q.js:624:44
      at runSingle (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\q\q.js:137:13)
      at flush (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\q\q.js:125:13)
      at _combinedTickCallback (internal/process/next_tick.js:131:7)
      at process._tickCallback (internal/process/next_tick.js:180:9)

  14) prospects should allow CRUDS for /hubs/erp/prospects:

      AssertionError [ERR_ASSERTION]: expected status code 400 to equal 200 - {"requestId":"5b32679ee4b0a6f6dac56cc3","message":"Bad request: An unexpected error occurred. Error ID: jivwggu11qczajr20afyw,"}
      + expected - actual

      -false
      +true

      at Assertion.chakram.addMethod (C:\Users\gs-1108\Documents\GitHub\churros\src\core\assertions.js:17:3)
      at Assertion.<anonymous> (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\chakram\lib\plugins.js:123:22)
      at Assertion.ctx.(anonymous function) (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\chai\lib\chai\utils\addMethod.js:41:25)
      at doAsserterAsyncAndAddThen (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\chai-as-promised\lib\chai-as-promised.js:296:33)
      at Assertion.<anonymous> (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\chai-as-promised\lib\chai-as-promised.js:255:21)
      at Assertion.ctx.(anonymous function) (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\chai\lib\chai\utils\overwriteMethod.js:49:33)
      at doAsserterAsyncAndAddThen (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\chai-as-promised\lib\chai-as-promised.js:296:33)
      at Assertion.<anonymous> (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\chai-as-promised\lib\chai-as-promised.js:255:21)
      at Assertion.ctx.(anonymous function) [as statusCode] (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\chai\lib\chai\utils\overwriteMethod.js:49:33)
      at C:\Users\gs-1108\Documents\GitHub\churros\src\core\cloud.js:33:25
      at chakram.delete.then.r (C:\Users\gs-1108\Documents\GitHub\churros\src\core\cloud.js:121:44)
      at _fulfilled (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\q\q.js:854:54)
      at self.promiseDispatch.done (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\q\q.js:883:30)
      at Promise.promise.promiseDispatch (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\q\q.js:816:13)
      at C:\Users\gs-1108\Documents\GitHub\churros\node_modules\q\q.js:624:44
      at runSingle (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\q\q.js:137:13)
      at flush (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\q\q.js:125:13)
      at _combinedTickCallback (internal/process/next_tick.js:131:7)
      at process._tickCallback (internal/process/next_tick.js:180:9)

  15) prospects should support searching /hubs/erp/prospects by id:

      AssertionError [ERR_ASSERTION]: expected status code 400 to equal 200 - {"requestId":"5b326864e4b09e774dc9aa20","message":"Bad request: A customer record with this ID already exists. You must enter a unique customer ID for each record you create. To correct this record, click <a href='javascript:history.go(-1);';>back</a> and enter a new customer ID in the Customer field. Then, click Submit.,"}
      + expected - actual

      -false
      +true

      at Assertion.chakram.addMethod (C:\Users\gs-1108\Documents\GitHub\churros\src\core\assertions.js:17:3)
      at Assertion.<anonymous> (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\chakram\lib\plugins.js:123:22)
      at Assertion.ctx.(anonymous function) (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\chai\lib\chai\utils\addMethod.js:41:25)
      at doAsserterAsyncAndAddThen (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\chai-as-promised\lib\chai-as-promised.js:296:33)
      at Assertion.<anonymous> (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\chai-as-promised\lib\chai-as-promised.js:255:21)
      at Assertion.ctx.(anonymous function) (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\chai\lib\chai\utils\overwriteMethod.js:49:33)
      at doAsserterAsyncAndAddThen (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\chai-as-promised\lib\chai-as-promised.js:296:33)
      at Assertion.<anonymous> (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\chai-as-promised\lib\chai-as-promised.js:255:21)
      at Assertion.ctx.(anonymous function) [as statusCode] (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\chai\lib\chai\utils\overwriteMethod.js:49:33)
      at C:\Users\gs-1108\Documents\GitHub\churros\src\core\cloud.js:33:25
      at chakram.post.then.r (C:\Users\gs-1108\Documents\GitHub\churros\src\core\cloud.js:53:44)
      at _fulfilled (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\q\q.js:854:54)
      at self.promiseDispatch.done (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\q\q.js:883:30)
      at Promise.promise.promiseDispatch (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\q\q.js:816:13)
      at C:\Users\gs-1108\Documents\GitHub\churros\node_modules\q\q.js:624:44
      at runSingle (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\q\q.js:137:13)
      at flush (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\q\q.js:125:13)
      at _combinedTickCallback (internal/process/next_tick.js:131:7)
      at process._tickCallback (internal/process/next_tick.js:180:9)

  16) vendors should allow CRUDS for /hubs/erp/vendors:

      AssertionError [ERR_ASSERTION]: expected status code 400 to equal 200 - {"requestId":"5b326c99e4b00acadaf1d841","message":"Bad request: An unexpected error occurred. Error ID: jivx7q916olu2olti7y6,"}
      + expected - actual

      -false
      +true

      at Assertion.chakram.addMethod (C:\Users\gs-1108\Documents\GitHub\churros\src\core\assertions.js:17:3)
      at Assertion.<anonymous> (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\chakram\lib\plugins.js:123:22)
      at Assertion.ctx.(anonymous function) (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\chai\lib\chai\utils\addMethod.js:41:25)
      at doAsserterAsyncAndAddThen (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\chai-as-promised\lib\chai-as-promised.js:296:33)
      at Assertion.<anonymous> (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\chai-as-promised\lib\chai-as-promised.js:255:21)
      at Assertion.ctx.(anonymous function) (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\chai\lib\chai\utils\overwriteMethod.js:49:33)
      at doAsserterAsyncAndAddThen (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\chai-as-promised\lib\chai-as-promised.js:296:33)
      at Assertion.<anonymous> (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\chai-as-promised\lib\chai-as-promised.js:255:21)
      at Assertion.ctx.(anonymous function) [as statusCode] (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\chai\lib\chai\utils\overwriteMethod.js:49:33)
      at C:\Users\gs-1108\Documents\GitHub\churros\src\core\cloud.js:33:25
      at chakram.delete.then.r (C:\Users\gs-1108\Documents\GitHub\churros\src\core\cloud.js:121:44)
      at _fulfilled (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\q\q.js:854:54)
      at self.promiseDispatch.done (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\q\q.js:883:30)
      at Promise.promise.promiseDispatch (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\q\q.js:816:13)
      at C:\Users\gs-1108\Documents\GitHub\churros\node_modules\q\q.js:624:44
      at runSingle (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\q\q.js:137:13)
      at flush (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\q\q.js:125:13)
      at _combinedTickCallback (internal/process/next_tick.js:131:7)
      at process._tickCallback (internal/process/next_tick.js:180:9)

  17) vendors should support searching /hubs/erp/vendors by id:

      AssertionError [ERR_ASSERTION]: expected status code 400 to equal 200 - {"requestId":"5b326d55e4b017acfcaf42ea","message":"Bad request: There is already a vendor using that entity name. All vendors must have a unique entity name. Go <a href=\"javascript:history.go(-1);\";>back</a>, change the entity name and resubmit.,"}
      + expected - actual

      -false
      +true

      at Assertion.chakram.addMethod (C:\Users\gs-1108\Documents\GitHub\churros\src\core\assertions.js:17:3)
      at Assertion.<anonymous> (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\chakram\lib\plugins.js:123:22)
      at Assertion.ctx.(anonymous function) (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\chai\lib\chai\utils\addMethod.js:41:25)
      at doAsserterAsyncAndAddThen (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\chai-as-promised\lib\chai-as-promised.js:296:33)
      at Assertion.<anonymous> (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\chai-as-promised\lib\chai-as-promised.js:255:21)
      at Assertion.ctx.(anonymous function) (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\chai\lib\chai\utils\overwriteMethod.js:49:33)
      at doAsserterAsyncAndAddThen (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\chai-as-promised\lib\chai-as-promised.js:296:33)
      at Assertion.<anonymous> (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\chai-as-promised\lib\chai-as-promised.js:255:21)
      at Assertion.ctx.(anonymous function) [as statusCode] (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\chai\lib\chai\utils\overwriteMethod.js:49:33)
      at C:\Users\gs-1108\Documents\GitHub\churros\src\core\cloud.js:33:25
      at chakram.post.then.r (C:\Users\gs-1108\Documents\GitHub\churros\src\core\cloud.js:53:44)
      at _fulfilled (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\q\q.js:854:54)
      at self.promiseDispatch.done (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\q\q.js:883:30)
      at Promise.promise.promiseDispatch (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\q\q.js:816:13)
      at C:\Users\gs-1108\Documents\GitHub\churros\node_modules\q\q.js:624:44
      at runSingle (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\q\q.js:137:13)
      at flush (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\q\q.js:125:13)
      at _combinedTickCallback (internal/process/next_tick.js:131:7)
      at process._tickCallback (internal/process/next_tick.js:180:9)
```
* **Note:** The above 16 testcases are failing because there is some issue on vendor side, the  delete api is not working on vendor side itself. Verified on `snapshot`, `staging`, `console` and `local` as well.

![image](https://user-images.githubusercontent.com/34128818/41965335-f4551fb4-7a19-11e8-9950-aaa7af7469f7.png)


## Reference
* [RALLY-#${DE1294}](https://rally1.rallydev.com/#/144349237612d/detail/defect/211085376704)

## Closes
* [DE1294](https://rally1.rallydev.com/#/144349237612d/detail/defect/211085376704)
