### PR TITLE
Slack: Added ceql test for GET channels

### DIFF
--- a/src/test/elements/slack/channels.js
+++ b/src/test/elements/slack/channels.js
@@ -37,6 +37,14 @@ suite.forElement('collaboration', 'channels', (test) => {
   //test for GET channels
   test.should.return200OnGet();
   test.should.supportPagination();
+  test
+    .withOptions({ qs: { where: `exclude_members = 'true'` } })
+    .withName(`should support Ceql search for ${test.api}`)
+    .withValidation(r => {
+      expect(r).to.statusCode(200);
+      const validValues = r.body.filter(obj => obj.members === undefined);
+    })
+    .should.return200OnGet();
 
   //tests for /messages apis
   let timestamp;

--- a/src/test/elements/slack/channels.js
+++ b/src/test/elements/slack/channels.js
@@ -43,6 +43,7 @@ suite.forElement('collaboration', 'channels', (test) => {
     .withValidation(r => {
       expect(r).to.statusCode(200);
       const validValues = r.body.filter(obj => obj.members === undefined);
+      expect(validValues.length).to.equal(r.body.length);
     })
     .should.return200OnGet();
 


### PR DESCRIPTION
## Highlights
* Added ceql test for GET channels.

## Screenshot
  - Report - [slack churros.txt](https://github.com/cloud-elements/churros/files/2205325/slack.churros.txt)
  -Raised [DE ](https://rally1.rallydev.com/#/144349237612ud/detail/defect/238399140816?fdp=true)for failing tests.


## Reference
* [SOBA](https://github.com/cloud-elements/soba/pull/9043)
* [RALLY-#DE2110](https://rally1.rallydev.com/#/144349237612ud/detail/defect/236266830044)

## Closes
* Closes [#DE2110](https://rally1.rallydev.com/#/144349237612ud/detail/defect/236266830044)
