### PR TITLE
Quickbooks : Added tests for new resources

### DIFF
--- a/src/test/elements/quickbooks/assets/exchange-rates.json
+++ b/src/test/elements/quickbooks/assets/exchange-rates.json
@@ -1,0 +1,8 @@
+{
+  "SourceCurrencyCode": "USD",
+  "AsOfDate": "2018-08-17",
+  "sparse": false,
+  "Rate": 1,
+  "domain": "QBO",
+  "TargetCurrencyCode": "USD"
+}

--- a/src/test/elements/quickbooks/assets/journal-codes.json
+++ b/src/test/elements/quickbooks/assets/journal-codes.json
@@ -1,0 +1,4 @@
+{
+   "Name": "<random.word>",
+   "Type": "Sales"
+}

--- a/src/test/elements/quickbooks/entitlements.js
+++ b/src/test/elements/quickbooks/entitlements.js
@@ -1,0 +1,7 @@
+'use strict';
+
+const suite = require('core/suite');
+
+suite.forElement('finance', 'entitlements', null, (test) => {
+  test.should.return200OnGet();
+});

--- a/src/test/elements/quickbooks/exchange-rates.js
+++ b/src/test/elements/quickbooks/exchange-rates.js
@@ -13,7 +13,7 @@ suite.forElement('finance', 'exchange-rates', { payload: payload }, (test) => {
   });
   //PUT only works with account having multicurrency enabled. Hence need to skip
   it.skip(`Should support U on ${test.api}`, () => {
-    return cloud.put(`${test.api}/USD`, payload)
+    return cloud.put(`${test.api}/USD`, payload);
       //.then(r => cloud.withOptions({ skip: true }).put(`${test.api}/USD`, payload));
   });
 });

--- a/src/test/elements/quickbooks/exchange-rates.js
+++ b/src/test/elements/quickbooks/exchange-rates.js
@@ -1,0 +1,16 @@
+'use strict';
+
+const suite = require('core/suite');
+const tools = require('core/tools');
+const cloud = require('core/cloud');
+const expect = require('chakram').expect;
+const payload = tools.requirePayload(`${__dirname}/assets/exchange-rates.json`);
+
+suite.forElement('finance', 'entitlements', { payload: payload }, (test) => {
+  it(`Should support RU on ${test.api}`, () => {
+    cloud.get(`${test.api}/USD`)
+      .then(r => expect(r).to.statusCode(200));
+    //PUT only works with account having multicurrency enabled. Hence need to skip
+    cloud.withOptions({ skip: true }).put(`${test.api}/USD`, payload);
+  });
+});

--- a/src/test/elements/quickbooks/exchange-rates.js
+++ b/src/test/elements/quickbooks/exchange-rates.js
@@ -7,10 +7,13 @@ const expect = require('chakram').expect;
 const payload = tools.requirePayload(`${__dirname}/assets/exchange-rates.json`);
 
 suite.forElement('finance', 'exchange-rates', { payload: payload }, (test) => {
-  it(`Should support RU on ${test.api}`, () => {
-    cloud.get(`${test.api}/USD`)
+  it(`Should support R on ${test.api}`, () => {
+    return cloud.get(`${test.api}/USD`)
       .then(r => expect(r).to.statusCode(200));
-    //PUT only works with account having multicurrency enabled. Hence need to skip
-    cloud.withOptions({ skip: true }).put(`${test.api}/USD`, payload);
+  });
+  //PUT only works with account having multicurrency enabled. Hence need to skip
+  it.skip(`Should support U on ${test.api}`, () => {
+    return cloud.put(`${test.api}/USD`, payload)
+      //.then(r => cloud.withOptions({ skip: true }).put(`${test.api}/USD`, payload));
   });
 });

--- a/src/test/elements/quickbooks/exchange-rates.js
+++ b/src/test/elements/quickbooks/exchange-rates.js
@@ -6,7 +6,7 @@ const cloud = require('core/cloud');
 const expect = require('chakram').expect;
 const payload = tools.requirePayload(`${__dirname}/assets/exchange-rates.json`);
 
-suite.forElement('finance', 'entitlements', { payload: payload }, (test) => {
+suite.forElement('finance', 'exchange-rates', { payload: payload }, (test) => {
   it(`Should support RU on ${test.api}`, () => {
     cloud.get(`${test.api}/USD`)
       .then(r => expect(r).to.statusCode(200));

--- a/src/test/elements/quickbooks/journal-codes.js
+++ b/src/test/elements/quickbooks/journal-codes.js
@@ -21,7 +21,7 @@ suite.forElement('finance', 'journal-codes', { payload: payload, skip: true }, (
         delete putPayload.id;
         delete putPayload.metaData;
       })
-      .then(cloud.put(`${test.api}/${termId}`, putPayload));
+      .then(cloud.put(`${test.api}/${entityId}`, putPayload));
   });
   test.withOptions({ qs: { page: 1, pageSize: 5 } }).should.return200OnGet();
   test.withName(`should support searching ${test.api} by Name`)
@@ -29,5 +29,6 @@ suite.forElement('finance', 'journal-codes', { payload: payload, skip: true }, (
     .withValidation((r) => {
       expect(r).to.have.statusCode(200);
       const validValues = r.body.filter(obj => obj.Name = 'VT');
+      expect(validValues.length).to.equal(r.body.length);
     }).should.return200OnGet();
 });

--- a/src/test/elements/quickbooks/journal-codes.js
+++ b/src/test/elements/quickbooks/journal-codes.js
@@ -2,37 +2,32 @@
 
 const suite = require('core/suite');
 const tools = require('core/tools');
+const cloud = require('core/cloud');
 const chakram = require('chakram');
 const expect = chakram.expect;
-const cloud = require('core/cloud');
-const payload = tools.requirePayload(`${__dirname}/assets/credit-terms.json`);
+const payload = tools.requirePayload(`${__dirname}/assets/journal-codes.json`);
 
-//Need to skip as there is no delete API
-suite.forElement('finance', 'credit-terms', { payload: payload }, (test) => {
-  let termId;
+//Need to skip as the resource  only works in the France locale on QBO
+suite.forElement('finance', 'journal-codes', { payload: payload, skip: true }, (test) => {
+  let entityId;
   let putPayload;
   test.should.supportSr();
   test.withOptions({ skip: true }).should.return200OnPost();
   it(`should support update on ${test.api}`, () => {
     return cloud.get(test.api)
       .then(r => {
-        termId = r.body[0].id;
+        entityId = r.body[0].id;
         putPayload = r.body[0];
         delete putPayload.id;
-        delete putPayload.attachableRef;
         delete putPayload.metaData;
       })
       .then(cloud.put(`${test.api}/${termId}`, putPayload));
   });
   test.withOptions({ qs: { page: 1, pageSize: 5 } }).should.return200OnGet();
-  test.withName(`should support searching ${test.api} by Id and returnCount in response`)
-    .withOptions({ qs: { where: `id ='1234'`, returnCount: true } })
+  test.withName(`should support searching ${test.api} by Name`)
+    .withOptions({ qs: { where: `Name ='VT'` } })
     .withValidation((r) => {
       expect(r).to.have.statusCode(200);
-      const validValues = r.body.filter(obj => obj.id = '1234');
-      expect(validValues.length).to.equal(r.body.length);
-      expect(r.response.headers['elements-total-count']).to.exist;
+      const validValues = r.body.filter(obj => obj.Name = 'VT');
     }).should.return200OnGet();
-
-
 });


### PR DESCRIPTION
## Highlights
* Added churros tests for below resources :
    * Journal Codes (CRUS)
    * Credit-Terms (U)
    * Entitlements (S)
    * Exchange-Rates (RU)
* Journal codes test is skipped as we are not able to test the API as it is available only for France locale. As per the vendor docs, 'Applicable only for France-locale companies (FR locale)'
* Skipped update of exchange rates as it only works with account having multicurrency enabled.

## Screenshot
![churros_credit-terms](https://user-images.githubusercontent.com/22442264/44398753-a8131100-a562-11e8-896a-4717d55a1b8d.PNG)
![churros_entitlements](https://user-images.githubusercontent.com/22442264/44398754-a8131100-a562-11e8-936a-693027490c07.PNG)
![churros_exchange-rates](https://user-images.githubusercontent.com/22442264/44398756-a8aba780-a562-11e8-8bd3-2d4ee72b9ccd.PNG)


## Reference
* [SOBA](https://github.com/cloud-elements/soba/pull/9203)
* [RALLY-US13476](https://rally1.rallydev.com/#/144349237612d/detail/userstory/246869751416)

## Closes
* [US13476](https://rally1.rallydev.com/#/144349237612d/detail/userstory/246869751416)
