### PR TITLE
Added churros test cases for the newly added ZohoCRM V2 element

### DIFF
--- a/src/core/oauth.js
+++ b/src/core/oauth.js
@@ -782,14 +782,14 @@ const manipulateDom = (element, browser, r, username, password, config) => {
         .then(() => browser.getCurrentUrl());
       }
       break;
-      case 'zohocrmv2':
-        browser.get(r.body.oauthUrl);
-        browser.wait(webdriver.until.elementLocated(webdriver.By.name('lid'), 5000));
-        browser.findElement(webdriver.By.name('lid')).sendKeys(username);
-        browser.findElement(webdriver.By.name('pwd')).sendKeys(password);
-        browser.findElement(webdriver.By.id('signin_submit')).click();
-        return browser.getCurrentUrl();
-        default:
+    case 'zohocrmv2':
+      browser.get(r.body.oauthUrl);
+      browser.wait(webdriver.until.elementLocated(webdriver.By.name('lid'), 5000));
+      browser.findElement(webdriver.By.name('lid')).sendKeys(username);
+      browser.findElement(webdriver.By.name('pwd')).sendKeys(password);
+      browser.findElement(webdriver.By.id('signin_submit')).click();
+      return browser.getCurrentUrl();
+    default:
       throw 'No OAuth function found for element ' + element + '.  Please implement function in core/oauth so ' + element + ' can be provisioned';
   }
 };

--- a/src/core/oauth.js
+++ b/src/core/oauth.js
@@ -50,15 +50,15 @@ const manipulateDom = (element, browser, r, username, password, config) => {
     case 'sapbobylaunchbi':
     case 'salesforcebylaunchbi':
     case 'tableaubylaunchbi':
-      browser.get(r.body.oauthUrl);
-      browser.findElement(webdriver.By.id('username')).sendKeys(username);
-      browser.findElement(webdriver.By.id('password')).sendKeys(password);
-      browser.findElement(webdriver.By.xpath('//*[@id="loginform"]/table/tbody/tr[6]/td/input')).click();
-      browser.wait(() => browser.isElementPresent(webdriver.By.xpath('//*[@id="ui-id-2"]/table/tbody/tr[4]/td[2]/input')), 5000)
-        .thenCatch(r => true); // ignore
-      browser.findElement(webdriver.By.xpath('//*[@id="ui-id-2"]/table/tbody/tr[4]/td[2]/input'))
-        .then((element) => element.click(), (err) => {}); // ignore this
-      return browser.getCurrentUrl();
+    browser.get(r.body.oauthUrl);
+    browser.findElement(webdriver.By.id('username')).sendKeys(username);
+    browser.findElement(webdriver.By.id('password')).sendKeys(password);
+    browser.findElement(webdriver.By.xpath('//*[@id="loginform"]/table/tbody/tr[6]/td/input')).click();
+    browser.wait(() => browser.isElementPresent(webdriver.By.xpath('//*[@id="ui-id-2"]/table/tbody/tr[4]/td[2]/input')), 5000)
+      .thenCatch(r => true); // ignore
+    browser.findElement(webdriver.By.xpath('//*[@id="ui-id-2"]/table/tbody/tr[4]/td[2]/input'))
+      .then((element) => element.click(), (err) => {}); // ignore this
+    return browser.getCurrentUrl();
     case 'bullhorn--v1':
     case 'bullhorn--v2':
       browser.get(r.body.oauthUrl);
@@ -105,18 +105,18 @@ const manipulateDom = (element, browser, r, username, password, config) => {
       browser.findElement(webdriver.By.name('commit')).click();
       return browser.getCurrentUrl();
     case 'economic':
-      browser.get(r.body.oauthUrl);
-      waitForElement(webdriver.By.id('btnRedirect'));
-      browser.findElement(webdriver.By.id('btnRedirect')).click();
-      waitForElement(webdriver.By.name('aftalenr'));
-      browser.findElement(webdriver.By.name('aftalenr')).sendKeys(config.agreementId);
-      browser.findElement(webdriver.By.name('brugernavn')).sendKeys(username);
-      browser.findElement(webdriver.By.name('password')).sendKeys(password);
-      browser.findElement(webdriver.By.id('edit-submit')).click();
-      waitForElement(webdriver.By.xpath('html/body/div[1]/div/div[2]/div/div/div[2]/button'));
-      browser.findElement(webdriver.By.xpath('html/body/div[1]/div/div[2]/div/div/div[2]/button')).click();
-      browser.sleep(2000);
-      return browser.getCurrentUrl();
+         browser.get(r.body.oauthUrl);
+ 	       waitForElement(webdriver.By.id('btnRedirect'));
+         browser.findElement(webdriver.By.id('btnRedirect')).click();
+         waitForElement(webdriver.By.name('aftalenr'));
+         browser.findElement(webdriver.By.name('aftalenr')).sendKeys(config.agreementId);
+         browser.findElement(webdriver.By.name('brugernavn')).sendKeys(username);
+         browser.findElement(webdriver.By.name('password')).sendKeys(password);
+         browser.findElement(webdriver.By.id('edit-submit')).click();
+         waitForElement(webdriver.By.xpath('html/body/div[1]/div/div[2]/div/div/div[2]/button'));
+         browser.findElement(webdriver.By.xpath('html/body/div[1]/div/div[2]/div/div/div[2]/button')).click();
+         browser.sleep(2000);
+         return browser.getCurrentUrl();
     case 'actoneb':
     case 'acton':
       browser.get(r.body.oauthUrl);
@@ -475,13 +475,13 @@ const manipulateDom = (element, browser, r, username, password, config) => {
       browser.findElement(webdriver.By.id('i0118')).sendKeys(password);
       waitForElement(webdriver.By.xpath('.//*[@value= "Sign in" and @type= "submit"]'));
       browser.findElement(webdriver.By.xpath('.//*[@value= "Sign in" and @type= "submit"]')).click();
-      waitForElement(webdriver.By.id('idSIButton9')).thenCatch(r => true); //Stay signed in screen
+      waitForElement(webdriver.By.id('idSIButton9')).thenCatch(r => true);  //Stay signed in screen
       browser.findElement(webdriver.By.id('idSIButton9'))
         .then((element) => element.click(), (err) => {}); // ignore this
       waitForElement(webdriver.By.id('ctl00_PlaceHolderMain_BtnAllow')).thenCatch(r => true); // ignore
       browser.findElement(webdriver.By.id('ctl00_PlaceHolderMain_BtnAllow'))
         .then((element) => element.click(), (err) => {}); // ignore this
-      browser.sleep(2000); //plz wait for the code to show up in httpbin
+      browser.sleep(2000);  //plz wait for the code to show up in httpbin
       return browser.getCurrentUrl();
     case 'paypalv2--sandbox':
       //Sandbox version has slightly different url. Will fall into regular flow after changing url
@@ -630,14 +630,14 @@ const manipulateDom = (element, browser, r, username, password, config) => {
       browser.findElement(webdriver.By.className('primary'))
         .then((element) => element.click(), (err) => {});
       return browser.getCurrentUrl();
-    case 'smartrecruiters':
-      browser.get(r.body.oauthUrl);
-      browser.findElement(webdriver.By.id('email')).sendKeys(username);
-      browser.findElement(webdriver.By.id('password')).sendKeys(password);
-      browser.findElement(webdriver.By.id('sign-in-btn')).click();
-      waitForElement(webdriver.By.xpath('//*[@id="approveAccessForm"]/input[3]'));
-      browser.findElement(webdriver.By.xpath('//*[@id="approveAccessForm"]/input[3]')).click();
-      return browser.getCurrentUrl();
+    case  'smartrecruiters':
+       browser.get(r.body.oauthUrl);
+       browser.findElement(webdriver.By.id('email')).sendKeys(username);
+       browser.findElement(webdriver.By.id('password')).sendKeys(password);
+       browser.findElement(webdriver.By.id('sign-in-btn')).click();
+       waitForElement(webdriver.By.xpath('//*[@id="approveAccessForm"]/input[3]'));
+       browser.findElement(webdriver.By.xpath('//*[@id="approveAccessForm"]/input[3]')).click();
+       return browser.getCurrentUrl();
     case 'microsoftgraph':
       browser.get(r.body.oauthUrl);
       browser.findElement(webdriver.By.id('i0116')).sendKeys(username);
@@ -730,7 +730,7 @@ const manipulateDom = (element, browser, r, username, password, config) => {
       browser.findElement(webdriver.By.xpath('.//*[@id="auth0-lock-container-1"]/div/div[2]/form/div/div/button')).click();
       browser.sleep(5000);
       return browser.getCurrentUrl();
-    case 'docusign':
+   case 'docusign':
       browser.get(r.body.oauthUrl);
       browser.wait(webdriver.until.elementLocated(webdriver.By.name('email'), 5000));
       browser.findElement(webdriver.By.name('email')).sendKeys(username);
@@ -754,9 +754,9 @@ const manipulateDom = (element, browser, r, username, password, config) => {
     case 'docushareflex':
       if (config['provider.version'] === '1') {
         /* For version 1 Docushare renders a popup that selenium can't handle with firefox - eg browser.switchTo().alert()
-         * There is also a firefox issue with sending the Basic credentials in the URL if you're targeting a sub-resource on a domain.
-         * To workaround we first hit the main domain with the creds in the URL then call the sub-resource (our OG auth url);
-         **/
+        * There is also a firefox issue with sending the Basic credentials in the URL if you're targeting a sub-resource on a domain.
+        * To workaround we first hit the main domain with the creds in the URL then call the sub-resource (our OG auth url);
+        **/
         let docushareOauthUrl = r.body.oauthUrl;
         let domainExtension = '.com';
         let baseUrl = docushareOauthUrl.substring(0, docushareOauthUrl.indexOf(domainExtension) + domainExtension.length);
@@ -771,25 +771,25 @@ const manipulateDom = (element, browser, r, username, password, config) => {
       } else {
         browser.get(r.body.oauthUrl);
         return browser.wait(() => browser.isElementPresent(webdriver.By.id('xsltforms-mainform-input-username')), 5000)
-          .then(() => browser.findElement(webdriver.By.xpath('//*[@id="xsltforms-mainform-input-username"]')).sendKeys(username))
-          .then(() => browser.findElement(webdriver.By.xpath('//*[@id="password"]/span[2]/input')).sendKeys(password))
-          .then(() => browser.findElement(webdriver.By.xpath('//*[@id="xsltforms-mainform-submit-2_3_3_2_1_2_4_"]/span[1]/button')))
-          .then(r => r.click())
-          .then(() => browser.wait(() => browser.isElementPresent(webdriver.By.id('xsltforms-mainform-trigger-1_3_1_2_4_')), 5000))
-          .then(() => browser.findElement(webdriver.By.xpath('//*[@id="xsltforms-mainform-trigger-1_3_1_2_4_"]/span[1]/button')))
-          .then(r => r.click())
-          .then(() => browser.sleep(2000))
-          .then(() => browser.getCurrentUrl());
+        .then(() => browser.findElement(webdriver.By.xpath('//*[@id="xsltforms-mainform-input-username"]')).sendKeys(username))
+        .then(() => browser.findElement(webdriver.By.xpath('//*[@id="password"]/span[2]/input')).sendKeys(password))
+        .then(() => browser.findElement(webdriver.By.xpath('//*[@id="xsltforms-mainform-submit-2_3_3_2_1_2_4_"]/span[1]/button')))
+        .then(r => r.click())
+        .then(() => browser.wait(() => browser.isElementPresent(webdriver.By.id('xsltforms-mainform-trigger-1_3_1_2_4_')), 5000))
+        .then(() => browser.findElement(webdriver.By.xpath('//*[@id="xsltforms-mainform-trigger-1_3_1_2_4_"]/span[1]/button')))
+        .then(r => r.click())
+        .then(() => browser.sleep(2000))
+        .then(() => browser.getCurrentUrl());
       }
       break;
-    case 'zohocrmv2':
-      browser.get(r.body.oauthUrl);
-      browser.wait(webdriver.until.elementLocated(webdriver.By.name('lid'), 5000));
-      browser.findElement(webdriver.By.name('lid')).sendKeys(username);
-      browser.findElement(webdriver.By.name('pwd')).sendKeys(password);
-      browser.findElement(webdriver.By.id('signin_submit')).click();
-      return browser.getCurrentUrl();
-    default:
+      case 'zohocrmv2':
+        browser.get(r.body.oauthUrl);
+        browser.wait(webdriver.until.elementLocated(webdriver.By.name('lid'), 5000));
+        browser.findElement(webdriver.By.name('lid')).sendKeys(username);
+        browser.findElement(webdriver.By.name('pwd')).sendKeys(password);
+        browser.findElement(webdriver.By.id('signin_submit')).click();
+        return browser.getCurrentUrl();
+        default:
       throw 'No OAuth function found for element ' + element + '.  Please implement function in core/oauth so ' + element + ' can be provisioned';
   }
 };

--- a/src/core/oauth.js
+++ b/src/core/oauth.js
@@ -50,15 +50,15 @@ const manipulateDom = (element, browser, r, username, password, config) => {
     case 'sapbobylaunchbi':
     case 'salesforcebylaunchbi':
     case 'tableaubylaunchbi':
-    browser.get(r.body.oauthUrl);
-    browser.findElement(webdriver.By.id('username')).sendKeys(username);
-    browser.findElement(webdriver.By.id('password')).sendKeys(password);
-    browser.findElement(webdriver.By.xpath('//*[@id="loginform"]/table/tbody/tr[6]/td/input')).click();
-    browser.wait(() => browser.isElementPresent(webdriver.By.xpath('//*[@id="ui-id-2"]/table/tbody/tr[4]/td[2]/input')), 5000)
-      .thenCatch(r => true); // ignore
-    browser.findElement(webdriver.By.xpath('//*[@id="ui-id-2"]/table/tbody/tr[4]/td[2]/input'))
-      .then((element) => element.click(), (err) => {}); // ignore this
-    return browser.getCurrentUrl();
+      browser.get(r.body.oauthUrl);
+      browser.findElement(webdriver.By.id('username')).sendKeys(username);
+      browser.findElement(webdriver.By.id('password')).sendKeys(password);
+      browser.findElement(webdriver.By.xpath('//*[@id="loginform"]/table/tbody/tr[6]/td/input')).click();
+      browser.wait(() => browser.isElementPresent(webdriver.By.xpath('//*[@id="ui-id-2"]/table/tbody/tr[4]/td[2]/input')), 5000)
+        .thenCatch(r => true); // ignore
+      browser.findElement(webdriver.By.xpath('//*[@id="ui-id-2"]/table/tbody/tr[4]/td[2]/input'))
+        .then((element) => element.click(), (err) => {}); // ignore this
+      return browser.getCurrentUrl();
     case 'bullhorn--v1':
     case 'bullhorn--v2':
       browser.get(r.body.oauthUrl);
@@ -105,18 +105,18 @@ const manipulateDom = (element, browser, r, username, password, config) => {
       browser.findElement(webdriver.By.name('commit')).click();
       return browser.getCurrentUrl();
     case 'economic':
-         browser.get(r.body.oauthUrl);
- 	       waitForElement(webdriver.By.id('btnRedirect'));
-         browser.findElement(webdriver.By.id('btnRedirect')).click();
-         waitForElement(webdriver.By.name('aftalenr'));
-         browser.findElement(webdriver.By.name('aftalenr')).sendKeys(config.agreementId);
-         browser.findElement(webdriver.By.name('brugernavn')).sendKeys(username);
-         browser.findElement(webdriver.By.name('password')).sendKeys(password);
-         browser.findElement(webdriver.By.id('edit-submit')).click();
-         waitForElement(webdriver.By.xpath('html/body/div[1]/div/div[2]/div/div/div[2]/button'));
-         browser.findElement(webdriver.By.xpath('html/body/div[1]/div/div[2]/div/div/div[2]/button')).click();
-         browser.sleep(2000);
-         return browser.getCurrentUrl();
+      browser.get(r.body.oauthUrl);
+      waitForElement(webdriver.By.id('btnRedirect'));
+      browser.findElement(webdriver.By.id('btnRedirect')).click();
+      waitForElement(webdriver.By.name('aftalenr'));
+      browser.findElement(webdriver.By.name('aftalenr')).sendKeys(config.agreementId);
+      browser.findElement(webdriver.By.name('brugernavn')).sendKeys(username);
+      browser.findElement(webdriver.By.name('password')).sendKeys(password);
+      browser.findElement(webdriver.By.id('edit-submit')).click();
+      waitForElement(webdriver.By.xpath('html/body/div[1]/div/div[2]/div/div/div[2]/button'));
+      browser.findElement(webdriver.By.xpath('html/body/div[1]/div/div[2]/div/div/div[2]/button')).click();
+      browser.sleep(2000);
+      return browser.getCurrentUrl();
     case 'actoneb':
     case 'acton':
       browser.get(r.body.oauthUrl);
@@ -475,13 +475,13 @@ const manipulateDom = (element, browser, r, username, password, config) => {
       browser.findElement(webdriver.By.id('i0118')).sendKeys(password);
       waitForElement(webdriver.By.xpath('.//*[@value= "Sign in" and @type= "submit"]'));
       browser.findElement(webdriver.By.xpath('.//*[@value= "Sign in" and @type= "submit"]')).click();
-      waitForElement(webdriver.By.id('idSIButton9')).thenCatch(r => true);  //Stay signed in screen
+      waitForElement(webdriver.By.id('idSIButton9')).thenCatch(r => true); //Stay signed in screen
       browser.findElement(webdriver.By.id('idSIButton9'))
         .then((element) => element.click(), (err) => {}); // ignore this
       waitForElement(webdriver.By.id('ctl00_PlaceHolderMain_BtnAllow')).thenCatch(r => true); // ignore
       browser.findElement(webdriver.By.id('ctl00_PlaceHolderMain_BtnAllow'))
         .then((element) => element.click(), (err) => {}); // ignore this
-      browser.sleep(2000);  //plz wait for the code to show up in httpbin
+      browser.sleep(2000); //plz wait for the code to show up in httpbin
       return browser.getCurrentUrl();
     case 'paypalv2--sandbox':
       //Sandbox version has slightly different url. Will fall into regular flow after changing url
@@ -630,14 +630,14 @@ const manipulateDom = (element, browser, r, username, password, config) => {
       browser.findElement(webdriver.By.className('primary'))
         .then((element) => element.click(), (err) => {});
       return browser.getCurrentUrl();
-    case  'smartrecruiters':
-       browser.get(r.body.oauthUrl);
-       browser.findElement(webdriver.By.id('email')).sendKeys(username);
-       browser.findElement(webdriver.By.id('password')).sendKeys(password);
-       browser.findElement(webdriver.By.id('sign-in-btn')).click();
-       waitForElement(webdriver.By.xpath('//*[@id="approveAccessForm"]/input[3]'));
-       browser.findElement(webdriver.By.xpath('//*[@id="approveAccessForm"]/input[3]')).click();
-       return browser.getCurrentUrl();
+    case 'smartrecruiters':
+      browser.get(r.body.oauthUrl);
+      browser.findElement(webdriver.By.id('email')).sendKeys(username);
+      browser.findElement(webdriver.By.id('password')).sendKeys(password);
+      browser.findElement(webdriver.By.id('sign-in-btn')).click();
+      waitForElement(webdriver.By.xpath('//*[@id="approveAccessForm"]/input[3]'));
+      browser.findElement(webdriver.By.xpath('//*[@id="approveAccessForm"]/input[3]')).click();
+      return browser.getCurrentUrl();
     case 'microsoftgraph':
       browser.get(r.body.oauthUrl);
       browser.findElement(webdriver.By.id('i0116')).sendKeys(username);
@@ -730,7 +730,7 @@ const manipulateDom = (element, browser, r, username, password, config) => {
       browser.findElement(webdriver.By.xpath('.//*[@id="auth0-lock-container-1"]/div/div[2]/form/div/div/button')).click();
       browser.sleep(5000);
       return browser.getCurrentUrl();
-   case 'docusign':
+    case 'docusign':
       browser.get(r.body.oauthUrl);
       browser.wait(webdriver.until.elementLocated(webdriver.By.name('email'), 5000));
       browser.findElement(webdriver.By.name('email')).sendKeys(username);
@@ -754,9 +754,9 @@ const manipulateDom = (element, browser, r, username, password, config) => {
     case 'docushareflex':
       if (config['provider.version'] === '1') {
         /* For version 1 Docushare renders a popup that selenium can't handle with firefox - eg browser.switchTo().alert()
-        * There is also a firefox issue with sending the Basic credentials in the URL if you're targeting a sub-resource on a domain.
-        * To workaround we first hit the main domain with the creds in the URL then call the sub-resource (our OG auth url);
-        **/
+         * There is also a firefox issue with sending the Basic credentials in the URL if you're targeting a sub-resource on a domain.
+         * To workaround we first hit the main domain with the creds in the URL then call the sub-resource (our OG auth url);
+         **/
         let docushareOauthUrl = r.body.oauthUrl;
         let domainExtension = '.com';
         let baseUrl = docushareOauthUrl.substring(0, docushareOauthUrl.indexOf(domainExtension) + domainExtension.length);
@@ -771,17 +771,24 @@ const manipulateDom = (element, browser, r, username, password, config) => {
       } else {
         browser.get(r.body.oauthUrl);
         return browser.wait(() => browser.isElementPresent(webdriver.By.id('xsltforms-mainform-input-username')), 5000)
-        .then(() => browser.findElement(webdriver.By.xpath('//*[@id="xsltforms-mainform-input-username"]')).sendKeys(username))
-        .then(() => browser.findElement(webdriver.By.xpath('//*[@id="password"]/span[2]/input')).sendKeys(password))
-        .then(() => browser.findElement(webdriver.By.xpath('//*[@id="xsltforms-mainform-submit-2_3_3_2_1_2_4_"]/span[1]/button')))
-        .then(r => r.click())
-        .then(() => browser.wait(() => browser.isElementPresent(webdriver.By.id('xsltforms-mainform-trigger-1_3_1_2_4_')), 5000))
-        .then(() => browser.findElement(webdriver.By.xpath('//*[@id="xsltforms-mainform-trigger-1_3_1_2_4_"]/span[1]/button')))
-        .then(r => r.click())
-        .then(() => browser.sleep(2000))
-        .then(() => browser.getCurrentUrl());
+          .then(() => browser.findElement(webdriver.By.xpath('//*[@id="xsltforms-mainform-input-username"]')).sendKeys(username))
+          .then(() => browser.findElement(webdriver.By.xpath('//*[@id="password"]/span[2]/input')).sendKeys(password))
+          .then(() => browser.findElement(webdriver.By.xpath('//*[@id="xsltforms-mainform-submit-2_3_3_2_1_2_4_"]/span[1]/button')))
+          .then(r => r.click())
+          .then(() => browser.wait(() => browser.isElementPresent(webdriver.By.id('xsltforms-mainform-trigger-1_3_1_2_4_')), 5000))
+          .then(() => browser.findElement(webdriver.By.xpath('//*[@id="xsltforms-mainform-trigger-1_3_1_2_4_"]/span[1]/button')))
+          .then(r => r.click())
+          .then(() => browser.sleep(2000))
+          .then(() => browser.getCurrentUrl());
       }
       break;
+    case 'zohocrmv2':
+      browser.get(r.body.oauthUrl);
+      browser.wait(webdriver.until.elementLocated(webdriver.By.name('lid'), 5000));
+      browser.findElement(webdriver.By.name('lid')).sendKeys(username);
+      browser.findElement(webdriver.By.name('pwd')).sendKeys(password);
+      browser.findElement(webdriver.By.id('signin_submit')).click();
+      return browser.getCurrentUrl();
     default:
       throw 'No OAuth function found for element ' + element + '.  Please implement function in core/oauth so ' + element + ' can be provisioned';
   }

--- a/src/test/elements/assets/object.definitions.json
+++ b/src/test/elements/assets/object.definitions.json
@@ -3050,5 +3050,41 @@
         "type": "string"
       }
     ]
+  },
+  "activities-calls": {
+    "fields": [
+      {
+        "path": "idTransformed",
+        "type": "string"
+      },
+      {
+        "path": "id",
+        "type": "string"
+      }
+    ]
+  },
+  "activities-events": {
+    "fields": [
+      {
+        "path": "idTransformed",
+        "type": "string"
+      },
+      {
+        "path": "id",
+        "type": "string"
+      }
+    ]
+  },
+  "notes": {
+    "fields": [
+      {
+        "path": "idTransformed",
+        "type": "string"
+      },
+      {
+        "path": "id",
+        "type": "string"
+      }
+    ]
   }
 }

--- a/src/test/elements/zohocrmv2/accounts.js
+++ b/src/test/elements/zohocrmv2/accounts.js
@@ -1,0 +1,37 @@
+'use strict';
+
+const suite = require('core/suite');
+const cloud = require('core/cloud');
+const chakram = require('chakram');
+const expect = chakram.expect;
+const accountsPayload = require('./assets/accounts');
+const notesPayload = require('./assets/notes');
+
+suite.forElement('crm', 'accounts', { payload: accountsPayload }, (test) => {
+  it('should allow ping for zohocrmv2', () => {
+    return cloud.get(`/hubs/crm/ping`);
+  });
+
+  test.should.supportCruds(chakram.put);
+  test.should.supportPagination();
+  test.withName(`should support searching ${test.api} by word`)
+    .withOptions({ qs: { where: 'word=\'Test\'' } })
+    .withValidation(r => {
+      expect(r).to.statusCode(200);
+      const validValues = r.body.filter(obj => JSON.stringify(obj).toLowerCase().indexOf('test'));
+      expect(validValues.length).to.equal(r.body.length);
+    })
+    .should.return200OnGet();
+
+  it('should allow CRUDS for accounts/{id}/notes', () => {
+    let accountId = -1;
+    let notesId = -1;
+    return cloud.post(test.api, accountsPayload)
+      .then(r => accountId = r.body.id)
+      .then(r => cloud.cruds(`${test.api}/${accountId}/notes`, notesPayload, chakram.put))
+      .then(r => cloud.post(`${test.api}/${accountId}/notes`, notesPayload))
+      .then(r => cloud.withOptions({ qs: { page: 1, pageSize: 1 } }).get(`${test.api}/${accountId}/notes`))
+      .then(r => expect(r.body.length).to.equal(1))
+      .then(r => cloud.delete(`${test.api}/${accountId}`));
+  });
+});

--- a/src/test/elements/zohocrmv2/accounts.js
+++ b/src/test/elements/zohocrmv2/accounts.js
@@ -25,7 +25,6 @@ suite.forElement('crm', 'accounts', { payload: accountsPayload }, (test) => {
 
   it('should allow CRUDS for accounts/{id}/notes', () => {
     let accountId = -1;
-    let notesId = -1;
     return cloud.post(test.api, accountsPayload)
       .then(r => accountId = r.body.id)
       .then(r => cloud.cruds(`${test.api}/${accountId}/notes`, notesPayload, chakram.put))

--- a/src/test/elements/zohocrmv2/activities-calls.js
+++ b/src/test/elements/zohocrmv2/activities-calls.js
@@ -1,0 +1,19 @@
+'use strict';
+
+const suite = require('core/suite');
+const chakram = require('chakram');
+const expect = chakram.expect;
+const payload = require('./assets/activities-calls');
+
+suite.forElement('crm', 'activities-calls', { payload: payload }, (test) => {
+  test.should.supportCruds(chakram.put);
+  test.should.supportPagination();
+  test.withName(`should support searching ${test.api} by word`)
+    .withOptions({ qs: { where: 'word=\'Test\'' } })
+    .withValidation(r => {
+      expect(r).to.statusCode(200);
+      const validValues = r.body.filter(obj => JSON.stringify(obj).toLowerCase().indexOf('test'));
+      expect(validValues.length).to.equal(r.body.length);
+    })
+    .should.return200OnGet();
+});

--- a/src/test/elements/zohocrmv2/activities-events.js
+++ b/src/test/elements/zohocrmv2/activities-events.js
@@ -1,0 +1,19 @@
+'use strict';
+
+const suite = require('core/suite');
+const chakram = require('chakram');
+const expect = chakram.expect;
+const payload = require('./assets/activities-events');
+
+suite.forElement('crm', 'activities-events', { payload: payload }, (test) => {
+  test.should.supportCruds(chakram.put);
+  test.should.supportPagination();
+  test.withName(`should support searching ${test.api} by word`)
+    .withOptions({ qs: { where: 'word=\'Test\'' } })
+    .withValidation(r => {
+      expect(r).to.statusCode(200);
+      const validValues = r.body.filter(obj => JSON.stringify(obj).toLowerCase().indexOf('test'));
+      expect(validValues.length).to.equal(r.body.length);
+    })
+    .should.return200OnGet();
+});

--- a/src/test/elements/zohocrmv2/assets/accounts.json
+++ b/src/test/elements/zohocrmv2/assets/accounts.json
@@ -1,0 +1,3 @@
+{
+  "Account_Name": "<<random.word>>"
+}

--- a/src/test/elements/zohocrmv2/assets/activities-calls.json
+++ b/src/test/elements/zohocrmv2/assets/activities-calls.json
@@ -1,0 +1,3 @@
+{
+  "Subject": "<<random.word>>"
+}

--- a/src/test/elements/zohocrmv2/assets/activities-events.json
+++ b/src/test/elements/zohocrmv2/assets/activities-events.json
@@ -1,0 +1,5 @@
+{
+  "Event_Title": "<<random.word>>",
+  "Start_DateTime": "2018-06-26T00:00:00+00:00",
+  "End_DateTime": "2018-06-26T23:59:59+00:00"
+}

--- a/src/test/elements/zohocrmv2/assets/campaigns.json
+++ b/src/test/elements/zohocrmv2/assets/campaigns.json
@@ -1,0 +1,3 @@
+{
+  "Campaign_Name": "<<random.word>>"
+}

--- a/src/test/elements/zohocrmv2/assets/cases.json
+++ b/src/test/elements/zohocrmv2/assets/cases.json
@@ -1,0 +1,3 @@
+{
+	"Case_Reason": "<<random.word>>"
+}

--- a/src/test/elements/zohocrmv2/assets/contacts.json
+++ b/src/test/elements/zohocrmv2/assets/contacts.json
@@ -1,0 +1,3 @@
+{
+  "Last_Name": "<<random.word>>"
+}

--- a/src/test/elements/zohocrmv2/assets/leads.json
+++ b/src/test/elements/zohocrmv2/assets/leads.json
@@ -1,0 +1,3 @@
+{
+  "Last_Name": "<<random.word>>"
+}

--- a/src/test/elements/zohocrmv2/assets/notes.json
+++ b/src/test/elements/zohocrmv2/assets/notes.json
@@ -1,0 +1,3 @@
+{
+  "Note_Content": "<<random.word>>"
+}

--- a/src/test/elements/zohocrmv2/assets/opportunities.json
+++ b/src/test/elements/zohocrmv2/assets/opportunities.json
@@ -1,0 +1,3 @@
+{
+  "Deal_Name": "<<random.word>>"
+}

--- a/src/test/elements/zohocrmv2/assets/products.json
+++ b/src/test/elements/zohocrmv2/assets/products.json
@@ -1,0 +1,3 @@
+{
+  "Product_Name": "<<random.word>>"
+}

--- a/src/test/elements/zohocrmv2/assets/tasks.json
+++ b/src/test/elements/zohocrmv2/assets/tasks.json
@@ -1,0 +1,3 @@
+{
+  "Subject": "<<random.word>>"
+}

--- a/src/test/elements/zohocrmv2/assets/transformations.json
+++ b/src/test/elements/zohocrmv2/assets/transformations.json
@@ -1,0 +1,85 @@
+{
+  "accounts": {
+    "vendorName": "Accounts",
+    "fields": [{
+        "path": "id",
+        "vendorPath": "details.id"
+      }]
+  },
+  "campaigns": {
+    "vendorName": "Campaigns",
+    "fields": [{
+      "path": "id",
+      "vendorPath": "details.id"
+    }]
+
+  },
+  "cases": {
+    "vendorName": "Cases",
+    "fields": [{
+      "path": "id",
+      "vendorPath": "details.id"
+    }]
+
+  },
+  "contacts": {
+    "vendorName": "Contacts",
+    "fields": [{
+        "path": "id",
+        "vendorPath": "details.id"
+      }]
+  },
+
+  "leads": {
+    "vendorName": "Leads",
+    "fields": [{
+        "path": "id",
+        "vendorPath": "details.id"
+      }]
+  },
+  "notes": {
+    "vendorName": "Notes",
+    "fields": [{
+        "path": "id",
+        "vendorPath": "details.id"
+      }]
+  },
+
+
+  "tasks": {
+    "vendorName": "Tasks",
+    "fields": [{
+      "path": "id",
+      "vendorPath": "details.id"
+    }]
+  },
+
+  "activities-calls": {
+    "vendorName": "Calls",
+    "fields": [{
+        "path": "id",
+        "vendorPath":  "details.id"
+      }]
+  },
+  "activities-events": {
+    "vendorName": "Events",
+    "fields": [{
+        "path": "id",
+        "vendorPath":  "details.id"
+      }]
+  },
+  "opportunities": {
+    "vendorName": "Potentials",
+    "fields": [{
+        "path": "id",
+        "vendorPath": "details.id"
+      }]
+  },
+  "products": {
+    "vendorName": "Products",
+    "fields": [{
+        "path": "id",
+        "vendorPath": "details.id"
+      }]
+  }
+}

--- a/src/test/elements/zohocrmv2/campaigns.js
+++ b/src/test/elements/zohocrmv2/campaigns.js
@@ -1,0 +1,19 @@
+'use strict';
+
+const suite = require('core/suite');
+const chakram = require('chakram');
+const expect = chakram.expect;
+const payload = require('./assets/campaigns');
+
+suite.forElement('crm', 'campaigns', { payload: payload }, (test) => {
+  test.should.supportCruds(chakram.put);
+  test.should.supportPagination();
+  test.withName(`should support searching ${test.api} by word`)
+    .withOptions({ qs: { where: 'word=\'Test\'' } })
+    .withValidation(r => {
+      expect(r).to.statusCode(200);
+      const validValues = r.body.filter(obj => JSON.stringify(obj).toLowerCase().indexOf('test'));
+      expect(validValues.length).to.equal(r.body.length);
+    })
+    .should.return200OnGet();
+});

--- a/src/test/elements/zohocrmv2/cases.js
+++ b/src/test/elements/zohocrmv2/cases.js
@@ -1,0 +1,20 @@
+'use strict';
+
+const suite = require('core/suite');
+const chakram = require('chakram');
+const expect = chakram.expect;
+const casesPayload = require('./assets/cases');
+
+suite.forElement('crm', 'cases', { payload: casesPayload }, (test) => {
+
+  test.should.supportCruds(chakram.put);
+  test.should.supportPagination();
+  test.withName(`should support searching ${test.api} by word`)
+    .withOptions({ qs: { where: 'word=\'Test\'' } })
+    .withValidation(r => {
+      expect(r).to.statusCode(200);
+      const validValues = r.body.filter(obj => JSON.stringify(obj).toLowerCase().indexOf('test'));
+      expect(validValues.length).to.equal(r.body.length);
+    })
+    .should.return200OnGet();
+});

--- a/src/test/elements/zohocrmv2/contacts.js
+++ b/src/test/elements/zohocrmv2/contacts.js
@@ -1,0 +1,33 @@
+'use strict';
+
+const suite = require('core/suite');
+const cloud = require('core/cloud');
+const chakram = require('chakram');
+const expect = chakram.expect;
+const contactsPayload = require('./assets/contacts');
+const notesPayload = require('./assets/notes');
+
+suite.forElement('crm', 'contacts', { payload: contactsPayload }, (test) => {
+
+  test.should.supportCruds(chakram.put);
+  test.should.supportPagination();
+  test.withName(`should support searching ${test.api} by word`)
+    .withOptions({ qs: { where: 'word=\'Test\'' } })
+    .withValidation(r => {
+      expect(r).to.statusCode(200);
+      const validValues = r.body.filter(obj => JSON.stringify(obj).toLowerCase().indexOf('test'));
+      expect(validValues.length).to.equal(r.body.length);
+    })
+    .should.return200OnGet();
+
+it('should allow CRUDS for contacts/{id}/notes', () => {
+    let contactId = -1;
+    return cloud.post(test.api, contactsPayload)
+      .then(r => contactId = r.body.id)
+      .then(r => cloud.cruds(`${test.api}/${contactId}/notes`, notesPayload, chakram.put))
+      .then(r => cloud.post(`${test.api}/${contactId}/notes`, notesPayload))
+      .then(r => cloud.withOptions({ qs: { page: 1, pageSize: 1 } }).get(`${test.api}/${contactId}/notes`))
+      .then(r => expect(r.body.length).to.equal(1))
+      .then(r => cloud.delete(`${test.api}/${contactId}`));
+  });
+});

--- a/src/test/elements/zohocrmv2/leads.js
+++ b/src/test/elements/zohocrmv2/leads.js
@@ -1,0 +1,32 @@
+'use strict';
+
+const suite = require('core/suite');
+const cloud = require('core/cloud');
+const chakram = require('chakram');
+const expect = chakram.expect;
+const leadsPayload = require('./assets/leads');
+const notesPayload = require('./assets/notes');
+
+suite.forElement('crm', 'leads', { payload: leadsPayload }, (test) => {
+  test.should.supportCruds(chakram.put);
+  test.should.supportPagination();
+  test.withName(`should support searching ${test.api} by word`)
+    .withOptions({ qs: { where: 'word=\'max\'' } })
+    .withValidation(r => {
+      expect(r).to.statusCode(200);
+      const validValues = r.body.filter(obj => JSON.stringify(obj).toLowerCase().indexOf('max'));
+      expect(validValues.length).to.equal(r.body.length);
+    })
+    .should.return200OnGet();
+
+  it('should allow CRUDS for leads/{id}/notes', () => {
+    let leadId = -1;
+    return cloud.post(test.api, leadsPayload)
+      .then(r => leadId = r.body.id)
+      .then(r => cloud.cruds(`${test.api}/${leadId}/notes`, notesPayload, chakram.put))
+      .then(r => cloud.post(`${test.api}/${leadId}/notes`, notesPayload))
+      .then(r => cloud.withOptions({ qs: { page: 1, pageSize: 1 } }).get(`${test.api}/${leadId}/notes`))
+      .then(r => expect(r.body.length).to.equal(1))
+      .then(r => cloud.delete(`${test.api}/${leadId}`));
+  });
+});

--- a/src/test/elements/zohocrmv2/opportunities.js
+++ b/src/test/elements/zohocrmv2/opportunities.js
@@ -1,0 +1,32 @@
+'use strict';
+
+const suite = require('core/suite');
+const cloud = require('core/cloud');
+const chakram = require('chakram');
+const expect = chakram.expect;
+const opportunitiesPayload = require('./assets/opportunities');
+const notesPayload = require('./assets/notes');
+
+suite.forElement('crm', 'opportunities', { payload: opportunitiesPayload }, (test) => {
+  test.should.supportCruds(chakram.put);
+  test.should.supportPagination();
+  test.withName(`should support searching ${test.api} by word`)
+    .withOptions({ qs: { where: 'word=\'Test\'' } })
+    .withValidation(r => {
+      expect(r).to.statusCode(200);
+      const validValues = r.body.filter(obj => JSON.stringify(obj).toLowerCase().indexOf('test'));
+      expect(validValues.length).to.equal(r.body.length);
+    })
+    .should.return200OnGet();
+
+    it('should allow CRUDS for opportunities/{id}/notes', () => {
+      let opportunityId = -1;
+      return cloud.post(test.api, opportunitiesPayload)
+        .then(r => opportunityId = r.body.id)
+        .then(r => cloud.cruds(`${test.api}/${opportunityId}/notes`, notesPayload, chakram.put))
+        .then(r => cloud.post(`${test.api}/${opportunityId}/notes`, notesPayload))
+        .then(r => cloud.withOptions({ qs: { page: 1, pageSize: 1 } }).get(`${test.api}/${opportunityId}/notes`))
+        .then(r => expect(r.body.length).to.equal(1))
+        .then(r => cloud.delete(`${test.api}/${opportunityId}`));
+    });
+});

--- a/src/test/elements/zohocrmv2/products.js
+++ b/src/test/elements/zohocrmv2/products.js
@@ -1,0 +1,21 @@
+'use strict';
+
+const suite = require('core/suite');
+const chakram = require('chakram');
+const expect = chakram.expect;
+const productsPayload = require('./assets/products');
+
+suite.forElement('crm', 'products', { payload: productsPayload }, (test) => {
+
+  test.should.supportCruds(chakram.put);
+  test.should.supportPagination();
+  test.withName(`should support searching ${test.api} by word`)
+    .withOptions({ qs: { where: 'word=\'Test\'' } })
+    .withValidation(r => {
+      expect(r).to.statusCode(200);
+      const validValues = r.body.filter(obj => JSON.stringify(obj).toLowerCase().indexOf('test'));
+      expect(validValues.length).to.equal(r.body.length);
+    })
+    .should.return200OnGet();
+
+});

--- a/src/test/elements/zohocrmv2/tasks.js
+++ b/src/test/elements/zohocrmv2/tasks.js
@@ -1,0 +1,19 @@
+'use strict';
+
+const suite = require('core/suite');
+const chakram = require('chakram');
+const expect = chakram.expect;
+const payload = require('./assets/tasks');
+
+suite.forElement('crm', 'tasks', { payload: payload }, (test) => {
+  test.should.supportCruds(chakram.put);
+  test.should.supportPagination();
+  test.withName(`should support searching ${test.api} by word`)
+    .withOptions({ qs: { where: 'word=\'Test\'' } })
+    .withValidation(r => {
+      expect(r).to.statusCode(200);
+      const validValues = r.body.filter(obj => JSON.stringify(obj).toLowerCase().indexOf('test'));
+      expect(validValues.length).to.equal(r.body.length);
+    })
+    .should.return200OnGet();
+});

--- a/src/test/elements/zohocrmv2/users.js
+++ b/src/test/elements/zohocrmv2/users.js
@@ -1,0 +1,15 @@
+'use strict';
+
+const suite = require('core/suite');
+const expect = require('chakram').expect;
+
+suite.forElement('crm', 'users', null, (test) => {
+  test.should.supportSr();
+  test.should.supportPagination();
+  test.withName(`should support searching ${test.api} by type`)
+    .withOptions({ qs: { type: 'CurrentUser' } })
+    .withValidation(r => {
+      expect(r.body.length).to.equal(1);
+    })
+    .should.return200OnGet();
+});


### PR DESCRIPTION
## Highlights
* Added test cases for following resources are added:
  - accounts
  - account notes
  - campaigns
  - contacts
  - contact notes
  - activities-calls
  - activities-events
  - cases
  - leads
  - lead notes
  - opportunities
  - opportunity notes
  - products
  - tasks
  - users



## Screenshot
PS C:\Git\churros> churros test elements/zohocrmv2

(node:12640) [DEP0022] DeprecationWarning: os.tmpDir() is deprecated. Use os.tmpdir() instead.

info: Using url: http://localhost:8080
info: Using user: mithila.garud@gslab.com
info: Using oauth username: zoho@cloud-elements.com
info: Using api key: 1000.OQED8XTSGYQ608895COSTV7639Q25R
info: Running tests for element: zohocrmv2
error: Failed to create or validate: /instances
error: Failed to create an instance of zohocrmv2
error: Failed to initialize element: Error: AssertionError [ERR_ASSERTION]: expected status code 400 to equal 200 - {"requestId":"5b3e01bc89c1dd63de5257da","message":"You must provide an OAuth
 code in order to create an instance of this element"}
PS C:\Git\churros>
PS C:\Git\churros> churros test elements/zohocrmv2

(node:30696) [DEP0022] DeprecationWarning: os.tmpDir() is deprecated. Use os.tmpdir() instead.

info: Using url: http://localhost:8080
info: Using user: mithila.garud@gslab.com
info: Using oauth username: zoho@cloud-elements.com
info: Using api key: 1000.OQED8XTSGYQ608895COSTV7639Q25R
info: Running tests for element: zohocrmv2
info: Provisioned with instance id of 46
(node:30696) [DEP0013] DeprecationWarning: Calling an asynchronous function without callback is deprecated.
  Basic tests
    √ should provision
    √ should GET /objects (569ms)
    - docs
    √ metadata (402ms)
error: Failed to retrieve or validate: /hubs/crm/notes
    1) transformations
    - should not allow provisioning with bad credentials

  accounts
    √ should allow ping for zohocrmv2 (367ms)
    √ should allow CRUDS for /hubs/crm/accounts (9603ms)
    √ should allow paginating with page and pageSize for /hubs/crm/accounts (25941ms)
    √ should support searching /hubs/crm/accounts by word (4338ms)
    √ should allow CRUDS for accounts/{id}/notes (11466ms)

  activities-calls
    √ should allow CRUDS for /hubs/crm/activities-calls (15321ms)
    √ should allow paginating with page and pageSize for /hubs/crm/activities-calls (18780ms)
    √ should support searching /hubs/crm/activities-calls by word (2082ms)

  activities-events
    √ should allow CRUDS for /hubs/crm/activities-events (21848ms)
    √ should allow paginating with page and pageSize for /hubs/crm/activities-events (42179ms)
    √ should support searching /hubs/crm/activities-events by word (1252ms)

  campaigns
    √ should allow CRUDS for /hubs/crm/campaigns (13422ms)
    √ should allow paginating with page and pageSize for /hubs/crm/campaigns (18507ms)
    √ should support searching /hubs/crm/campaigns by word (1209ms)

  cases
    √ should allow CRUDS for /hubs/crm/cases (7106ms)
    √ should allow paginating with page and pageSize for /hubs/crm/cases (4998ms)
    √ should support searching /hubs/crm/cases by word (1350ms)

  contacts
    √ should allow CRUDS for /hubs/crm/contacts (7651ms)
    √ should allow paginating with page and pageSize for /hubs/crm/contacts (3909ms)
    √ should support searching /hubs/crm/contacts by word (2034ms)
    √ should allow CRUDS for contacts/{id}/notes (10035ms)

  leads
    √ should allow CRUDS for /hubs/crm/leads (9629ms)
    √ should allow paginating with page and pageSize for /hubs/crm/leads (6496ms)
    √ should support searching /hubs/crm/leads by word (1483ms)
    √ should allow CRUDS for leads/{id}/notes (10281ms)

  opportunities
    √ should allow CRUDS for /hubs/crm/opportunities (6278ms)
    √ should allow paginating with page and pageSize for /hubs/crm/opportunities (3700ms)
    √ should support searching /hubs/crm/opportunities by word (1315ms)
    √ should allow CRUDS for opportunities/{id}/notes (12494ms)

  products
    √ should allow CRUDS for /hubs/crm/products (7660ms)
    √ should allow paginating with page and pageSize for /hubs/crm/products (6119ms)
    √ should support searching /hubs/crm/products by word (1329ms)

  tasks
    √ should allow CRUDS for /hubs/crm/tasks (13352ms)
    √ should allow paginating with page and pageSize for /hubs/crm/tasks (18547ms)
    √ should support searching /hubs/crm/tasks by word (4058ms)

  users
    √ should allow SR for /hubs/crm/users (4768ms)
    √ should allow paginating with page and pageSize for /hubs/crm/users (5073ms)
    √ should support searching /hubs/crm/users by type (1123ms)


  41 passing (6m)
  2 pending
  1 failing  

  1) Basic tests transformations:
     Error: AssertionError: expected 48 to equal 0
      at cloud.delete.catch.then.catch.then.then.catch.then (C:\Git\churros\src\test\elements\assets\basics.js:128:17)
      at _fulfilled (C:\Git\churros\node_modules\q\q.js:854:54)
      at self.promiseDispatch.done (C:\Git\churros\node_modules\q\q.js:883:30)
      at Promise.promise.promiseDispatch (C:\Git\churros\node_modules\q\q.js:816:13)
      at C:\Git\churros\node_modules\q\q.js:624:44
      at runSingle (C:\Git\churros\node_modules\q\q.js:137:13)
      at flush (C:\Git\churros\node_modules\q\q.js:125:13)
      at process._tickCallback (internal/process/next_tick.js:150:11)
  
## Reference
* [SOBA](https://github.com/cloud-elements/soba/pull/8990)
* [churros-sauce](https://github.com/cloud-elements/churros-sauce/pull/207)
* [RALLY-#US12545](https://rally1.rallydev.com/#/144349237612d/detail/userstory/227738829196)

## Closes
* [#US12545](https://rally1.rallydev.com/#/144349237612d/detail/userstory/227738829196)

