### PR TITLE
Tango Card - Added test cases for new element in Rewards hub

### DIFF
--- a/src/test/elements/assets/object.definitions.json
+++ b/src/test/elements/assets/object.definitions.json
@@ -2563,6 +2563,18 @@
       }
     ]
   },
+  "credit-cards": {
+    "fields": [
+      {
+        "path": "idTransformed",
+        "type": "string"
+      },
+      {
+        "path": "id",
+        "type": "string"
+      }
+    ]
+  },
   "data-extensions": {
     "fields": [
       {

--- a/src/test/elements/tangocard/accounts.js
+++ b/src/test/elements/tangocard/accounts.js
@@ -1,0 +1,8 @@
+'use strict';
+
+const suite = require('core/suite');
+
+suite.forElement('rewards', 'accounts', (test) => {
+ test.should.supportSr();
+ test.should.supportPagination();
+});

--- a/src/test/elements/tangocard/assets/creditcard.json
+++ b/src/test/elements/tangocard/assets/creditcard.json
@@ -1,0 +1,22 @@
+{
+  "accountIdentifier": "cloud-elements",
+  "billingAddress": {
+    "addressLine1": "123 Street",
+    "addressLine2": "Apt 24",
+    "city": "Seattle",
+    "country": "US",
+    "emailAddress": "brian.crowley@tangocard.com",
+    "firstName": "Brian",
+    "lastName": "Crowley",
+    "postalCode": "12345",
+    "state": "WA"
+  },
+  "creditCard": {
+    "expiration": "2025-12",
+    "number": "5555555555554444",
+    "verificationNumber": "123"
+  },
+  "customerIdentifier": "cloud-elements",
+  "ipAddress": "209.210.187.156",
+  "label": "Test Card"
+}

--- a/src/test/elements/tangocard/assets/creditcard2.json
+++ b/src/test/elements/tangocard/assets/creditcard2.json
@@ -1,0 +1,4 @@
+{
+  "accountIdentifier": "cloud-elements",
+  "customerIdentifier": "cloud-elements"
+}

--- a/src/test/elements/tangocard/assets/creditcarddeposits.json
+++ b/src/test/elements/tangocard/assets/creditcarddeposits.json
@@ -1,0 +1,5 @@
+{
+  "accountIdentifier": "account-sonali",
+  "amount": 0,
+  "customerIdentifier": "sonali"
+}

--- a/src/test/elements/tangocard/assets/customers.json
+++ b/src/test/elements/tangocard/assets/customers.json
@@ -1,0 +1,5 @@
+{
+  "customerIdentifier": "<<random.letter##6>>",
+  "displayName": "<<random.letter##6>>",
+  "status": "ACTIVE"
+}

--- a/src/test/elements/tangocard/assets/customers2.json
+++ b/src/test/elements/tangocard/assets/customers2.json
@@ -1,0 +1,5 @@
+{
+  "customerIdentifier": "<<random.letter##6>>",
+  "displayName": "<<random.letter##6>>",
+  "status": "ACTIVE"
+}

--- a/src/test/elements/tangocard/assets/customersAccounts.json
+++ b/src/test/elements/tangocard/assets/customersAccounts.json
@@ -1,0 +1,5 @@
+{
+  "accountIdentifier": "<<random.letter##4>>account",
+  "contactEmail": "ss2@gmsk.com",
+  "displayName": "<<random.letter##6>>"
+}

--- a/src/test/elements/tangocard/assets/orders.json
+++ b/src/test/elements/tangocard/assets/orders.json
@@ -1,0 +1,23 @@
+{
+  "accountIdentifier": "cloud-elements",
+  "amount": 0.01,
+  "campaign": "ss",
+  "customerIdentifier": "cloud-elements",
+  "emailSubject": "testing purpose",
+  "etid": "E000000",
+  "externalRefID": "123reff",
+  "message": "test message",
+  "notes": "This is my notes",
+  "recipient": {
+    "email": "soni.sonali@hsm.com",
+    "firstName": "sonali",
+    "lastName": "soni"
+  },
+  "sendEmail": true,
+  "sender": {
+    "email": "soni.sonali@hsm.com",
+    "firstName": "sonali",
+    "lastName": "soni"
+  },
+  "utid": "U666425"
+}

--- a/src/test/elements/tangocard/assets/orders2.json
+++ b/src/test/elements/tangocard/assets/orders2.json
@@ -1,0 +1,23 @@
+{
+  "accountIdentifier": "cloud-elements",
+  "amount": 0.01,
+  "campaign": "ss",
+  "customerIdentifier": "cloud-elements",
+  "emailSubject": "testing purpose2",
+  "etid": "E000000",
+  "externalRefID": "234ref",
+  "message": "test message",
+  "notes": "This is my notes",
+  "recipient": {
+    "email": "soni.sonali@sdk.com",
+    "firstName": "sonali",
+    "lastName": "soni"
+  },
+  "sendEmail": true,
+  "sender": {
+    "email": "soni.sonali@sdk.com",
+    "firstName": "sonali",
+    "lastName": "soni"
+  },
+  "utid": "U666425"
+}

--- a/src/test/elements/tangocard/assets/transformations.json
+++ b/src/test/elements/tangocard/assets/transformations.json
@@ -1,0 +1,39 @@
+{
+  "credit-cards": {
+    "vendorName": "credit-cards",
+    "fields": [
+      {
+        "path": "id",
+        "vendorPath": "token"
+      }
+    ]
+  },
+"accounts": {
+    "vendorName": "accounts",
+    "fields": [
+      {
+        "path": "id",
+        "vendorPath": "accountIdentifier"
+      }
+    ]
+  },
+  "customers": {
+    "vendorName": "customers",
+    "fields": [
+      {
+        "path": "id",
+        "vendorPath": "customerIdentifier"
+      }
+    ]
+  },
+  "orders": {
+    "vendorName": "orders",
+    "fields": [
+      {
+        "path": "id",
+        "vendorPath": "referenceOrderID"
+      }
+    ]
+  }
+
+}

--- a/src/test/elements/tangocard/catalogs.js
+++ b/src/test/elements/tangocard/catalogs.js
@@ -4,4 +4,5 @@ const suite = require('core/suite');
 
 suite.forElement('rewards', 'catalogs', (test) => {
  test.should.supportS();
+ test.withOptions({ qs: { where: 'verbose =\'false\'' } }).should.return200OnGet();
 });

--- a/src/test/elements/tangocard/catalogs.js
+++ b/src/test/elements/tangocard/catalogs.js
@@ -1,0 +1,7 @@
+'use strict';
+
+const suite = require('core/suite');
+
+suite.forElement('rewards', 'catalogs', (test) => {
+ test.should.supportS();
+});

--- a/src/test/elements/tangocard/credit-cards.js
+++ b/src/test/elements/tangocard/credit-cards.js
@@ -7,10 +7,10 @@ const customerpayload = tools.requirePayload(`${__dirname}/assets/customersAccou
 const payloadcustomer = tools.requirePayload(`${__dirname}/assets/customers.json`);
 const creditcarddeposits = tools.requirePayload(`${__dirname}/assets/creditcarddeposits.json`);
 
-//Skipping the test to POST an credit-card we need to create customer first and customers object has limits of records to be create_discount_coupons
-suite.forElement('rewards', 'credit-cards', { skip: true }, (test) => {
-  let accountId, customerId, depositId, id;
+//Skipping the test since to POST a credit-card we need to create a customer first and customers object has limits of records which can be created
+suite.forElement('rewards', 'credit-cards', (test) => {
   it('should allow Csr for credit-cards and credit-cards-deposits', () => {
+     let accountId, customerId, depositId, id;
     return cloud.post('/customers', payloadcustomer)
       .then(r => customerId = r.body.id)
       .then(r => cloud.post(`customers/${customerId}/accounts`, customerpayload))
@@ -37,6 +37,7 @@ suite.forElement('rewards', 'credit-cards', { skip: true }, (test) => {
         depositId = r.body.referenceDepositID;
       })
       .then(r => cloud.get(`credit-cards-deposits/${depositId}`))
-      .then(r => cloud.withOptions({ qs: { customerId: '${customerId}', accountId: '${accountId}' } }).delete(`${test.api}/${id}/unregister`));
+     .then(r => cloud.withOptions({ qs: { customerId: creditcarddeposits.customerIdentifier, accountId: creditcarddeposits.accountIdentifier } }).delete(`${test.api}/${id}`));
   });
+ test.should.supportPagination();
 });

--- a/src/test/elements/tangocard/credit-cards.js
+++ b/src/test/elements/tangocard/credit-cards.js
@@ -3,40 +3,40 @@ const tools = require('core/tools');
 const cloud = require('core/cloud');
 const creditcardPayload = tools.requirePayload(`${__dirname}/assets/creditcard.json`);
 const payload2 = tools.requirePayload(`${__dirname}/assets/creditcard2.json`);
-const customerpayload = require('core/tools').requirePayload(`${__dirname}/assets/customersAccounts.json`);
-const payloadcustomer = require('core/tools').requirePayload(`${__dirname}/assets/customers.json`);
-const creditcarddeposits = require('core/tools').requirePayload(`${__dirname}/assets/creditcarddeposits.json`);
+const customerpayload = tools.requirePayload(`${__dirname}/assets/customersAccounts.json`);
+const payloadcustomer = tools.requirePayload(`${__dirname}/assets/customers.json`);
+const creditcarddeposits = tools.requirePayload(`${__dirname}/assets/creditcarddeposits.json`);
 
 //Skipping the test to POSt an credit-card we need to create customer first and customers object has limits of records to be create_discount_coupons
-suite.forElement('rewards', 'credit-cards', {skip: true}, (test) => {
- let accountId, customerId, depositId, id;
- it('should allow Csr for credit-cards and credit-cards-deposits', () => {
-  return cloud.post('/customers', payloadcustomer)
-   .then(r => customerId = r.body.id)
-   .then(r => cloud.post(`customers/${customerId}/accounts`, customerpayload))
-   .then(r => accountId = r.body.id)
-   .then(r => {
-    creditcardPayload.accountIdentifier = accountId;
-    creditcardPayload.customerIdentifier = customerId;
-   })
-   .then(r => cloud.post(`${test.api}`, creditcardPayload))
-   .then(r => {
-    id = r.body.id;
-   })
-   .then(r => cloud.get(`${test.api}/${id}`))
-   .then(r => {
-    payload2.accountIdentifier = accountId;
-    payload2.customerIdentifier = customerId;
-   })
-   .then(r => {
-    creditcarddeposits.accountIdentifier = accountId;
-    creditcarddeposits.customerIdentifier = customerId;
-   })
-   .then(r => cloud.post(`credit-cards/${id}/deposits`, creditcarddeposits))
-   .then(r => {
-    depositId = r.body.referenceDepositID;
-   })
-   .then(r => cloud.get(`credit-cards/deposits/${depositId}`))
-   .then(r => cloud.post(`${test.api}/${id}/unregister`, payload2));
- });
+suite.forElement('rewards', 'credit-cards', { skip: true }, (test) => {
+  let accountId, customerId, depositId, id;
+  it('should allow Csr for credit-cards and credit-cards-deposits', () => {
+    return cloud.post('/customers', payloadcustomer)
+      .then(r => customerId = r.body.id)
+      .then(r => cloud.post(`customers/${customerId}/accounts`, customerpayload))
+      .then(r => accountId = r.body.id)
+      .then(r => {
+        creditcardPayload.accountIdentifier = accountId;
+        creditcardPayload.customerIdentifier = customerId;
+      })
+      .then(r => cloud.post(`${test.api}`, creditcardPayload))
+      .then(r => {
+        id = r.body.id;
+      })
+      .then(r => cloud.get(`${test.api}/${id}`))
+      .then(r => {
+        payload2.accountIdentifier = accountId;
+        payload2.customerIdentifier = customerId;
+      })
+      .then(r => {
+        creditcarddeposits.accountIdentifier = accountId;
+        creditcarddeposits.customerIdentifier = customerId;
+      })
+      .then(r => cloud.post(`credit-cards/${id}/deposits`, creditcarddeposits))
+      .then(r => {
+        depositId = r.body.referenceDepositID;
+      })
+      .then(r => cloud.get(`credit-cards-deposits/${depositId}`))
+      .then(r => cloud.withOptions({ qs: { customerId: '${customerId}', accountId: '${accountId}' } }).delete(`${test.api}/${id}/unregister`));
+  });
 });

--- a/src/test/elements/tangocard/credit-cards.js
+++ b/src/test/elements/tangocard/credit-cards.js
@@ -1,6 +1,5 @@
 const suite = require('core/suite');
 const tools = require('core/tools');
-const expect = require('chakram').expect;
 const cloud = require('core/cloud');
 const creditcardPayload = tools.requirePayload(`${__dirname}/assets/creditcard.json`);
 const payload2 = tools.requirePayload(`${__dirname}/assets/creditcard2.json`);
@@ -10,7 +9,7 @@ const creditcarddeposits = require('core/tools').requirePayload(`${__dirname}/as
 
 //Skipping the test to POSt an credit-card we need to create customer first and customers object has limits of records to be create_discount_coupons
 suite.forElement('rewards', 'credit-cards', {skip: true}, (test) => {
- let accountId, customerId, depositId;
+ let accountId, customerId, depositId, id;
  it('should allow Csr for credit-cards and credit-cards-deposits', () => {
   return cloud.post('/customers', payloadcustomer)
    .then(r => customerId = r.body.id)
@@ -22,7 +21,7 @@ suite.forElement('rewards', 'credit-cards', {skip: true}, (test) => {
    })
    .then(r => cloud.post(`${test.api}`, creditcardPayload))
    .then(r => {
-    id = r.body.id
+    id = r.body.id;
    })
    .then(r => cloud.get(`${test.api}/${id}`))
    .then(r => {
@@ -35,9 +34,9 @@ suite.forElement('rewards', 'credit-cards', {skip: true}, (test) => {
    })
    .then(r => cloud.post(`credit-cards/${id}/deposits`, creditcarddeposits))
    .then(r => {
-    depositId = r.body.id
+    depositId = r.body.id;
    })
    .then(r => cloud.get(`credit-cards/deposits/${depositId}`))
    .then(r => cloud.post(`${test.api}/${id}/unregister`, payload2));
- })
+ });
 });

--- a/src/test/elements/tangocard/credit-cards.js
+++ b/src/test/elements/tangocard/credit-cards.js
@@ -7,7 +7,7 @@ const customerpayload = tools.requirePayload(`${__dirname}/assets/customersAccou
 const payloadcustomer = tools.requirePayload(`${__dirname}/assets/customers.json`);
 const creditcarddeposits = tools.requirePayload(`${__dirname}/assets/creditcarddeposits.json`);
 
-//Skipping the test since to POST a credit-card we need to create a customer first and customers object has limits of records which can be created
+//Skipping the test as, for posting a credit card we need to create a customer first and creating customers have certain limit from vendor
 suite.forElement('rewards', 'credit-cards', { skip: true }, (test) => {
   it('should allow Csr for credit-cards and credit-cards-deposits', () => {
      let accountId, customerId, depositId, id;

--- a/src/test/elements/tangocard/credit-cards.js
+++ b/src/test/elements/tangocard/credit-cards.js
@@ -8,7 +8,7 @@ const payloadcustomer = tools.requirePayload(`${__dirname}/assets/customers.json
 const creditcarddeposits = tools.requirePayload(`${__dirname}/assets/creditcarddeposits.json`);
 
 //Skipping the test since to POST a credit-card we need to create a customer first and customers object has limits of records which can be created
-suite.forElement('rewards', 'credit-cards', (test) => {
+suite.forElement('rewards', 'credit-cards', { skip: true }, (test) => {
   it('should allow Csr for credit-cards and credit-cards-deposits', () => {
      let accountId, customerId, depositId, id;
     return cloud.post('/customers', payloadcustomer)

--- a/src/test/elements/tangocard/credit-cards.js
+++ b/src/test/elements/tangocard/credit-cards.js
@@ -34,7 +34,7 @@ suite.forElement('rewards', 'credit-cards', {skip: true}, (test) => {
    })
    .then(r => cloud.post(`credit-cards/${id}/deposits`, creditcarddeposits))
    .then(r => {
-    depositId = r.body.id;
+    depositId = r.body.referenceDepositID;
    })
    .then(r => cloud.get(`credit-cards/deposits/${depositId}`))
    .then(r => cloud.post(`${test.api}/${id}/unregister`, payload2));

--- a/src/test/elements/tangocard/credit-cards.js
+++ b/src/test/elements/tangocard/credit-cards.js
@@ -7,7 +7,7 @@ const customerpayload = tools.requirePayload(`${__dirname}/assets/customersAccou
 const payloadcustomer = tools.requirePayload(`${__dirname}/assets/customers.json`);
 const creditcarddeposits = tools.requirePayload(`${__dirname}/assets/creditcarddeposits.json`);
 
-//Skipping the test to POSt an credit-card we need to create customer first and customers object has limits of records to be create_discount_coupons
+//Skipping the test to POST an credit-card we need to create customer first and customers object has limits of records to be create_discount_coupons
 suite.forElement('rewards', 'credit-cards', { skip: true }, (test) => {
   let accountId, customerId, depositId, id;
   it('should allow Csr for credit-cards and credit-cards-deposits', () => {

--- a/src/test/elements/tangocard/credit-cards.js
+++ b/src/test/elements/tangocard/credit-cards.js
@@ -1,0 +1,43 @@
+const suite = require('core/suite');
+const tools = require('core/tools');
+const expect = require('chakram').expect;
+const cloud = require('core/cloud');
+const creditcardPayload = tools.requirePayload(`${__dirname}/assets/creditcard.json`);
+const payload2 = tools.requirePayload(`${__dirname}/assets/creditcard2.json`);
+const customerpayload = require('core/tools').requirePayload(`${__dirname}/assets/customersAccounts.json`);
+const payloadcustomer = require('core/tools').requirePayload(`${__dirname}/assets/customers.json`);
+const creditcarddeposits = require('core/tools').requirePayload(`${__dirname}/assets/creditcarddeposits.json`);
+
+//Skipping the test to POSt an credit-card we need to create customer first and customers object has limits of records to be create_discount_coupons
+suite.forElement('rewards', 'credit-cards', {skip: true}, (test) => {
+ let accountId, customerId, depositId;
+ it('should allow Csr for credit-cards and credit-cards-deposits', () => {
+  return cloud.post('/customers', payloadcustomer)
+   .then(r => customerId = r.body.id)
+   .then(r => cloud.post(`customers/${customerId}/accounts`, customerpayload))
+   .then(r => accountId = r.body.id)
+   .then(r => {
+    creditcardPayload.accountIdentifier = accountId;
+    creditcardPayload.customerIdentifier = customerId;
+   })
+   .then(r => cloud.post(`${test.api}`, creditcardPayload))
+   .then(r => {
+    id = r.body.id
+   })
+   .then(r => cloud.get(`${test.api}/${id}`))
+   .then(r => {
+    payload2.accountIdentifier = accountId;
+    payload2.customerIdentifier = customerId;
+   })
+   .then(r => {
+    creditcarddeposits.accountIdentifier = accountId;
+    creditcarddeposits.customerIdentifier = customerId;
+   })
+   .then(r => cloud.post(`credit-cards/${id}/deposits`, creditcarddeposits))
+   .then(r => {
+    depositId = r.body.id
+   })
+   .then(r => cloud.get(`credit-cards/deposits/${depositId}`))
+   .then(r => cloud.post(`${test.api}/${id}/unregister`, payload2));
+ })
+});

--- a/src/test/elements/tangocard/customers.js
+++ b/src/test/elements/tangocard/customers.js
@@ -1,20 +1,21 @@
 'use strict';
 
 const suite = require('core/suite');
-const payload = require('core/tools').requirePayload(`${__dirname}/assets/customers.json`);
-const payload2 = require('core/tools').requirePayload(`${__dirname}/assets/customers2.json`);
-const customerpayload = require('core/tools').requirePayload(`${__dirname}/assets/customersAccounts.json`);
+const tools = require('core/tools');
+const payload = tools.requirePayload(`${__dirname}/assets/customers.json`);
+const payload2 = tools.requirePayload(`${__dirname}/assets/customers2.json`);
+const customerpayload = tools.requirePayload(`${__dirname}/assets/customersAccounts.json`);
 const cloud = require('core/cloud');
 
 //Skipping the test since we have limit for customers to be created in sandbox account and we don't have delete API for sutomers
-suite.forElement('rewards', 'customers', {payload: payload, skip: true}, (test) => {
- test.should.supportCrs();
- test.should.supportPagination();
- let customerId;
- it('should support CS for customers/{id}/accounts', () => {
-  return cloud.post(test.api, payload2)
-   .then(r => customerId = r.body.id)
-   .then(r => cloud.post(`${test.api}/${customerId}/accounts`, customerpayload))
-   .then(r => cloud.get(`${test.api}/${customerId}/accounts`));
- });
+suite.forElement('rewards', 'customers', { payload: payload, skip: true }, (test) => {
+  test.should.supportCrs();
+  test.should.supportPagination();
+  it('should support CS for customers/{id}/accounts', () => {
+    let customerId;
+    return cloud.post(test.api, payload2)
+      .then(r => customerId = r.body.id)
+      .then(r => cloud.post(`${test.api}/${customerId}/accounts`, customerpayload))
+      .then(r => cloud.get(`${test.api}/${customerId}/accounts`));
+  });
 });

--- a/src/test/elements/tangocard/customers.js
+++ b/src/test/elements/tangocard/customers.js
@@ -1,0 +1,20 @@
+'use strict';
+
+const suite = require('core/suite');
+const payload = require('core/tools').requirePayload(`${__dirname}/assets/customers.json`);
+const payload2 = require('core/tools').requirePayload(`${__dirname}/assets/customers2.json`);
+const customerpayload = require('core/tools').requirePayload(`${__dirname}/assets/customersAccounts.json`);
+const cloud = require('core/cloud');
+
+//Skipping the test since we have limit for customers to be created in sandbox account and we don't have delete API for sutomers
+suite.forElement('rewards', 'customers', {payload: payload, skip: true}, (test) => {
+ test.should.supportCrs();
+ test.should.supportPagination();
+ let customerId;
+ it('should support CS for customers/{id}/accounts', () => {
+  return cloud.post(test.api, payload2)
+   .then(r => customerId = r.body.id)
+   .then(r => cloud.post(`${test.api}/${customerId}/accounts`, customerpayload))
+   .then(r => cloud.get(`${test.api}/${customerId}/accounts`));
+ });
+});

--- a/src/test/elements/tangocard/orders.js
+++ b/src/test/elements/tangocard/orders.js
@@ -1,29 +1,29 @@
 'use strict';
 
 const suite = require('core/suite');
-const payload = require('core/tools').requirePayload(`${__dirname}/assets/orders.json`);
-const payload2 = require('core/tools').requirePayload(`${__dirname}/assets/orders2.json`);
+const tools = require('core/tools');
+const payload = tools.requirePayload(`${__dirname}/assets/orders.json`);
+const payload2 = tools.requirePayload(`${__dirname}/assets/orders2.json`);
 const cloud = require('core/cloud');
 const expect = require('chakram').expect;
 
 //Skipping the test since there are limits to the orders we can post and there are no delete API supported
-suite.forElement('rewards', 'orders', {payload: payload, skip: true}, (test) => {
- test.should.supportCrs();
- test.should.supportPagination();
-
- let orderId,externalRefId;
- it('should support C for orders/{id}/resends', () => {
-  return cloud.post(test.api, payload2)
-   .then(r => {
-    orderId = r.body.id;
-    externalRefId = r.body.externalRefID;
-   })
-  .then(r => cloud.withOptions({ qs: { where: `externalRefID='${externalRefId}'` } }).get(test.api))
-  .then(r => {
-   expect(r.body).to.not.be.empty;
-   expect(r.body.length).to.equal(1);
-   expect(r.body[0].externalRefID).to.equal(externalRefId);
- })
-  .then(r => cloud.post(`${test.api}/${orderId}/resends`));
- });
+suite.forElement('rewards', 'orders', { payload: payload, skip: true }, (test) => {
+  test.should.supportCrs();
+  test.should.supportPagination();
+  it('should support C for orders/{id}/resends', () => {
+    let orderId, externalRefId;
+    return cloud.post(test.api, payload2)
+      .then(r => {
+        orderId = r.body.id;
+        externalRefId = r.body.externalRefID;
+      })
+      .then(r => cloud.withOptions({ qs: { where: `externalRefID='${externalRefId}'` } }).get(test.api))
+      .then(r => {
+        expect(r.body).to.not.be.empty;
+        expect(r.body.length).to.equal(1);
+        expect(r.body[0].externalRefID).to.equal(externalRefId);
+      })
+      .then(r => cloud.post(`${test.api}/${orderId}/resends`));
+  });
 });

--- a/src/test/elements/tangocard/orders.js
+++ b/src/test/elements/tangocard/orders.js
@@ -1,0 +1,18 @@
+'use strict';
+
+const suite = require('core/suite');
+const payload = require('core/tools').requirePayload(`${__dirname}/assets/orders.json`);
+const payload2 = require('core/tools').requirePayload(`${__dirname}/assets/orders2.json`);
+const cloud = require('core/cloud');
+
+//Skipping the test since there are limits to the orders we can post and there are no delete API supported
+suite.forElement('rewards', 'orders', {payload: payload, skip: true}, (test) => {
+ test.should.supportCrs();
+ test.should.supportPagination();
+ let orderId;
+ it('should support C for orders/{id}/resends', () => {
+  return cloud.post(test.api, payload2)
+   .then(r => orderId = r.body.id)
+   .then(r => cloud.post(`${test.api}/${orderId}/resends`));
+ });
+});

--- a/src/test/elements/tangocard/orders.js
+++ b/src/test/elements/tangocard/orders.js
@@ -4,9 +4,10 @@ const suite = require('core/suite');
 const payload = require('core/tools').requirePayload(`${__dirname}/assets/orders.json`);
 const payload2 = require('core/tools').requirePayload(`${__dirname}/assets/orders2.json`);
 const cloud = require('core/cloud');
+const expect = require('chakram').expect;
 
 //Skipping the test since there are limits to the orders we can post and there are no delete API supported
-suite.forElement('rewards', 'orders', {payload: payload,  skip: true}, (test) => {
+suite.forElement('rewards', 'orders', {payload: payload}, (test) => {
  test.should.supportCrs();
  test.should.supportPagination();
 
@@ -18,6 +19,11 @@ suite.forElement('rewards', 'orders', {payload: payload,  skip: true}, (test) =>
     externalRefId = r.body.externalRefID;
    })
   .then(r => cloud.withOptions({ qs: { where: `externalRefID='${externalRefId}'` } }).get(test.api))
-   .then(r => cloud.post(`${test.api}/${orderId}/resends`));
+  .then(r => {
+   expect(r.body).to.not.be.empty;
+   expect(r.body.length).to.equal(1);
+   expect(r.body[0].externalRefID).to.equal(externalRefId);
+ })
+  .then(r => cloud.post(`${test.api}/${orderId}/resends`));
  });
 });

--- a/src/test/elements/tangocard/orders.js
+++ b/src/test/elements/tangocard/orders.js
@@ -6,13 +6,18 @@ const payload2 = require('core/tools').requirePayload(`${__dirname}/assets/order
 const cloud = require('core/cloud');
 
 //Skipping the test since there are limits to the orders we can post and there are no delete API supported
-suite.forElement('rewards', 'orders', {payload: payload, skip: true}, (test) => {
+suite.forElement('rewards', 'orders', {payload: payload,  skip: true}, (test) => {
  test.should.supportCrs();
  test.should.supportPagination();
- let orderId;
+
+ let orderId,externalRefId;
  it('should support C for orders/{id}/resends', () => {
   return cloud.post(test.api, payload2)
-   .then(r => orderId = r.body.id)
+   .then(r => {
+    orderId = r.body.id;
+    externalRefId = r.body.externalRefID
+   })
+  .then(r => cloud.withOptions({ qs: { where: `externalRefID='${externalRefId}'` } }).get(test.api))
    .then(r => cloud.post(`${test.api}/${orderId}/resends`));
  });
 });

--- a/src/test/elements/tangocard/orders.js
+++ b/src/test/elements/tangocard/orders.js
@@ -7,7 +7,7 @@ const cloud = require('core/cloud');
 const expect = require('chakram').expect;
 
 //Skipping the test since there are limits to the orders we can post and there are no delete API supported
-suite.forElement('rewards', 'orders', {payload: payload}, (test) => {
+suite.forElement('rewards', 'orders', {payload: payload, skip: true}, (test) => {
  test.should.supportCrs();
  test.should.supportPagination();
 

--- a/src/test/elements/tangocard/orders.js
+++ b/src/test/elements/tangocard/orders.js
@@ -15,7 +15,7 @@ suite.forElement('rewards', 'orders', {payload: payload,  skip: true}, (test) =>
   return cloud.post(test.api, payload2)
    .then(r => {
     orderId = r.body.id;
-    externalRefId = r.body.externalRefID
+    externalRefId = r.body.externalRefID;
    })
   .then(r => cloud.withOptions({ qs: { where: `externalRefID='${externalRefId}'` } }).get(test.api))
    .then(r => cloud.post(`${test.api}/${orderId}/resends`));


### PR DESCRIPTION
## Highlights
* Added test cases for `accounts`, `catalogs`, `customers`, `orders`, and `credit-cards` objects for Tango card
* Since there are limits for `customers` and `orders` objects and `credit-cards` are dependent `customers`, we needed to skip the tests for churros
## Screenshot
![churrosresults](https://user-images.githubusercontent.com/29943090/43510839-7c603f20-9594-11e8-9f77-60cd4717aa6a.PNG)

* Screenshots for credit-cards and orders
  * One API fails in orders due to order resend limit from vendor
![image](https://user-images.githubusercontent.com/29943090/43520700-3bd56ef4-95b1-11e8-86a0-b2a08c1456ad.png)

![image](https://user-images.githubusercontent.com/29943090/43520654-0ec9e732-95b1-11e8-9bd6-59c2a4c11188.png)

## Reference
* [SOBA](https://github.com/cloud-elements/soba/pull/9108)
* [churros-sauce](https://github.com/cloud-elements/churros-sauce/pull/214)
* [RALLY](https://rally1.rallydev.com/#/144349237612d/detail/userstory/236655542160)

## Closes
* [US13175](https://rally1.rallydev.com/#/144349237612d/detail/userstory/236655542160
