### PR TITLE
Added test for /contents

### DIFF
--- a/src/test/elements/slack/files.js
+++ b/src/test/elements/slack/files.js
@@ -2,6 +2,7 @@
 
 const suite = require('core/suite');
 const cloud = require('core/cloud');
+const expect = require('chakram').expect;
 const commentPayload = require('./assets/comment');
 
 suite.forElement('collaboration', 'files', (test) => {
@@ -18,7 +19,17 @@ suite.forElement('collaboration', 'files', (test) => {
 
   //Test for get files
   test.withOptions({ qs: { 'where': 'types = \'images\'' } }).should.return200OnGet();
-  test.should.supportPagination('id');
+  it(`should support GET and pagination for ${test.api}`, () => {
+    return cloud.get(`${test.api}`)
+      .then(r => cloud.withOptions({ qs: { page: 1, pageSize: 1 } }).get(`${test.api}`));
+  });
+
+  it(`should allow RETRIEVE ${test.api}/contents`, () => {
+    let fileid;
+    return cloud.get(test.api)
+      .then(r => fileid = r.body[0].id)
+      .then(r => cloud.get(`${test.api}/${fileid}/contents`));
+  });
 
   //test for CRD operations on files
   it(`should allow SR ${test.api}`, () => {

--- a/src/test/elements/slack/files.js
+++ b/src/test/elements/slack/files.js
@@ -18,10 +18,7 @@ suite.forElement('collaboration', 'files', (test) => {
 
   //Test for get files
   test.withOptions({ qs: { 'where': 'types = \'images\'' } }).should.return200OnGet();
-  it(`should support GET and pagination for ${test.api}`, () => {
-    return cloud.get(`${test.api}`)
-      .then(r => cloud.withOptions({ qs: { page: 1, pageSize: 1 } }).get(`${test.api}`));
-  });
+  test.should.supportPagination('id');
 
   it(`should allow RETRIEVE ${test.api}/contents`, () => {
     let fileid;

--- a/src/test/elements/slack/files.js
+++ b/src/test/elements/slack/files.js
@@ -2,7 +2,6 @@
 
 const suite = require('core/suite');
 const cloud = require('core/cloud');
-const expect = require('chakram').expect;
 const commentPayload = require('./assets/comment');
 
 suite.forElement('collaboration', 'files', (test) => {


### PR DESCRIPTION
## Highlights
* Added test for /files/{fileId}/contents API.
* Pagination test is failing for which [DE2151](https://rally1.rallydev.com/#/144349237612d/detail/defect/238399140816) is already raised.

## Screenshot
![image](https://user-images.githubusercontent.com/22442264/43067634-89068556-8e85-11e8-8a8e-bc81e8befd3a.png)
![image](https://user-images.githubusercontent.com/22442264/43067704-c3faa2b4-8e85-11e8-8dcc-ac918e18826d.png)
![image](https://user-images.githubusercontent.com/22442264/43067713-cc49a4c4-8e85-11e8-911a-0410a58fe672.png)

## Reference
* [SOBA](https://github.com/cloud-elements/soba/pull/9059)
* [RALLY-US13236](https://rally1.rallydev.com/#/144349237612d/detail/userstory/239219008916)

## Closes
* [US13236](https://rally1.rallydev.com/#/144349237612d/detail/userstory/239219008916)
