### PR TITLE
Sharepoint: Included subsite header in testcases for /files and /folders 

### DIFF
--- a/src/test/elements/sharepoint/files.js
+++ b/src/test/elements/sharepoint/files.js
@@ -5,6 +5,7 @@ const cloud = require('core/cloud');
 const tools = require('core/tools');
 const expect = require('chakram').expect;
 const payload = tools.requirePayload(`${__dirname}/assets/files.json`);
+const subsite = { "Subsite": "/RobotSite" };
 
 suite.forElement('documents', 'files', { payload: payload }, (test) => {
   let jpgFile = __dirname + '/assets/Penguins.jpg';
@@ -36,18 +37,18 @@ suite.forElement('documents', 'files', { payload: payload }, (test) => {
   it('should allow CRD for hubs/documents/files and RU for hubs/documents/files/metadata by path', () => {
     let UploadFile = __dirname + '/assets/Penguins.jpg',
       srcPath;
-    return cloud.withOptions({ qs: { path: `/${tools.random()}`, overwrite: 'true', size: '777835' }, headers: { "Subsite": "/RobotSite" } }).postFile(test.api, UploadFile)
+    return cloud.withOptions({ qs: { path: `/${tools.random()}`, overwrite: 'true', size: '777835' }, headers: subsite  }).postFile(test.api, UploadFile)
       .then(r => {
         srcPath = r.body.path;
         expect(r.body.parentFolderId).to.not.be.null;
       })
-      .then(r => cloud.withOptions({ qs: { path: `${srcPath}` }, headers: { "Subsite": "/RobotSite" } }).get(test.api))
-      .then(r => cloud.withOptions({ qs: { path: `${srcPath}` }, headers: { "Subsite": "/RobotSite" } }).post(`${test.api}/copy`, payload))
-      .then(r => cloud.withOptions({ qs: { path: `${srcPath}` }, headers: { "Subsite": "/RobotSite" } }).get(`${test.api}/links`))
-      .then(r => cloud.withOptions({ qs: { path: `${srcPath}` }, headers: { "Subsite": "/RobotSite" } }).get(`${test.api}/metadata`))
-      .then(r => cloud.withOptions({ qs: { path: `${srcPath}` }, headers: { "Subsite": "/RobotSite" } }).patch(`${test.api}/metadata`, payload))
+      .then(r => cloud.withOptions({ qs: { path: `${srcPath}` }, headers: subsite }).get(test.api))
+      .then(r => cloud.withOptions({ qs: { path: `${srcPath}` }, headers: subsite }).post(`${test.api}/copy`, payload))
+      .then(r => cloud.withOptions({ qs: { path: `${srcPath}` }, headers: subsite  }).get(`${test.api}/links`))
+      .then(r => cloud.withOptions({ qs: { path: `${srcPath}` }, headers: subsite  }).get(`${test.api}/metadata`))
+      .then(r => cloud.withOptions({ qs: { path: `${srcPath}` }, headers: subsite  }).patch(`${test.api}/metadata`, payload))
       .then(r => srcPath = r.body.path)
-      .then(r => cloud.withOptions({ qs: { path: `${srcPath}` }, headers: { "Subsite": "/RobotSite" } }).delete(test.api));
+      .then(r => cloud.withOptions({ qs: { path: `${srcPath}` }, headers: subsite  }).delete(test.api));
   });
 
   it('should allow CRD for hubs/documents/files and RU for hubs/documents/files/metadata by id', () => {

--- a/src/test/elements/sharepoint/files.js
+++ b/src/test/elements/sharepoint/files.js
@@ -36,18 +36,18 @@ suite.forElement('documents', 'files', { payload: payload }, (test) => {
   it('should allow CRD for hubs/documents/files and RU for hubs/documents/files/metadata by path', () => {
     let UploadFile = __dirname + '/assets/Penguins.jpg',
       srcPath;
-    return cloud.withOptions({ qs: { path: `/${tools.random()}`, overwrite: 'true', size: '777835' } }).postFile(test.api, UploadFile)
+    return cloud.withOptions({ qs: { path: `/${tools.random()}`, overwrite: 'true', size: '777835' }, headers: { "Subsite": "/RobotSite" } }).postFile(test.api, UploadFile)
       .then(r => {
         srcPath = r.body.path;
         expect(r.body.parentFolderId).to.not.be.null;
       })
-      .then(r => cloud.withOptions({ qs: { path: `${srcPath}` } }).get(test.api))
-      .then(r => cloud.withOptions({ qs: { path: `${srcPath}` } }).post(`${test.api}/copy`, payload))
-      .then(r => cloud.withOptions({ qs: { path: `${srcPath}` } }).get(`${test.api}/links`))
-      .then(r => cloud.withOptions({ qs: { path: `${srcPath}` } }).get(`${test.api}/metadata`))
-      .then(r => cloud.withOptions({ qs: { path: `${srcPath}` } }).patch(`${test.api}/metadata`, payload))
+      .then(r => cloud.withOptions({ qs: { path: `${srcPath}` }, headers: { "Subsite": "/RobotSite" } }).get(test.api))
+      .then(r => cloud.withOptions({ qs: { path: `${srcPath}` }, headers: { "Subsite": "/RobotSite" } }).post(`${test.api}/copy`, payload))
+      .then(r => cloud.withOptions({ qs: { path: `${srcPath}` }, headers: { "Subsite": "/RobotSite" } }).get(`${test.api}/links`))
+      .then(r => cloud.withOptions({ qs: { path: `${srcPath}` }, headers: { "Subsite": "/RobotSite" } }).get(`${test.api}/metadata`))
+      .then(r => cloud.withOptions({ qs: { path: `${srcPath}` }, headers: { "Subsite": "/RobotSite" } }).patch(`${test.api}/metadata`, payload))
       .then(r => srcPath = r.body.path)
-      .then(r => cloud.withOptions({ qs: { path: `${srcPath}` } }).delete(test.api));
+      .then(r => cloud.withOptions({ qs: { path: `${srcPath}` }, headers: { "Subsite": "/RobotSite" } }).delete(test.api));
   });
 
   it('should allow CRD for hubs/documents/files and RU for hubs/documents/files/metadata by id', () => {

--- a/src/test/elements/sharepoint/folders.js
+++ b/src/test/elements/sharepoint/folders.js
@@ -5,6 +5,7 @@ const cloud = require('core/cloud');
 const tools = require('core/tools');
 const expect = require('chakram').expect;
 const payload = tools.requirePayload(`${__dirname}/assets/folders.json`);
+const subsite = { "Subsite": "/RobotSite" };
 
 suite.forElement('documents', 'folders', { payload: payload }, (test) => {
 
@@ -12,15 +13,15 @@ suite.forElement('documents', 'folders', { payload: payload }, (test) => {
   
   it('should allow CRD for hubs/documents/folders and GET for hubs/documents/folders/metadata by path', () => {
     let srcPath;
-  return cloud.withOptions({headers: { "Subsite": "/RobotSite" }}).post(test.api, payload)
+  return cloud.withOptions({headers: subsite }).post(test.api, payload)
       .then(r => {
         srcPath = r.body.path;
         expect(r.body.parentFolderId).to.not.be.null;
       })
-      .then(r => cloud.withOptions({ qs: { path: `${srcPath}` },headers: { "Subsite": "/RobotSite" } }).get(`${test.api}/contents`))
-      .then(r => cloud.withOptions({ qs: { path: `${srcPath}`, page: 1, pageSize: 1 },headers: { "Subsite": "/RobotSite" } }).get(`${test.api}/contents`))
-      .then(r => cloud.withOptions({ qs: { path: `${srcPath}` },headers: { "Subsite": "/RobotSite" }} ).get(`${test.api}/metadata`))
-      .then(r => cloud.withOptions({ qs: { path: `${srcPath}` },headers: { "Subsite": "/RobotSite" }} ).delete(test.api));
+      .then(r => cloud.withOptions({ qs: { path: `${srcPath}` },headers: subsite  }).get(`${test.api}/contents`))
+      .then(r => cloud.withOptions({ qs: { path: `${srcPath}`, page: 1, pageSize: 1 },headers: subsite  }).get(`${test.api}/contents`))
+      .then(r => cloud.withOptions({ qs: { path: `${srcPath}` },headers: subsite } ).get(`${test.api}/metadata`))
+      .then(r => cloud.withOptions({ qs: { path: `${srcPath}` },headers: subsite } ).delete(test.api));
   });
 
   it('should allow CRD for hubs/documents/folders and GET for hubs/documents/folders/metadata by id', () => {

--- a/src/test/elements/sharepoint/folders.js
+++ b/src/test/elements/sharepoint/folders.js
@@ -12,15 +12,15 @@ suite.forElement('documents', 'folders', { payload: payload }, (test) => {
   
   it('should allow CRD for hubs/documents/folders and GET for hubs/documents/folders/metadata by path', () => {
     let srcPath;
-    return cloud.post(test.api, payload)
+  return cloud.withOptions({headers: { "Subsite": "/RobotSite" }}).post(test.api, payload)
       .then(r => {
         srcPath = r.body.path;
         expect(r.body.parentFolderId).to.not.be.null;
       })
-      .then(r => cloud.withOptions({ qs: { path: `${srcPath}` } }).get(`${test.api}/contents`))
-      .then(r => cloud.withOptions({ qs: { path: `${srcPath}`, page: 1, pageSize: 1 } }).get(`${test.api}/contents`))
-      .then(r => cloud.withOptions({ qs: { path: `${srcPath}` } }).get(`${test.api}/metadata`))
-      .then(r => cloud.withOptions({ qs: { path: `${srcPath}` } }).delete(test.api));
+      .then(r => cloud.withOptions({ qs: { path: `${srcPath}` },headers: { "Subsite": "/RobotSite" } }).get(`${test.api}/contents`))
+      .then(r => cloud.withOptions({ qs: { path: `${srcPath}`, page: 1, pageSize: 1 },headers: { "Subsite": "/RobotSite" } }).get(`${test.api}/contents`))
+      .then(r => cloud.withOptions({ qs: { path: `${srcPath}` },headers: { "Subsite": "/RobotSite" }} ).get(`${test.api}/metadata`))
+      .then(r => cloud.withOptions({ qs: { path: `${srcPath}` },headers: { "Subsite": "/RobotSite" }} ).delete(test.api));
   });
 
   it('should allow CRD for hubs/documents/folders and GET for hubs/documents/folders/metadata by id', () => {

--- a/src/test/elements/sharepoint/search.js
+++ b/src/test/elements/sharepoint/search.js
@@ -3,7 +3,6 @@
 const suite = require('core/suite');
 const tools = require('core/tools');
 const cloud = require('core/cloud');
-const expect = require('chakram').expect;
 
 suite.forElement('documents', 'search', null, (test) => {
 

--- a/src/test/elements/sharepoint/search.js
+++ b/src/test/elements/sharepoint/search.js
@@ -6,7 +6,6 @@ const cloud = require('core/cloud');
 
 suite.forElement('documents', 'search', null, (test) => {
 
-  test.should.supportNextPagePagination(1);
   it('should allow GET /hubs/documents/search ', () => {
     let UploadFile = __dirname + '/assets/Penguins.jpg',
       srcPath;

--- a/src/test/elements/sharepoint/search.js
+++ b/src/test/elements/sharepoint/search.js
@@ -3,9 +3,19 @@
 const suite = require('core/suite');
 const tools = require('core/tools');
 const cloud = require('core/cloud');
+const expect = require('chakram').expect;
 
 suite.forElement('documents', 'search', null, (test) => {
 
+  let jpgFile = __dirname + '/assets/Penguins.jpg';
+  var jpgFileBody;
+  let query = { path: `/churros.jpg` , overwrite: 'true', size: '777835'};
+  before(() => cloud.withOptions({ qs : query }).postFile('/hubs/documents/files', jpgFile)
+  .then(r => jpgFileBody = r.body.path));
+
+  after(() => cloud.withOptions({ qs: { path: `${jpgFileBody}` } }).delete('/hubs/documents/files'));
+  
+  test.withOptions({ qs: { path: `/churros.jpg` } }).should.supportNextPagePagination(1);
   it('should allow GET /hubs/documents/search ', () => {
     let UploadFile = __dirname + '/assets/Penguins.jpg',
       srcPath;


### PR DESCRIPTION
## Highlights
* Now included `subsite` as a header in existing testcases for `/files` and `/folders` resources

## Screenshot
![image](https://user-images.githubusercontent.com/34128818/42319280-173105ec-806f-11e8-86b8-a375afc545eb.png)


## Reference
* [SOBA](https://github.com/cloud-elements/soba/pull/8989)
* [RALLY-#${DE2013}](https://rally1.rallydev.com/#/144349237612d/detail/defect/232550823596)

## Closes
* [DE2013](https://rally1.rallydev.com/#/144349237612d/detail/defect/232550823596)
