### PR TITLE
Microsoft Outlook & Graph : Added tests for Contacts CRUDS

### DIFF
--- a/src/test/elements/microsoftgraph/assets/contacts.json
+++ b/src/test/elements/microsoftgraph/assets/contacts.json
@@ -1,0 +1,3 @@
+{
+	"GivenName": "Churros Name"
+}

--- a/src/test/elements/microsoftgraph/contacts.js
+++ b/src/test/elements/microsoftgraph/contacts.js
@@ -21,7 +21,6 @@ suite.forElement('general', 'contacts', { payload: payload }, (test) => {
     .withName('Should support orderBy for date')
     .withValidation(r => {
       expect(r).to.statusCode(200);
-      expect(r.body.length).to.be.at.least(2);
       const success = new Date(r.body[0].lastModifiedDateTime).getTime() > new Date(r.body[1].lastModifiedDateTime).getTime();
       expect(success).to.be.true;
     })

--- a/src/test/elements/microsoftgraph/contacts.js
+++ b/src/test/elements/microsoftgraph/contacts.js
@@ -9,7 +9,6 @@ suite.forElement('general', 'contacts', { payload: payload }, (test) => {
   test.should.supportCruds();
   test.should.supportPagination();
   test.withName(`should support searching ${test.api} by name`)
-
     .withOptions({ qs: { where: `DisplayName ='Churros Name'` } })
     .withValidation((r) => {
       expect(r).to.have.statusCode(200);

--- a/src/test/elements/microsoftgraph/contacts.js
+++ b/src/test/elements/microsoftgraph/contacts.js
@@ -8,8 +8,8 @@ const expect = require('chakram').expect;
 suite.forElement('general', 'contacts', { payload: payload }, (test) => {
   test.should.supportCruds();
   test.should.supportPagination();
-  // the CEQL values are hard coded in do to a problem with microsoft api's that don't allow you to create a calendar, query, and delete it
-    test.withName(`should support searching ${test.api} by name`)
+  test.withName(`should support searching ${test.api} by name`)
+
     .withOptions({ qs: { where: `DisplayName ='Churros Name'` } })
     .withValidation((r) => {
       expect(r).to.have.statusCode(200);

--- a/src/test/elements/microsoftgraph/contacts.js
+++ b/src/test/elements/microsoftgraph/contacts.js
@@ -1,0 +1,30 @@
+'use strict';
+
+const suite = require('core/suite');
+const tools = require('core/tools');
+const payload = tools.requirePayload(`${__dirname}/assets/contacts.json`);
+const expect = require('chakram').expect;
+
+suite.forElement('general', 'contacts', { payload: payload }, (test) => {
+  test.should.supportCruds();
+  test.should.supportPagination();
+  // the CEQL values are hard coded in do to a problem with microsoft api's that don't allow you to create a calendar, query, and delete it
+    test.withName(`should support searching ${test.api} by name`)
+    .withOptions({ qs: { where: `DisplayName ='Churros Name'` } })
+    .withValidation((r) => {
+      expect(r).to.have.statusCode(200);
+      const validValues = r.body.filter(obj => obj.name === 'Churros Name');
+      expect(validValues.length).to.equal(r.body.length);
+    }).should.return200OnGet();
+
+  test
+    .withOptions({ qs: { orderBy: `lastModifiedDateTime desc` } })
+    .withName('Should support orderBy for date')
+    .withValidation(r => {
+      expect(r).to.statusCode(200);
+      expect(r.body.length).to.be.at.least(2);
+      const success = new Date(r.body[0].lastModifiedDateTime).getTime() > new Date(r.body[1].lastModifiedDateTime).getTime();
+      expect(success).to.be.true;
+    })
+    .should.return200OnGet();
+});

--- a/src/test/elements/outlookemail/assets/contacts.json
+++ b/src/test/elements/outlookemail/assets/contacts.json
@@ -1,0 +1,3 @@
+{
+	"GivenName": "Peter"
+}

--- a/src/test/elements/outlookemail/assets/transformations.json
+++ b/src/test/elements/outlookemail/assets/transformations.json
@@ -7,14 +7,5 @@
 	        "vendorPath": "Id"
 	      }
 	    ]
-  	},
-  	"messages": {
-    	"vendorName": "messages",
-	    "fields": [
-	      {
-	        "path": "id",
-	        "vendorPath": "Id"
-	      }
-	    ]
-  	},
+  	}
 }

--- a/src/test/elements/outlookemail/assets/transformations.json
+++ b/src/test/elements/outlookemail/assets/transformations.json
@@ -1,1 +1,11 @@
-{}
+{
+	"contacts": {
+    "vendorName": "contacts",
+    "fields": [
+      {
+        "path": "id",
+        "vendorPath": "Id"
+      }
+    ]
+  }
+}

--- a/src/test/elements/outlookemail/assets/transformations.json
+++ b/src/test/elements/outlookemail/assets/transformations.json
@@ -1,11 +1,20 @@
 {
 	"contacts": {
-    "vendorName": "contacts",
-    "fields": [
-      {
-        "path": "id",
-        "vendorPath": "Id"
-      }
-    ]
-  }
+    	"vendorName": "contacts",
+	    "fields": [
+	      {
+	        "path": "id",
+	        "vendorPath": "Id"
+	      }
+	    ]
+  	},
+  	"messages": {
+    	"vendorName": "messages",
+	    "fields": [
+	      {
+	        "path": "id",
+	        "vendorPath": "Id"
+	      }
+	    ]
+  	},
 }

--- a/src/test/elements/outlookemail/contacts.js
+++ b/src/test/elements/outlookemail/contacts.js
@@ -1,0 +1,32 @@
+'use strict';
+
+const suite = require('core/suite');
+const tools = require('core/tools');
+const expect = require('chakram').expect;
+const payload = tools.requirePayload(`${__dirname}/assets/contacts.json`);
+
+suite.forElement('general', 'contacts', { payload: payload }, (test) => {
+  test.should.supportCruds();
+  test.should.supportPagination('Id');
+
+  test
+    .withOptions({ qs: { orderBy: `LastModifiedDateTime desc` } })
+    .withName('Should support orderBy for date')
+    .withValidation(r => {
+      expect(r).to.statusCode(200);
+      expect(r.body.length).to.be.at.least(2);
+      const success = new Date(r.body[0].LastModifiedDateTime).getTime() > new Date(r.body[1].LastModifiedDateTime).getTime();
+      expect(success).to.be.true;
+    })
+    .should.return200OnGet();
+
+  test
+    .withOptions({ qs: { where: `LastModifiedDateTime >= '2018-08-07T06:45:27Z'` } })
+    .withName('Should support Ceql date search')
+    .withValidation(r => {
+      expect(r).to.statusCode(200);
+      const validValues = r.body.filter(obj => obj.LastModifiedDateTime >= '2018-08-07T06:45:27Z');
+      expect(validValues.length).to.equal(r.body.length);
+    })
+    .should.return200OnGet();
+});

--- a/src/test/elements/outlookemail/contacts.js
+++ b/src/test/elements/outlookemail/contacts.js
@@ -14,7 +14,6 @@ suite.forElement('general', 'contacts', { payload: payload }, (test) => {
     .withName('Should support orderBy for date')
     .withValidation(r => {
       expect(r).to.statusCode(200);
-      expect(r.body.length).to.be.at.least(2);
       const success = new Date(r.body[0].LastModifiedDateTime).getTime() > new Date(r.body[1].LastModifiedDateTime).getTime();
       expect(success).to.be.true;
     })


### PR DESCRIPTION
## Highlights
* Added tests for CRUDS of Contacts API for below two elements :
    * Microsoft Graph
    * Microsoft Outlook
* Churros for messaging is failing because of permission issue on account to send an email.

## Screenshot
Outlook :
![image](https://user-images.githubusercontent.com/22442264/43954132-fb73eb1a-9cb8-11e8-8631-734830ade8be.png)

Graph:
![image](https://user-images.githubusercontent.com/22442264/43953531-eac390ba-9cb6-11e8-960b-683f78c84675.png)


## Reference
* [SOBA](https://github.com/cloud-elements/soba/pull/9157)
* [RALLY-US13357](https://rally1.rallydev.com/#/144349237612d/detail/userstory/243068459092)

## Closes
* [US13357](https://rally1.rallydev.com/#/144349237612d/detail/userstory/243068459092)
