### PR TITLE
Jira: Removed pagination test for GET /incident-types

### DIFF
--- a/src/test/elements/jira/incidentTypes.js
+++ b/src/test/elements/jira/incidentTypes.js
@@ -14,7 +14,6 @@ suite.forElement('helpdesk', 'incidentTypes', {payload:payload}, (test) => {
   let incidentTypeId;
   return cloud.post(uri, payload)
   .then(r => incidentTypeId = r.body.id)
-  .then(r => cloud.withOptions({qs:{ page: 1, pageSize: 1 }}).get('/hubs/helpdesk/incident-types'))
   .then(r => cloud.withOptions({qs:{ where: `id='${incidentTypeId}'` }}).get('/hubs/helpdesk/incident-types'))
   .then(r => cloud.get(uri + "/" + incidentTypeId))
   .then(r => cloud.get(uri))


### PR DESCRIPTION
## Highlights
* Removed pagination test for GET /incident-types as there is no pagination supported by [vendor](https://developer.atlassian.com/cloud/jira/platform/rest/#api-api-2-issuetype-get).

## Screenshot
Please include a screenshot of the tests running successfully
![image](https://user-images.githubusercontent.com/25840389/42032492-5edf45de-7af7-11e8-8cfd-74687d99b9f1.png)
![image](https://user-images.githubusercontent.com/25840389/42032503-69586ee6-7af7-11e8-8dcf-c64c4f3997fe.png)

## Reference
* [SOBA]()
* [RALLY-#DE2023](https://rally1.rallydev.com/#/144349237612ud/iterationstatus)

## Closes
* [DE2023](https://rally1.rallydev.com/#/144349237612ud/iterationstatus)
