### PR TITLE
Jira: Removed where clause from test cases

### DIFF
--- a/src/test/elements/jira/assets/projects.json
+++ b/src/test/elements/jira/assets/projects.json
@@ -1,6 +1,6 @@
 {
-   "name": "Ax123",
+   "name": "Ax323",
    "projectTypeKey": "business",
-   "key": "AX123",
+   "key": "AX1123",
    "lead":"kevin"
 }

--- a/src/test/elements/jira/incidentTypes.js
+++ b/src/test/elements/jira/incidentTypes.js
@@ -14,7 +14,7 @@ suite.forElement('helpdesk', 'incidentTypes', {payload:payload}, (test) => {
   let incidentTypeId;
   return cloud.post(uri, payload)
   .then(r => incidentTypeId = r.body.id)
-  .then(r => cloud.withOptions({qs:{ where: `id='${incidentTypeId}'` }}).get('/hubs/helpdesk/incident-types'))
+  .then(r => cloud.get('/hubs/helpdesk/incident-types'))
   .then(r => cloud.get(uri + "/" + incidentTypeId))
   .then(r => cloud.get(uri))
   .then(r => cloud.update(uri + '/' + incidentTypeId, updatePayload))


### PR DESCRIPTION
## Highlights
* Removed `where` clause from test cases, as vendor doesn't supports where clause from `/incident-types` API


## Screenshot
```
PS C:\Users\gs-1108\Documents\GitHub\churros> churros test elements/jira

(node:14656) [DEP0022] DeprecationWarning: os.tmpDir() is deprecated. Use os.tmpdir() instead.

info: Using url: https://staging.cloud-elements.com
info: Using user: abhay.pore@gslab.com
info: Using oauth username: jiradev
info: Running tests for element: jira
info: Provisioned with instance id of 103432
(node:14656) [DEP0013] DeprecationWarning: Calling an asynchronous function without callback is deprecated.
  Basic tests
    √ should provision
    √ should GET /objects (1054ms)
    - docs
    √ metadata (1670ms)
    √ transformations (18339ms)
    - should not allow provisioning with bad credentials

  agents
    √ should allow get for /agents (4307ms)

  contacts
    √ should allow CRUDS for /hubs/helpdesk/contacts with Ceql search (9771ms)
    √ should allow CRUDS for /hubs/helpdesk/contacts with special characters & Ceql search (9803ms)
    √ should allow paginating with page and pageSize for /hubs/helpdesk/contacts (3929ms)
error: Failed to delete /hubs/helpdesk/contacts/t4wpi5
error: Failed to delete /hubs/helpdesk/contacts/tfpnlv

  fields
    - should allow create and get of fields

  groups
    √ should allow SR for groups (2714ms)
    √ should allow paginating with page and pageSize for /hubs/helpdesk/groups (7477ms)
    √ should support search by filter (1383ms)

  incidents
    √ should allow CRUDS for /hubs/helpdesk/incidents (15863ms)
    √ should allow paginating with page and pageSize for /hubs/helpdesk/incidents (5382ms)
    √ should support searching /hubs/helpdesk/incidents by id (5295ms)
    √ should allow CRUDS for /incidents/:id/comments (11217ms)
    √ should allow CS for /incidents/:id/attachments and RD for /attachments (13593ms)
    √ should allow SR for /incidents/:id/history (10251ms)
    √ should allow creating for /incidents/:id/notifications (10682ms)
    √ should allow CRUDS for /incidents/:id/properties (10092ms)
    √ should allow GET /incidents with option defaultFields LIKE (1492ms)
    √ should allow GET /incidents with option customfields (1596ms)

  incidentTypes
    √ should allow CRUDS for /incidents-types (11825ms)

  priorities
    √ should allow CRUDS for /priorities (2774ms)

  projects
    √ should allow CRUDS for /hubs/helpdesk/projects (10436ms)
    √ should allow paginating with page and pageSize for /hubs/helpdesk/projects (4369ms)
    √ should allow GET for /hubs/helpdesk/projects (2378ms)

  statuses
    √ should allow CRUDS for /statuses (3170ms)

  worklogs
    √ should allow S for /hubs/helpdesk/worklogs (1349ms)
    √ should allow S for /hubs/helpdesk/worklogs (1404ms)
    √ should allow S for /hubs/helpdesk/worklogs (1482ms)
    √ should allow paginating with page and pageSize for /hubs/helpdesk/worklogs (4505ms)


  31 passing (4m)
  3 pending
```

## Reference
* [SOBA](https://github.com/cloud-elements/soba/pull/9067)
* [RALLY-#${DE1405}](https://rally1.rallydev.com/#/144349237612d/detail/defect/214004565004)

## Closes
* [DE1405](https://rally1.rallydev.com/#/144349237612d/detail/defect/214004565004)
