### PR TITLE
GoogleDrive : Added tests for Files Permissions API

### DIFF
--- a/src/test/elements/googledrive/assets/permission.json
+++ b/src/test/elements/googledrive/assets/permission.json
@@ -1,0 +1,4 @@
+{
+	"role": "reader",
+	"type": "anyone"
+}

--- a/src/test/elements/googledrive/assets/permissionUpdate.json
+++ b/src/test/elements/googledrive/assets/permissionUpdate.json
@@ -1,0 +1,3 @@
+{
+	"role": "commenter"
+}

--- a/src/test/elements/googledrive/files.js
+++ b/src/test/elements/googledrive/files.js
@@ -10,6 +10,8 @@ const folderPayload = require('./assets/folders');
 const randomInt = tools.randomInt();
 folderPayload.path += randomInt;
 folderPayload.name += randomInt;
+const permissionPayload = tools.requirePayload(`${__dirname}/assets/permission.json`);
+const permissionUpdatePayload = tools.requirePayload(`${__dirname}/assets/permissionUpdate.json`);
 const commentPayload1 = tools.requirePayload(`${__dirname}/assets/comment.json`);
 const commentPayload2 = tools.requirePayload(`${__dirname}/assets/comment.json`);
 
@@ -181,6 +183,8 @@ suite.forElement('documents', 'files', { payload: payload }, (test) => {
       .then(r => cloud.delete(`${test.api}/${fileId2}`));
   });
 
+
+
   it(`should allow CRUDS for ${test.api}/:id/comments`, () => cloud.cruds(`${test.api}/${jpgFileBody.id}/comments`, commentPayload1));
 
   it(`should allow CRUDS for ${test.api}/comments by path`, () => cloud.withOptions({ qs: { path: jpgFileBody.path } }).cruds(`${test.api}/comments`, commentPayload1));
@@ -322,4 +326,29 @@ suite.forElement('documents', 'files', { payload: payload }, (test) => {
       }
     }).get(test.api);
   });
+
+  it(`should aloow CRUDS for ${test.api}/permissions by ID`, () => {
+    let permissionId;
+    return cloud.post(`${test.api}/${jpgFileBody.id}/permissions`, permissionPayload)
+      .then(r => permissionId = r.body.id)
+      .then(r => cloud.get(`${test.api}/${jpgFileBody.id}/permissions`))
+      .then(r => cloud.withOptions({ qs: { pageSize: 1 } }).get(`${test.api}/${jpgFileBody.id}/permissions`))
+      .then(r => expect(r.body[0].permissions).to.have.lengthOf(1))
+      .then(r => cloud.get(`${test.api}/${jpgFileBody.id}/permissions/${permissionId}`))
+      .then(r => cloud.patch(`${test.api}/${jpgFileBody.id}/permissions/${permissionId}`, permissionUpdatePayload))
+      .then(r => cloud.delete(`${test.api}/${jpgFileBody.id}/permissions/${permissionId}`));
+  });
+
+  it(`should aloow CRUDS for ${test.api}/permissions by path`, () => {
+    let permissionId;
+    return cloud.withOptions({ qs: { path: jpgFileBody.path } }).post(`${test.api}/permissions`, permissionPayload)
+      .then(r => permissionId = r.body.id)
+      .then(r => cloud.withOptions({ qs: { path: jpgFileBody.path } }).get(`${test.api}/permissions`))
+      .then(r => cloud.withOptions({ qs: { pageSize: 1, path: jpgFileBody.path  } }).get(`${test.api}/permissions`))
+      .then(r => expect(r.body[0].permissions).to.have.lengthOf(1))
+      .then(r => cloud.withOptions({ qs: { path: jpgFileBody.path } }).get(`${test.api}/permissions/${permissionId}`))
+      .then(r => cloud.withOptions({ qs: { path: jpgFileBody.path } }).patch(`${test.api}/permissions/${permissionId}`, permissionUpdatePayload))
+      .then(r => cloud.withOptions({ qs: { path: jpgFileBody.path } }).delete(`${test.api}/permissions/${permissionId}`));
+  });
+  
 });


### PR DESCRIPTION
## Highlights
* Added tests for below permissions API for files.
    * GET /files/permissions
    * GET /files/permissions/{permissionId}
    * GET /files/{id}/permissions
    * GET /files/{id}/permissions/{permissionsId}
    * POST /files/{id}/permissions
    * POST /files/permissions
    * PATCH /files/{id}/permissions/{permissionId}
    * PATCH /files/permissions/{permissionId}
    * DELETE /files/{id}/permissions/{permissionId}
    * DELETE /files/permissions/{permissionId}

* 7 tests are failing on Staging. Have raised [DE2226](https://rally1.rallydev.com/#/144349237612d/detail/defect/240740623856?fdp=true) for the same.

## Screenshot
![image](https://user-images.githubusercontent.com/22442264/43260495-4ebe2506-90f7-11e8-982a-9cbc09c96266.png)
![image](https://user-images.githubusercontent.com/22442264/43260513-61af7052-90f7-11e8-829e-27a55f4cceb4.png)
![image](https://user-images.githubusercontent.com/22442264/43260524-6a320258-90f7-11e8-905f-d9a416981bf4.png)

## Reference
* [SOBA](https://github.com/cloud-elements/soba/pull/9084)
* [RALLY-US13270](https://rally1.rallydev.com/#/144349237612d/detail/userstory/239854764612)

## Closes
* [US13270](https://rally1.rallydev.com/#/144349237612d/detail/userstory/239854764612)
