### PR TITLE
Added bulk test cases to Netuite ERP V2

### DIFF
--- a/src/test/elements/netsuiteerpv2/bulk.js
+++ b/src/test/elements/netsuiteerpv2/bulk.js
@@ -3,7 +3,7 @@
 const suite = require('core/suite');
 
 suite.forElement('erp', 'bulk', null, (test) => {
-  const opts = {csv: true, json: false, timeout: 90000};
-  test.should.supportBulkDownload({ qs: { q: 'select * from employee' } }, opts, 'employee');
-  test.should.supportBulkDownload({ qs: { q: 'select lastName,isSupportRep,title from employee' } }, opts, 'employee');
+  const opts = {csv: true, json: false, timeout: 60000};
+  test.should.supportBulkDownload({ qs: { q: 'select * from employee limit 5' } }, opts, 'employee');
+  test.should.supportBulkDownload({ qs: { q: 'select lastName,isSupportRep,title from employee limit 5' } }, opts, 'employee');
 });

--- a/src/test/elements/netsuiteerpv2/bulk.js
+++ b/src/test/elements/netsuiteerpv2/bulk.js
@@ -1,0 +1,9 @@
+'use strict';
+
+const suite = require('core/suite');
+
+suite.forElement('erp', 'bulk', null, (test) => {
+  const opts = {csv: true, json: false, timeout: 90000};
+  test.should.supportBulkDownload({ qs: { q: 'select * from employee' } }, opts, 'employee');
+  test.should.supportBulkDownload({ qs: { q: 'select lastName,isSupportRep,title from employee' } }, opts, 'employee');
+});


### PR DESCRIPTION
## Non-customer Highlights
* Added test cases for Netsuite ERP bulk download:
  - All fields query
  - Only specific fields query

## Screenshot
PS C:\Users\GS-1026> churros test elements/netsuiteerpv2 --file bulk

(node:7784) [DEP0022] DeprecationWarning: os.tmpDir() is deprecated. Use os.tmpdir() instead.

info: Using url: http://localhost:8080
info: Using user: mithila.garud@gslab.com
info: Running tests for element: netsuiteerpv2
info: Provisioned with instance id of 87
(node:7784) [DEP0013] DeprecationWarning: Calling an asynchronous function without callback is deprecated.
  Basic tests
    √ should provision
    √ should GET /objects (448ms)
    - docs
    √ metadata (210ms)
error: Failed to delete /instances/87/transformations
    √ transformations (23058ms)
    - should not allow provisioning with bad credentials

  bulk
error: Failed to retrieve or validate: /hubs/erp/bulk/147/status
error: Failed to retrieve or validate: /hubs/erp/bulk/147/status
error: Failed to retrieve or validate: /hubs/erp/bulk/147/status
error: Failed to retrieve or validate: /hubs/erp/bulk/147/status
error: Failed to retrieve or validate: /hubs/erp/bulk/147/status
    √ should support bulk download with options (24040ms)
error: Failed to retrieve or validate: /hubs/erp/bulk/148/status
error: Failed to retrieve or validate: /hubs/erp/bulk/148/status
error: Failed to retrieve or validate: /hubs/erp/bulk/148/status
error: Failed to retrieve or validate: /hubs/erp/bulk/148/status
error: Failed to retrieve or validate: /hubs/erp/bulk/148/status
error: Failed to retrieve or validate: /hubs/erp/bulk/148/status
    √ should support bulk download with options (25008ms)


  6 passing (2m)
  2 pending

## Reference
* [SOBA](https://github.com/cloud-elements/soba/pull/9049)
* [RALLY-#DE2095](https://rally1.rallydev.com/#/144349237612d/detail/defect/235670822556)

## Closes
* [#DE2095](https://rally1.rallydev.com/#/144349237612d/detail/defect/235670822556)
