### PR TITLE
Added Accounts/Contacts tests for CU on native/custom fields

### DIFF
--- a/src/test/elements/eloqua/accounts.js
+++ b/src/test/elements/eloqua/accounts.js
@@ -2,10 +2,9 @@
 
 const suite = require('core/suite');
 const payload = require('./assets/accounts');
-const chakram = require('chakram');
+const updatePayload = require('./assets/accounts-update');
 const cloud = require('core/cloud');
-const expect = chakram.expect;
-
+const expect = require('chakram').expect;
 
 suite.forElement('marketing', 'accounts', { payload: payload }, (test) => {
   const opts = {
@@ -30,5 +29,17 @@ suite.forElement('marketing', 'accounts', { payload: payload }, (test) => {
     return cloud.get(test.api)
       .then(r => accountId = r.body[0].id)
       .then(r => cloud.get(`${test.api}/${accountId}/membership`));
+  });
+
+  it(`should allow CUD for /accounts with Eloqua field names`, () => {
+    let id;
+    return cloud.post(test.api, payload)
+      .then(r => id = r.body.id)
+      .then(r => cloud.patch(`${test.api}/${id}`, updatePayload))
+      .then(r => {
+        expect(r.body).to.not.be.empty;
+        expect(Object.keys(updatePayload).every(key => r.body[key] === updatePayload[key])).to.be.true;
+      })
+      .then(r => cloud.delete(`${test.api}/${id}`));
   });
 });

--- a/src/test/elements/eloqua/assets/accounts-update.json
+++ b/src/test/elements/eloqua/assets/accounts-update.json
@@ -1,0 +1,4 @@
+{
+  "M_CompanyName": "Churros Update Test",
+  "M_Churros_Account_Field1": "custom updated account field"
+}

--- a/src/test/elements/eloqua/assets/accounts.json
+++ b/src/test/elements/eloqua/assets/accounts.json
@@ -1,5 +1,5 @@
 {
-  "name": "Robot Test",
+  "name": "Churros Test",
   "address1": "3001 Brighton Blvd",
   "address2": "Suite",
   "address3": "153",
@@ -7,5 +7,6 @@
   "country": "US",
   "province": "CO",
   "postalCode": "80212",
-  "businessPhone": "303-123-4567"
+  "businessPhone": "303-123-4567",
+  "M_Churros_Account_Field1": "custom account field"
 }

--- a/src/test/elements/eloqua/assets/contacts-update.json
+++ b/src/test/elements/eloqua/assets/contacts-update.json
@@ -1,4 +1,5 @@
 {
   "C_EmailAddress": "update@this.com",
+  "C_FirstName": "updater",  
   "C_Churros_Contact_Field1": "custom update contact field"
 }

--- a/src/test/elements/eloqua/assets/contacts-update.json
+++ b/src/test/elements/eloqua/assets/contacts-update.json
@@ -1,0 +1,4 @@
+{
+  "C_EmailAddress": "update@this.com",
+  "C_Churros_Contact_Field1": "custom update contact field"
+}

--- a/src/test/elements/eloqua/assets/contacts.json
+++ b/src/test/elements/eloqua/assets/contacts.json
@@ -1,5 +1,6 @@
 {
   "firstName": "Churros",
   "lastName": "Tester",
-  "emailAddress": "<<internet.email>>"
+  "emailAddress": "<<internet.email>>",
+  "C_Churros_Contact_Field1": "custom contact field"
 }

--- a/src/test/elements/eloqua/assets/contacts.json
+++ b/src/test/elements/eloqua/assets/contacts.json
@@ -1,5 +1,5 @@
 {
-  "firstName": "Churros",
+  "C_FirstName": "Churros",
   "lastName": "Tester",
   "emailAddress": "<<internet.email>>",
   "C_Churros_Contact_Field1": "custom contact field"


### PR DESCRIPTION
## Highlights
* Tests for Native / Custom fields

## Reference
* [SOBA](https://github.com/cloud-elements/soba/pull/9186)
* [churros-sauce](Link to Associated Churros-sauce PR, when applicable)
* [DE2334](https://rally1.rallydev.com/#/144349237612d/detail/defect/246897692744)