### PR TITLE
Stripe: Fixed input schema issue for /charges/{id}/capture API

### DIFF
--- a/src/test/elements/stripe/assets/capture.json
+++ b/src/test/elements/stripe/assets/capture.json
@@ -1,0 +1,5 @@
+{
+"amount":60,
+"receipt_email":"<<internet.email>>",
+"statement_descriptor":"Test Descriptor"
+}

--- a/src/test/elements/stripe/charges.js
+++ b/src/test/elements/stripe/charges.js
@@ -5,6 +5,7 @@ const tools = require('core/tools');
 const cloud = require('core/cloud');
 const payload = require('./assets/charges');
 const expect = require('chakram').expect;
+const capture_payload = tools.requirePayload(`${__dirname}/assets/capture.json`);
 
 const updateCharges = () => ({
   "receipt_email": tools.randomEmail()
@@ -17,7 +18,7 @@ suite.forElement('payment', 'charges', { payload: payload }, (test) => {
     return cloud.post(test.api, payload)
       .then(r => chargeId = r.body.id)
       .then(r => cloud.patch(`${test.api}/${chargeId}`, updateCharges()))
-      .then(r => cloud.post(`${test.api}/${chargeId}/capture`))
+      .then(r => cloud.post(`${test.api}/${chargeId}/capture`,capture_payload))
       .then(r => cloud.withOptions({ qs: { where: `currency='usd' and  created=1485255289` } }).get(test.api));
   });
   


### PR DESCRIPTION
## Highlights
* Added payload for /charges/{id}/capture test cases.

## Screenshot
```
PS C:\Users\gs-1108\Documents\GitHub\churros> churros --instance 481 test elements/stripe

(node:21740) [DEP0022] DeprecationWarning: os.tmpDir() is deprecated. Use os.tmpdir() instead.

info: Using url: http://localhost:8080
info: Using user: pore@gslab.com
info: Using oauth username: sk_test_HZ6dO9HizZtYuHcO8Up9kmjI
info: Running tests for element: stripe
info: Provisioned with instance id of 481
error: Failed to create or validate: /instances/481/objects/charges/definitions
error: Failed to create or validate: /instances/481/objects/charges/definitions
error: Failed to create or validate: /instances/481/transformations/charges
error: Failed to create or validate: /instances/481/transformations/charges
  Basic tests
    √ should provision
    √ should GET /objects (5302ms)
    - docs
    √ metadata (290ms)
error: Failed to retrieve or validate: /hubs/payment/tokens
error: Failed to retrieve or validate: /hubs/payment/payment-methods
    √ transformations (160966ms)
    - should not allow provisioning with bad credentials

  balances
    √ should allow GET for /hubs/payment/balances (8014ms)

  charges
    √ should allow CRS for /hubs/payment/charges (20273ms)
    √ should allow CUS for /hubs/payment/charges (8483ms)
    √ should support searching /hubs/payment/charges by created (1663ms)
    √ should support searching /hubs/payment/charges by customer (1780ms)
    √ should support searching /hubs/payment/charges by transfer_group (1719ms)
    √ should support searching /hubs/payment/charges by nested fields source.object (11375ms)
    √ should allow paginating with page and pageSize for /hubs/payment/charges (5413ms)
    √ should allow paginating with page and nextPage /hubs/payment/charges (1790ms)

  customers
    √ should allow CRUDS for /hubs/payment/customers (15312ms)
    √ should allow GET for /hubs/payment/customers (5929ms)
    √ should allow paginating with page and pageSize for /hubs/payment/customers (5272ms)
    √ should allow paginating with page and nextPage /hubs/payment/customers (1690ms)

  events
    √ should allow GET for /hubs/payment/events (4791ms)
    √ should allow paginating with page and pageSize for /hubs/payment/events (4888ms)
    √ should allow paginating with page and nextPage /hubs/payment/events (1688ms)

  payment-methods
    √ should allow GET for /hubs/payment/customers/{customerId}/payment-methods (3478ms)
    √ should allow CRUD for /hubs/payment/customers/{customerId}/payment-methods/{paymentId} (7793ms)

  ping
    √ should allow GET for /hubs/payment/ping (1293ms)

  plans
    √ should allow CRUDS for /hubs/payment/plans (9952ms)
    √ should allow GET for /hubs/payment/plans (3036ms)
    √ should allow paginating with page and pageSize for /hubs/payment/plans (5082ms)
    √ should allow paginating with page and nextPage /hubs/payment/plans (1686ms)
    √ Should support create plan on existing and non-existing product (12856ms)

  polling
    - polling /hubs/payment/customers
    - polling /hubs/payment/plans
    - polling /hubs/payment/products

  products
    √ should allow CRUDS for /hubs/payment/products (8577ms)
    √ should allow GET for /hubs/payment/products (2077ms)
    √ should allow paginating with page and pageSize for /hubs/payment/products (5120ms)
    √ should allow paginating with page and nextPage /hubs/payment/products (1669ms)

  refunds
    √ should allow CRU for /hubs/payment/charges/{chargeId}/refunds (7216ms)
    √ should allow GET for /hubs/payment/refunds (4347ms)
    √ should allow paginating with page and nextPage /hubs/payment/refunds (1615ms)

  subscriptions
    √ should allow paginating with page and nextPage /hubs/payment/subscriptions (3497ms)
    √ should allow CRUDS for /hubs/payment/subscriptions (13879ms)
    √ should allow CRUD for /hubs/payment/customers/{customerId}/subscriptions/{subscriptionId} (8973ms)

  tokens
    √ should allow GET for /hubs/payment/tokens/tok_182kUjGdZbyQGmEeaRuzEj4F (1678ms)

  transactions
    √ should allow GET for /hubs/payment/transactions (5983ms)
    √ should allow GET for /hubs/payment/transactions/{transactionId} (14317ms)
    √ should allow paginating with page and nextPage /hubs/payment/transactions (1612ms)

  transfers
    √ should allow SR for /hubs/payment/transfers (6727ms)
    √ should allow PATCH for /hubs/payment/transfers (11054ms)
    √ should allow paginating with page and nextPage /hubs/payment/transfers (1646ms)


  45 passing (7m)
  5 pending
```
## Reference
* [SOBA](https://github.com/cloud-elements/soba/pull/9083)
* [RALLY-#${DE2194}](https://rally1.rallydev.com/#/144349237612d/detail/defect/240102537396)

## Closes
* [DE2194](https://rally1.rallydev.com/#/144349237612d/detail/defect/240102537396)
