### PR TITLE
Facebook : Removed tests for deprecated APIs

### DIFF
--- a/src/test/elements/facebooksocial/search.js
+++ b/src/test/elements/facebooksocial/search.js
@@ -5,27 +5,12 @@ const cloud = require('core/cloud');
 
 suite.forElement('social', 'search', null, (test) => {
   it('should allow GET for hubs/social/status and then comments and likes by statusId ', () => {
-    let statusId; 
+    let statusId;
     return cloud.get('/hubs/social/status')
       .then(r => statusId = r.body[0].id)
       .then(r => cloud.get(`${test.api}/${statusId}/comments`))
       .then(r => cloud.withOptions({ qs: { page: 1, pageSize: 1 } }).get(`${test.api}/${statusId}/comments`))
       .then(r => cloud.get(`${test.api}/${statusId}/likes`))
       .then(r => cloud.withOptions({ qs: { page: 1, pageSize: 1 } }).get(`${test.api}/${statusId}/likes`));
-  });
-
-  it('should allow GET for /hubs/social/search/group', () => {
-    return cloud.withOptions({ qs: { searchGroup: 'TryStack' } }).get(`${test.api}/group`)
-      .then(r => cloud.withOptions({ qs: { searchGroup: 'TryStack', page: 1, pageSize: 1 } }).get(`${test.api}/group`));
-  });
-	
-  it('should allow GET for /hubs/social/search/page', () => {
-    return cloud.withOptions({ qs: { pageName: 'Linux' } }).get(`${test.api}/page`)
-      .then(r => cloud.withOptions({ qs: { pageName: 'Linux', page: 1, pageSize: 1 } }).get(`${test.api}/page`));
-  });
-	
-  it('should allow GET for /hubs/social/search/user', () => {
-    return cloud.withOptions({ qs: { userName: 'Cloud Eles' } }).get(`${test.api}/user`)
-      .then(r => cloud.withOptions({ qs: { userName: 'Cloud Eles', page: 1, pageSize: 1 } }).get(`${test.api}/user`));
   });
 });

--- a/src/test/elements/facebooksocial/status.js
+++ b/src/test/elements/facebooksocial/status.js
@@ -2,11 +2,8 @@
 
 const suite = require('core/suite');
 const cloud = require('core/cloud');
-const tools = require('core/tools');
-const payload = tools.requirePayload(`${__dirname}/assets/status.json`);
-const comments = tools.requirePayload(`${__dirname}/assets/statusComments.json`);
 
-suite.forElement('social', 'status', { payload: payload }, (test) => {
+suite.forElement('social', 'status', null, (test) => {
   let userId, photoId;
   it(`should allow GET user/{id}/photos`, () => {
     cloud.get(`user/me`)
@@ -14,23 +11,7 @@ suite.forElement('social', 'status', { payload: payload }, (test) => {
       .then(r => cloud.get(`user/${userId}/photos`))
       .then(r => photoId = r.body[0].id);
   });
-  payload.object_attachment = photoId;
-
-  test.should.supportCrds();
+  
+  test.should.supportSr();
   test.should.supportPagination();
-
-  it('should allow POST and DELETE likes', () => {
-    let pageId,accessToken,statusId,commentId;
-    return cloud.get(`/hubs/social/pages`)
-      .then(r => pageId = r.body[0].id)
-      .then(r => cloud.get(`/hubs/social/pages/${pageId}/page-access-token`))
-      .then(r => accessToken = r.body.access_token)
-      .then(r => cloud.post(`/hubs/social/user/${pageId}/status`,payload))
-      .then(r => statusId = r.body.id)
-      .then(r => cloud.withOptions({ qs: {pageToken: accessToken } }).post(`/hubs/social/status/${statusId}/like`))
-      .then(r => cloud.withOptions({ qs: {pageToken: accessToken } }).post(`/hubs/social/status/${statusId}/comments`,comments))
-      .then(r => commentId = r.body.id)
-      .then(r => cloud.withOptions({ qs: {pageToken: accessToken } }).delete(`/hubs/social/user/comment/${commentId}`))
-      .then(r => cloud.withOptions({ qs: {pageToken: accessToken } }).delete(`/hubs/social/user/likes/${statusId}`));
-  });
 });

--- a/src/test/elements/facebooksocial/user.js
+++ b/src/test/elements/facebooksocial/user.js
@@ -2,11 +2,9 @@
 
 const suite = require('core/suite');
 const cloud = require('core/cloud');
-const tools = require('core/tools');
-const payload = tools.requirePayload(`${__dirname}/assets/status.json`);
 
-suite.forElement('social', 'user',{ payload:payload }, (test) => {
-  let userId,statusId;
+suite.forElement('social', 'user', null, (test) => {
+  let userId;
   it('should allow GET for hubs/social/user/me and GET user by id ', () => {
     return cloud.get(`${test.api}/me`)
       .then(r => userId = r.body.id)
@@ -23,24 +21,14 @@ suite.forElement('social', 'user',{ payload:payload }, (test) => {
       .then(r =>cloud.get(`${test.api}/${userId}/accounts`));
   });
 
-  it('should allow CRD for hubs/social/user/{id}/photos ', () => {
-    let path = __dirname + '/assets/temp.jpg';
-    let photoId;
+  it('should allow GET for hubs/social/user/{id}/photos ', () => {
     return cloud.withOptions({ qs: { type:'uploaded' } }).get(`${test.api}/${userId}/photos`)
-      .then(r => cloud.withOptions({ qs: { type:'uploaded', page: 1, pageSize: 1 } }).get(`${test.api}/${userId}/photos`))
-      .then(r => cloud.withOptions({ qs: { caption:'sample' } }).postFile(`${test.api}/${userId}/photos`, path))
-      .then(r => photoId = r.body.id)
-      .then(r =>cloud.delete(`${test.api}/photo/${photoId}`));
+      .then(r => cloud.withOptions({ qs: { type:'uploaded', page: 1, pageSize: 1 } }).get(`${test.api}/${userId}/photos`));
   });
 
-  it('should allow CRD for hubs/social/user/{id}/videos ', () => {
-    let path = __dirname + '/assets/temp.3gp';
-    let videoId;
+  it('should allow GET for hubs/social/user/{id}/videos ', () => {
     return cloud.withOptions({ qs: { type:'uploaded' } }).get(`${test.api}/${userId}/videos`)
-      .then(r => cloud.withOptions({ qs: { type:'uploaded', page: 1, pageSize: 1 } }).get(`${test.api}/${userId}/videos`))
-      .then(r => cloud.withOptions({ qs: { title:'sample' } }).postFile(`${test.api}/${userId}/videos`, path))
-      .then(r => videoId = r.body.id)
-      .then(r =>cloud.delete(`${test.api}/video/${videoId}`));
+      .then(r => cloud.withOptions({ qs: { type:'uploaded', page: 1, pageSize: 1 } }).get(`${test.api}/${userId}/videos`));
   });
 
   it('should allow GET for hubs/social/user/{id}/likes ', () => {
@@ -48,16 +36,9 @@ suite.forElement('social', 'user',{ payload:payload }, (test) => {
       .then(r => cloud.withOptions({ qs: { page: 1, pageSize: 1 } }).get(`${test.api}/${userId}/likes`));
   });
 
-  it('should allow Cr for hubs/social/user/{id}/status ', () => {
+  it('should allow GET for hubs/social/user/{id}/status ', () => {
     return cloud.get(`${test.api}/${userId}/status`)
-      .then(r => cloud.withOptions({ qs: { page: 1, pageSize: 1 } }).get(`${test.api}/${userId}/status`))
-      .then(r =>cloud.post(`${test.api}/${userId}/status`,payload))
-      .then(r => statusId = r.body.id);
+      .then(r => cloud.withOptions({ qs: { page: 1, pageSize: 1 } }).get(`${test.api}/${userId}/status`));
   });
-  it('should allow GET for hubs/social/user/context/{id}', () => {
-    let contextId;
-    return cloud.get(`${test.api}/me`)
-      .then(r => contextId = r.body.context.id)
-      .then(r =>cloud.get(`${test.api}/context/${contextId}`));
-  });
+
 });


### PR DESCRIPTION
## Highlights
* As we have migrated to 3.0 API and deprecated APIs has been removed from the Facebook element, removed churros tests for deprecated APIs
* Churros instance creation is failing as of now because I'm unable to set the redirect uri as the app is under review.
![churrosintancecreationfailure](https://user-images.githubusercontent.com/37102802/42376611-60573eac-813d-11e8-9f3a-0f2ab1055ed9.PNG)

## Screenshot
![churrosfinal](https://user-images.githubusercontent.com/37102802/42376465-de12fb0c-813c-11e8-8a77-b66dc2c2a79a.PNG)

## Reference
* [SOBA](https://github.com/cloud-elements/soba/pull/8998)
* [RALLY-#${US12232](https://rally1.rallydev.com/#/144349237612d/detail/userstory/223891389748)

## Closes
* [US12232](https://rally1.rallydev.com/#/144349237612d/detail/userstory/223891389748)
