### PR TITLE
Jira: Added churros Testsuite for dependent resources

### DIFF
--- a/src/test/elements/jira/issuesecurity-schemes.js
+++ b/src/test/elements/jira/issuesecurity-schemes.js
@@ -5,7 +5,7 @@ const cloud = require('core/cloud');
 suite.forElement('helpdesk', 'issuesecurity-schemes', (test) => {
   it('should allow SR for issuesecurity-schemes', () => {
     let issuesecurityschemes;
-    return cloud.get('/hubs/helpdesk/issuesecurity-schemes')
+    return cloud.get(test.api)
       .then(r => issuesecurityschemes = r.body[0].id)
       .then(r => cloud.get(`${test.api}/${issuesecurityschemes}`));
   });

--- a/src/test/elements/jira/issuesecurity-schemes.js
+++ b/src/test/elements/jira/issuesecurity-schemes.js
@@ -1,0 +1,14 @@
+'use strict';
+const suite = require('core/suite');
+const cloud = require('core/cloud');
+const expect = require('chakram').expect;
+
+suite.forElement('helpdesk', 'issuesecurity-schemes', (test) => {
+  it('should allow SR for issuesecurity-schemes', () => {
+    let issuesecurityschemes;
+    return cloud.get('/hubs/helpdesk/issuesecurity-schemes')
+      .then(r => issuesecurityschemes = r.body[0].id)
+      .then(r => cloud.get(`${test.api}/${issuesecurityschemes}`));
+  });
+  test.should.supportPagination();
+});

--- a/src/test/elements/jira/issuesecurity-schemes.js
+++ b/src/test/elements/jira/issuesecurity-schemes.js
@@ -1,7 +1,6 @@
 'use strict';
 const suite = require('core/suite');
 const cloud = require('core/cloud');
-const expect = require('chakram').expect;
 
 suite.forElement('helpdesk', 'issuesecurity-schemes', (test) => {
   it('should allow SR for issuesecurity-schemes', () => {

--- a/src/test/elements/jira/notification-schemes.js
+++ b/src/test/elements/jira/notification-schemes.js
@@ -1,7 +1,6 @@
 'use strict';
 const suite = require('core/suite');
 const cloud = require('core/cloud');
-const expect = require('chakram').expect;
 
 suite.forElement('helpdesk', 'notification-schemes', (test) => {
   it('should allow SR for notification-schemes', () => {

--- a/src/test/elements/jira/notification-schemes.js
+++ b/src/test/elements/jira/notification-schemes.js
@@ -1,0 +1,15 @@
+'use strict';
+const suite = require('core/suite');
+const cloud = require('core/cloud');
+const expect = require('chakram').expect;
+
+suite.forElement('helpdesk', 'notification-schemes', (test) => {
+  it('should allow SR for notification-schemes', () => {
+    let notificationschemesname;
+    return cloud.get('/hubs/helpdesk/notification-schemes')
+      .then(r => notificationschemesname = r.body[0].id)
+      .then(r => cloud.get(`${test.api}/${notificationschemesname}`));
+  });
+  test.should.supportPagination();
+  test.withOptions({ qs: { where :`expand='all'` }}).should.return200OnGet();
+});

--- a/src/test/elements/jira/notification-schemes.js
+++ b/src/test/elements/jira/notification-schemes.js
@@ -5,7 +5,7 @@ const cloud = require('core/cloud');
 suite.forElement('helpdesk', 'notification-schemes', (test) => {
   it('should allow SR for notification-schemes', () => {
     let notificationschemesname;
-    return cloud.get('/hubs/helpdesk/notification-schemes')
+    return cloud.get(test.api)
       .then(r => notificationschemesname = r.body[0].id)
       .then(r => cloud.get(`${test.api}/${notificationschemesname}`));
   });

--- a/src/test/elements/jira/permission-schemes.js
+++ b/src/test/elements/jira/permission-schemes.js
@@ -5,7 +5,7 @@ const cloud = require('core/cloud');
 suite.forElement('helpdesk', 'permission-schemes', (test) => {
   it('should allow SR for permission-schemes', () => {
     let permissionschemes;
-    return cloud.get('/hubs/helpdesk/permission-schemes')
+    return cloud.get(test.api)
       .then(r => permissionschemes = r.body[0].id)
       .then(r => cloud.get(`${test.api}/${permissionschemes}`));
   });

--- a/src/test/elements/jira/permission-schemes.js
+++ b/src/test/elements/jira/permission-schemes.js
@@ -1,7 +1,6 @@
 'use strict';
 const suite = require('core/suite');
 const cloud = require('core/cloud');
-const expect = require('chakram').expect;
 
 suite.forElement('helpdesk', 'permission-schemes', (test) => {
   it('should allow SR for permission-schemes', () => {

--- a/src/test/elements/jira/permission-schemes.js
+++ b/src/test/elements/jira/permission-schemes.js
@@ -1,0 +1,15 @@
+'use strict';
+const suite = require('core/suite');
+const cloud = require('core/cloud');
+const expect = require('chakram').expect;
+
+suite.forElement('helpdesk', 'permission-schemes', (test) => {
+  it('should allow SR for permission-schemes', () => {
+    let permissionschemes;
+    return cloud.get('/hubs/helpdesk/permission-schemes')
+      .then(r => permissionschemes = r.body[0].id)
+      .then(r => cloud.get(`${test.api}/${permissionschemes}`));
+  });
+  test.should.supportPagination();
+  test.withOptions({ qs: { where :`expand='all'` }}).should.return200OnGet();
+});

--- a/src/test/elements/jira/project-categories.js
+++ b/src/test/elements/jira/project-categories.js
@@ -1,0 +1,14 @@
+'use strict';
+const suite = require('core/suite');
+const cloud = require('core/cloud');
+const expect = require('chakram').expect;
+
+suite.forElement('helpdesk', 'project-categories', (test) => {
+  it('should allow SR for project-categories', () => {
+    let projectcategories;
+    return cloud.get('/hubs/helpdesk/project-categories')
+      .then(r => projectcategories = r.body[0].id)
+      .then(r => cloud.get(`${test.api}/${projectcategories}`));
+  });
+  test.should.supportPagination();
+});

--- a/src/test/elements/jira/project-categories.js
+++ b/src/test/elements/jira/project-categories.js
@@ -1,7 +1,6 @@
 'use strict';
 const suite = require('core/suite');
 const cloud = require('core/cloud');
-const expect = require('chakram').expect;
 
 suite.forElement('helpdesk', 'project-categories', (test) => {
   it('should allow SR for project-categories', () => {

--- a/src/test/elements/jira/project-categories.js
+++ b/src/test/elements/jira/project-categories.js
@@ -5,7 +5,7 @@ const cloud = require('core/cloud');
 suite.forElement('helpdesk', 'project-categories', (test) => {
   it('should allow SR for project-categories', () => {
     let projectcategories;
-    return cloud.get('/hubs/helpdesk/project-categories')
+    return cloud.get(test.api)
       .then(r => projectcategories = r.body[0].id)
       .then(r => cloud.get(`${test.api}/${projectcategories}`));
   });

--- a/src/test/elements/jira/projects.js
+++ b/src/test/elements/jira/projects.js
@@ -11,7 +11,7 @@ suite.forElement('helpdesk', 'projects', { payload: payload }, (test) => {
   test.withOptions({ qs: { where :`expand='lead'` }}).should.return200OnGet();
   it('should allow R for projects/{id}/avatars', () => {
     let projectid;
-    return cloud.get('/hubs/helpdesk/projects')
+    return cloud.get(test.api)
       .then(r => projectid = r.body[0].id)
       .then(r => cloud.get(`${test.api}/${projectid}/avatars`));
   });

--- a/src/test/elements/jira/projects.js
+++ b/src/test/elements/jira/projects.js
@@ -2,10 +2,17 @@
 
 const suite = require('core/suite');
 const tools = require('core/tools');
+const cloud = require('core/cloud');
 const payload = tools.requirePayload(`${__dirname}/assets/projects.json`);
 
 suite.forElement('helpdesk', 'projects', { payload: payload }, (test) => {
   test.should.supportCruds();
   test.should.supportPagination();
   test.withOptions({ qs: { where :`expand='lead'` }}).should.return200OnGet();
+  it('should allow R for projects/{id}/avatars', () => {
+    let projectid;
+    return cloud.get('/hubs/helpdesk/projects')
+      .then(r => projectid = r.body[0].id)
+      .then(r => cloud.get(`${test.api}/${projectid}/avatars`));
+  });
  });


### PR DESCRIPTION
## Highlights
* Added Testsuites for following resources:
- `issuesecurity-schemes`
- `notification-schemes`
- `permission-schemes`
- `project-categories`

* Added Test cases for following new API:
- `/projects/{id}/avatars` 

## Screenshot
```
PS C:\Users\gs-1108\Documents\GitHub\churros> churros test elements/jira

(node:11628) [DEP0022] DeprecationWarning: os.tmpDir() is deprecated. Use os.tmpdir() instead.

info: Using url: http://localhost:8080
info: Using user: pore@gslab.com
info: Using oauth username: jiradev
info: Running tests for element: jira
info: Provisioned with instance id of 575
(node:11628) [DEP0013] DeprecationWarning: Calling an asynchronous function without callback is deprecated.
  Basic tests
    √ should provision
    √ should GET /objects (5410ms)
    - docs
    √ metadata (362ms)
    √ transformations (28150ms)
    - should not allow provisioning with bad credentials

  agents
    √ should allow get for /agents (10004ms)

  contacts
    √ should allow CRUDS for /hubs/helpdesk/contacts with Ceql search (14176ms)
    √ should allow CRUDS for /hubs/helpdesk/contacts with special characters & Ceql search (13099ms)
    √ should allow paginating with page and pageSize for /hubs/helpdesk/contacts (6136ms)
error: Failed to delete /hubs/helpdesk/contacts/t2k3jn
error: Failed to delete /hubs/helpdesk/contacts/t3032a

  fields
    - should allow create and get of fields

  groups
    √ should allow SR for groups (3885ms)
    √ should allow paginating with page and pageSize for /hubs/helpdesk/groups (5715ms)
    √ should support search by filter (2054ms)

  incidents
    √ should allow CRUDS for /hubs/helpdesk/incidents (15491ms)
    √ should allow paginating with page and pageSize for /hubs/helpdesk/incidents (6892ms)
    √ should support searching /hubs/helpdesk/incidents by id (8102ms)
    √ should allow CRUDS for /incidents/:id/comments (16574ms)
    √ should allow CS for /incidents/:id/attachments and RD for /attachments (15821ms)
    √ should allow SR for /incidents/:id/history (71339ms)
    √ should allow creating for /incidents/:id/notifications (11974ms)
    √ should allow CRUDS for /incidents/:id/properties (13479ms)
    √ should allow GET /incidents with option defaultFields LIKE (2288ms)
    √ should allow GET /incidents with option customfields (2275ms)

  incidentTypes
    √ should allow CRUDS for /incidents-types (16044ms)

  issuesecurity-schemes
    1) should allow SR for issuesecurity-schemes
    √ should allow paginating with page and pageSize for /hubs/helpdesk/issuesecurity-schemes (6318ms)

  notification-schemes
    √ should allow SR for notification-schemes (4224ms)
    √ should allow paginating with page and pageSize for /hubs/helpdesk/notification-schemes (6565ms)
    √ should allow GET for /hubs/helpdesk/notification-schemes (2009ms)

  permission-schemes
    √ should allow SR for permission-schemes (3948ms)
    √ should allow paginating with page and pageSize for /hubs/helpdesk/permission-schemes (6056ms)
    √ should allow GET for /hubs/helpdesk/permission-schemes (2158ms)

  priorities
    √ should allow CRUDS for /priorities (4024ms)

  project-categories
    √ should allow SR for project-categories (4985ms)
    √ should allow paginating with page and pageSize for /hubs/helpdesk/project-categories (6058ms)

  projects
    √ should allow CRUDS for /hubs/helpdesk/projects (11329ms)
    √ should allow paginating with page and pageSize for /hubs/helpdesk/projects (6123ms)
    √ should allow GET for /hubs/helpdesk/projects (2154ms)
    √ should allow R for projects/{id}/avatars (4018ms)

  statuses
    √ should allow CRUDS for /statuses (4116ms)

  worklogs
    √ should allow S for /hubs/helpdesk/worklogs (3724ms)
    √ should allow S for /hubs/helpdesk/worklogs (2372ms)
    √ should allow S for /hubs/helpdesk/worklogs (2316ms)
    √ should allow paginating with page and pageSize for /hubs/helpdesk/worklogs (7071ms)


  41 passing (7m)
  3 pending
  1 failing

  1) issuesecurity-schemes should allow SR for issuesecurity-schemes:
     TypeError: Cannot read property 'id' of undefined
      at cloud.get.then.r (C:\Users\gs-1108\Documents\GitHub\churros\src\test\elements\jira\issuesecurity-schemes.js:10:51)
      at _fulfilled (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\q\q.js:854:54)
      at self.promiseDispatch.done (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\q\q.js:883:30)
      at Promise.promise.promiseDispatch (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\q\q.js:816:13)
      at C:\Users\gs-1108\Documents\GitHub\churros\node_modules\q\q.js:624:44
      at runSingle (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\q\q.js:137:13)
      at flush (C:\Users\gs-1108\Documents\GitHub\churros\node_modules\q\q.js:125:13)
      at _combinedTickCallback (internal/process/next_tick.js:131:7)
      at process._tickCallback (internal/process/next_tick.js:180:9)

```
* **Note:** The above issuesecutiry-schemes is failing because the current churros account doesn't have required data, so I verified it with my trial account, following is the screen shot verified from my trail account:
![image](https://user-images.githubusercontent.com/34128818/43626970-e37a7e72-9711-11e8-87a7-6788494147ed.png)


## Reference
* [SOBA](https://github.com/cloud-elements/soba/pull/9124)
* [RALLY-#${US13158}](https://rally1.rallydev.com/#/144349237612d/detail/userstory/236252143140)

## Closes
* [US13158](https://rally1.rallydev.com/#/144349237612d/detail/userstory/236252143140)