### PR TITLE
Jira : Added tests for 'groups' APIs

### DIFF
--- a/src/test/elements/jira/groups.js
+++ b/src/test/elements/jira/groups.js
@@ -1,12 +1,9 @@
 'use strict';
-
 const suite = require('core/suite');
-
 const cloud = require('core/cloud');
 const expect = require('chakram').expect;
 
-suite.forElement('helpdesk', 'groups', null, (test) => {
-
+suite.forElement('helpdesk', 'groups', (test) => {
   it('should allow SR for groups', () => {
     let groupname;
     return cloud.get('/hubs/helpdesk/groups')
@@ -20,7 +17,5 @@ suite.forElement('helpdesk', 'groups', null, (test) => {
       expect(r).to.statusCode(200);
       const validValues = r.body.filter(obj => JSON.stringify(obj).toLowerCase().indexOf('admin'));
       expect(validValues.length).to.equal(r.body.length);
-    })
-    .should.return200OnGet();
-
+    }).should.return200OnGet();
 });

--- a/src/test/elements/jira/groups.js
+++ b/src/test/elements/jira/groups.js
@@ -1,0 +1,26 @@
+'use strict';
+
+const suite = require('core/suite');
+
+const cloud = require('core/cloud');
+const expect = require('chakram').expect;
+
+suite.forElement('helpdesk', 'groups', null, (test) => {
+
+  it('should allow SR for groups', () => {
+    let groupname;
+    return cloud.get('/hubs/helpdesk/groups')
+      .then(r => groupname = r.body[0].name)
+      .then(r => cloud.get(`${test.api}/${groupname}`));
+  });
+  test.should.supportPagination();
+  test.withOptions({ qs: { where: `query='admin'` } })
+    .withName('should support search by filter')
+    .withValidation(r => {
+      expect(r).to.statusCode(200);
+      const validValues = r.body.filter(obj => JSON.stringify(obj).toLowerCase().indexOf('admin'));
+      expect(validValues.length).to.equal(r.body.length);
+    })
+    .should.return200OnGet();
+
+});


### PR DESCRIPTION
## Highlights
* Added churros tests for newly added `groups` APIs
* For API `GET /groups/{groupname}`, 'groupname' is path parameter for CE and query parameter for vendor. Thus I have not used test.should.supportSr() 

## Screenshot
![image](https://user-images.githubusercontent.com/37102802/42443973-9136d1d0-838c-11e8-8acc-e59739ac9758.png)
![image](https://user-images.githubusercontent.com/37102802/42443993-a4a4ed1a-838c-11e8-8d43-c7cf0c4373d6.png)



## Reference
* [SOBA](https://github.com/cloud-elements/soba/pull/9002)
* [RALLY-#${DE2015}](https://rally1.rallydev.com/#/144349237612d/detail/defect/231549189776)

## Closes
* [DE2015](https://rally1.rallydev.com/#/144349237612d/detail/defect/231549189776)
