### PR TITLE
Dropbox : Added test cases for DELETE - `files/links` and `files/{id}/links`

### DIFF
--- a/src/test/elements/dropbox/files.js
+++ b/src/test/elements/dropbox/files.js
@@ -47,5 +47,15 @@ suite.forElement('documents','files',(test) => {
         .then(r => cloud.delete(`/hubs/documents/files/${jpgFileBody.id}/custom-fields-templates/${tempKey}/custom-fields`));
   });
 
+  it('it should allow D for documents/files/{id}/links', () => {
+      return cloud.get(`${test.api}/${jpgFileBody.id}/links`)
+      .then(() => cloud.delete(`${test.api}/${jpgFileBody.id}/links`));
+  });
+
+  it('it should allow D for documents/files/links', () => {
+     var filePath = jpgFileBody.path;
+      return cloud.get(`${test.api}/${jpgFileBody.id}/links`)
+      .then(() => cloud.withOptions({ qs: { path: filePath  } }).delete(`${test.api}/links`));
+  });
 
 });

--- a/src/test/elements/dropboxv2/assets/revokelinkaccess.json
+++ b/src/test/elements/dropboxv2/assets/revokelinkaccess.json
@@ -1,3 +1,0 @@
-{
-"url" : "https://www.dropbox.com/s/duybyrtybvfyzoo/testme.txt?dl=0"
-}

--- a/src/test/elements/dropboxv2/files.js
+++ b/src/test/elements/dropboxv2/files.js
@@ -3,7 +3,6 @@
 const cloud = require('core/cloud');
 const suite = require('core/suite');
 const tools = require('core/tools');
-const expect = require('chakram').expect;
 
 suite.forElement('documents', 'files', (test) => {
 

--- a/src/test/elements/dropboxv2/files.js
+++ b/src/test/elements/dropboxv2/files.js
@@ -4,7 +4,6 @@ const cloud = require('core/cloud');
 const suite = require('core/suite');
 const tools = require('core/tools');
 const expect = require('chakram').expect;
-const revokelinkaccessPayload = require('./assets/revokelinkaccess.json');
 
 suite.forElement('documents', 'files', (test) => {
 
@@ -29,13 +28,14 @@ suite.forElement('documents', 'files', (test) => {
       .then(() => cloud.withOptions({ qs: query }).get(`${test.api}/revisions/${revisionId}`));
   });
 
-  it('it should allow C for documents/files/revoke-link-access', () => {
-      return cloud.get(`${test.api}/${jpgFileBody.id}/links`)
-      .then(r => revokelinkaccessPayload.url = r.body.providerViewLink)
-      .then(r => cloud.post(`${test.api}/revoke-link-access`, revokelinkaccessPayload))
-      .then(r => expect(r.body).to.be.empty);
+  it('it should allow D for documents/files/{id}/links', () => {
+       return cloud.get(`${test.api}/${jpgFileBody.id}/links`)
+       .then(() => cloud.delete(`${test.api}/${jpgFileBody.id}/links`));
+   });
+
+   it('it should allow D for documents/files/links', () => {
+       var filePath = jpgFileBody.path;
+       return cloud.get(`${test.api}/${jpgFileBody.id}/links`)
+      .then(() => cloud.withOptions({ qs: { path: filePath  } }).delete(`${test.api}/links`));
   });
-
-
-
 });


### PR DESCRIPTION
## Highlights
* Added test cases for DELETE - `files/links` and `files/{id}/links`

## Screenshot
![image](https://user-images.githubusercontent.com/29943090/42082064-a5777d10-7ba4-11e8-8e68-a366c0b726e3.png)
![image](https://user-images.githubusercontent.com/29943090/42082082-b151ce2e-7ba4-11e8-9563-72167e2181b0.png)

## Reference
* [SOBA](https://github.com/cloud-elements/soba/pull/8970)
* [RALLY-#DE1992](https://rally1.rallydev.com/#/144349237612d/detail/defect/230993131944)

## Closes
* Closes #[DE1992](https://rally1.rallydev.com/#/144349237612d/detail/defect/230993131944)
