### PR TITLE
SFDC: Fixed failing churros tests

### DIFF
--- a/src/test/elements/sfdc/bulk.js
+++ b/src/test/elements/sfdc/bulk.js
@@ -3,13 +3,24 @@
 const suite = require('core/suite');
 const cloud = require('core/cloud');
 const tools = require('core/tools');
+const parentPayload = tools.requirePayload(`${__dirname}/assets/accounts.json`);
+const childPayload = tools.requirePayload(`${__dirname}/assets/accounts.json`);
 const expect = require('chakram').expect;
 
 suite.forElement('crm', 'bulk', null, (test) => {
+  let parentId, childId;
+  before(() => cloud.post('/hubs/crm/accounts', parentPayload)
+    .then(r => parentId = r.body.id)
+    .then(r => childPayload.ParentId = parentId)
+    .then(r => cloud.post('/hubs/crm/accounts', childPayload))
+    .then(r => childId = r.body.id));
+
+  after(() => cloud.delete(`/hubs/crm/accounts/${parentId}`)
+    .then(r => cloud.delete(`/hubs/crm/accounts/${childId}`)));
 
   it('should support parent references', () => {
     let bulkId;
-    const opts = { qs: { q: "select Name, Parent.Name from Account where Name='Child'" } };
+    const opts = { qs: { q: `select Name, Parent.Name from Account where Name='${childPayload.name}'` } };
 
     // start bulk download
     return cloud.withOptions(opts).post('/hubs/crm/bulk/query')
@@ -23,9 +34,9 @@ suite.forElement('crm', 'bulk', null, (test) => {
         expect(r.body.recordsCount > 0).to.be.true;
         expect(r.body.recordsFailedCount).to.equal(0);
       })))
-      .then(r => cloud.withOptions({ headers: { accept: "text/csv" }}).get(`/hubs/crm/bulk/${bulkId}/accounts`, r => {
+      .then(r => cloud.withOptions({ headers: { accept: "text/csv" } }).get(`/hubs/crm/bulk/${bulkId}/accounts`, r => {
         expect(r.body).to.contain('Name,Parent.Name');
-        expect(r.body).to.contain('Child,Parent');
+        expect(r.body).to.contain(`${childPayload.name},${parentPayload.name}`);
       }));
   });
 

--- a/src/test/elements/sfdc/metadata.js
+++ b/src/test/elements/sfdc/metadata.js
@@ -5,8 +5,11 @@ const suite = require('core/suite');
 const cloud = require('core/cloud');
 const expect = require('chakram').expect;
 const resources = require('./assets/objects');
+const faker = require('faker');
 
 suite.forElement('crm', 'metadata', (test) => {
+const churrosTestObject = faker.random.word();
+const churrosTestNestedObject = faker.random.word();
 
   test.withApi('/hubs/crm/objects') //using specified api
     .withValidation(r => expect(r.body).to.include('Account')) //validating the response is what we expect
@@ -85,32 +88,32 @@ suite.forElement('crm', 'metadata', (test) => {
     'should include filterable, createable, and updateable for canonical object metadata').should.return200OnGet();
 
   it('should have email property with filterable, createable, and updateable metadata for VDR', () => {
-    return cloud.post('/organizations/objects/churrosTestObject/definitions', resources.churrosTestObject, () => {})
-      .then(r => cloud.post('/organizations/elements/sfdc/transformations/churrosTestObject', resources.churrosTestObjectXform, () => {}))
-      .then(r => cloud.get('/objects/churrosTestObject/metadata'))
+    return cloud.post(`/organizations/objects/${churrosTestObject}/definitions`, resources.churrosTestObject, () => {})
+      .then(r => cloud.post(`/organizations/elements/sfdc/transformations/${churrosTestObject}`, resources.churrosTestObjectXform, () => {}))
+      .then(r => cloud.get(`/objects/${churrosTestObject}/metadata`))
       .then(r => validEmail(r))
-      .then(r => cloud.delete('/organizations/elements/sfdc/transformations/churrosTestObject'))
-      .then(r => cloud.delete('/organizations/objects/churrosTestObject/definitions'));
+      .then(r => cloud.delete(`/organizations/elements/sfdc/transformations/${churrosTestObject}`))
+      .then(r => cloud.delete(`/organizations/objects/${churrosTestObject}/definitions`));
   });
 
   it('should include only mapped fields for VDR metadata', () => {
-    return cloud.post('/organizations/objects/churrosTestObject/definitions', resources.churrosTestObject, () => {})
-      .then(r => cloud.post('/organizations/elements/sfdc/transformations/churrosTestObject', resources.churrosTestObjectXform, () => {}))
-      .then(r => cloud.get('/objects/churrosTestObject/metadata'))
+    return cloud.post(`/organizations/objects/${churrosTestObject}/definitions`, resources.churrosTestObject, () => {})
+      .then(r => cloud.post(`/organizations/elements/sfdc/transformations/${churrosTestObject}`, resources.churrosTestObjectXform, () => {}))
+      .then(r => cloud.get(`/objects/${churrosTestObject}/metadata`))
       .then(r => validVdrMetadata(r))
-      .then(r => cloud.delete('/organizations/elements/sfdc/transformations/churrosTestObject'))
-      .then(r => cloud.delete('/organizations/objects/churrosTestObject/definitions'));
+      .then(r => cloud.delete(`/organizations/elements/sfdc/transformations/${churrosTestObject}`))
+      .then(r => cloud.delete(`/organizations/objects/${churrosTestObject}/definitions`));
   });
 
   it('should support VDR metadata for nested objects', () => {
-    return cloud.post('/organizations/objects/churrosTestNestedObject/definitions', resources.churrosTestNestedObject, () => {})
-      .then(r => cloud.post('/organizations/objects/churrosTestObject/definitions', resources.churrosTestObject, () => {}))
-      .then(r => cloud.post('/organizations/elements/sfdc/transformations/churrosTestObject', resources.churrosTestObjectXform, () => {}))
-      .then(r => cloud.get('/objects/churrosTestObject/metadata'))
+    return cloud.post(`/organizations/objects/${churrosTestNestedObject}/definitions`, resources.churrosTestNestedObject, () => {})
+      .then(r => cloud.post(`/organizations/objects/${churrosTestObject}/definitions`, resources.churrosTestObject, () => {}))
+      .then(r => cloud.post(`/organizations/elements/sfdc/transformations/${churrosTestObject}`, resources.churrosTestObjectXform, () => {}))
+      .then(r => cloud.get(`/objects/${churrosTestObject}/metadata`))
       .then(r => validVdrMetadataForNestedObject(r))
-      .then(r => cloud.delete('/organizations/elements/sfdc/transformations/churrosTestObject'))
-      .then(r => cloud.delete('/organizations/objects/churrosTestObject/definitions'))
-      .then(r => cloud.delete('/organizations/objects/churrosTestNestedObject/definitions'));
+      .then(r => cloud.delete(`/organizations/elements/sfdc/transformations/${churrosTestObject}`))
+      .then(r => cloud.delete(`/organizations/objects/${churrosTestObject}/definitions`))
+      .then(r => cloud.delete(`/organizations/objects/${churrosTestNestedObject}/definitions`));
   });
 
   test.withApi('/objects/contacts/metadata').withValidation(metaValid).withName(


### PR DESCRIPTION
## Highlights
* Fixed failing tests for `bulk` and `metadata` objects.
* Removed hardcoded names in bulk download query test.

## Screenshot
  - Report- [sfdc churros.txt](https://github.com/cloud-elements/churros/files/2204692/sfdc.churros.txt)
Churros are run on two different accounts as API limit was exhausted for first Salesforce account

## Reference
* [RALLY-DE2149](https://rally1.rallydev.com/#/144349237612ud/detail/defect/238018763604?fdp=true)

## Closes
* [DE2149](https://rally1.rallydev.com/#/144349237612ud/detail/defect/238018763604?fdp=true)
