### PR TITLE
Freshbooks Cloud Accounting: Added tests for expenses and corrected other tests

### DIFF
--- a/src/test/elements/freshbooksv2/assets/expenses-create.json
+++ b/src/test/elements/freshbooksv2/assets/expenses-create.json
@@ -1,0 +1,29 @@
+{
+        "date": "2011-11-24",
+        "ext_invoiceid": 0,
+
+        "amount": {
+          "amount": "20",
+          "code": "USD"
+        },
+        "clientid": 0,
+        "notes": "<<random.word>>",
+        "vis_state": 0,
+        "isduplicate": false,
+        "compounded_tax": false,
+
+        "markup_percent": "0",
+        "include_receipt": false,
+        "ext_systemid": 0,
+        "expenseid": 15045666,
+        "account_name": "Churros test account",
+         "transactionid"  : 23323,
+        "bank_name": "<<random.word>>",
+        "is_cogs": false,
+        "id": 15045025,
+        "projectid": 0,
+        "categoryid": 3729837,
+        "staffid": 1,
+        "status": 0,
+        "has_receipt": false
+      }

--- a/src/test/elements/freshbooksv2/assets/expenses-update.json
+++ b/src/test/elements/freshbooksv2/assets/expenses-update.json
@@ -1,0 +1,3 @@
+{
+  "account_name": "Updated- <<random.word>>>"
+}

--- a/src/test/elements/freshbooksv2/customers.js
+++ b/src/test/elements/freshbooksv2/customers.js
@@ -11,7 +11,11 @@ suite.forElement('finance', 'customers', { payload: payload }, (test) => {
   test.should.supportPagination();
   test.withApi(test.api)
     .withOptions({ qs: { where: "updated_min='2018-02-01'" } })
-    .withValidation(r => expect(r.body.filter(obj => obj.updated >= "2018-02-01")).to.not.be.empty)
+    .withValidation(r => {
+      expect(r).to.statusCode(200);
+      const validValues = r.body.filter(obj => obj.updated >= "2018-02-01");
+      expect(validValues.length).to.equal(r.body.length);
+    })
     .withName('should allow GET with option updated_min')
     .should.return200OnGet();
 });

--- a/src/test/elements/freshbooksv2/expenses.js
+++ b/src/test/elements/freshbooksv2/expenses.js
@@ -3,7 +3,6 @@
 const suite = require('core/suite');
 const tools = require('core/tools');
 const expect = require('chakram').expect;
-const cloud = require('core/cloud');
 const updatePayload = tools.requirePayload(`${__dirname}/assets/expenses-update.json`);
 const payload = tools.requirePayload(`${__dirname}/assets/expenses-create.json`);
 

--- a/src/test/elements/freshbooksv2/expenses.js
+++ b/src/test/elements/freshbooksv2/expenses.js
@@ -1,0 +1,29 @@
+'use strict';
+
+const suite = require('core/suite');
+const tools = require('core/tools');
+const expect = require('chakram').expect;
+const cloud = require('core/cloud');
+const updatePayload = tools.requirePayload(`${__dirname}/assets/expenses-update.json`);
+const payload = tools.requirePayload(`${__dirname}/assets/expenses-create.json`);
+
+suite.forElement('finance', 'expenses', { payload: payload }, (test) => {
+  test.withOptions({ churros: { updatePayload: updatePayload } }).should.supportCruds();
+  test.should.supportPagination();
+  test.withOptions({ qs: { where: 'categoryid =\'3729837\'' } })
+    .withName('should support search by filter')
+    .withValidation(r => {
+      expect(r).to.statusCode(200);
+      const validValues = r.body.filter(obj => obj.categoryid = '3729837');
+      expect(validValues.length).to.equal(r.body.length);
+    });
+  test.withApi(test.api)
+    .withOptions({ qs: { where: "amount_min=9000" } })
+    .withValidation(r => {
+      expect(r).to.statusCode(200);
+      const validValues = r.body.filter(obj => obj.amount.amount >= 9000);
+      expect(validValues.length).to.equal(r.body.length);
+    })
+    .withName('should allow GET with option amount_min')
+    .should.return200OnGet();
+});

--- a/src/test/elements/freshbooksv2/invoices.js
+++ b/src/test/elements/freshbooksv2/invoices.js
@@ -18,7 +18,11 @@ suite.forElement('finance', 'invoices', { payload: payload }, (test) => {
   test.should.supportPagination();
   test.withApi(test.api)
     .withOptions({ qs: { where: "currency_code='USD'" } })
-    .withValidation(r => expect(r.body.filter(obj => obj.currency_code === "USD")).to.not.be.empty)
+    .withValidation(r => {
+      expect(r).to.statusCode(200);
+      const validValues = r.body.filter(obj => obj.currency_code === "USD");
+      expect(validValues.length).to.equal(r.body.length);
+    })
     .withName('should allow GET with option currency_code')
     .should.return200OnGet();
 });

--- a/src/test/elements/freshbooksv2/items.js
+++ b/src/test/elements/freshbooksv2/items.js
@@ -10,7 +10,11 @@ suite.forElement('finance', 'items', { payload: payload }, (test) => {
   test.should.supportPagination();
   test.withApi(test.api)
     .withOptions({ qs: { where: "unit_cost_min=4" } })
-    .withValidation(r => expect(r.body.filter(obj => obj.unit_cost.amount >= 4)).to.not.be.empty)
+    .withValidation(r => {
+      expect(r).to.statusCode(200);
+      const validValues = r.body.filter(obj => obj.unit_cost.amount >= 4);
+      expect(validValues.length).to.equal(r.body.length);
+    })
     .withName('should allow GET with option unit_cost_max')
     .should.return200OnGet();
 });

--- a/src/test/elements/freshbooksv2/payments.js
+++ b/src/test/elements/freshbooksv2/payments.js
@@ -19,7 +19,11 @@ suite.forElement('finance', 'payments', { payload: payload }, (test) => {
   test.should.supportPagination();
   test.withApi(test.api)
     .withOptions({ qs: { where: "updated_min='2018-02-01'" } })
-    .withValidation(r => expect(r.body.filter(obj => obj.updated >= "2018-02-01")).to.not.be.empty)
+    .withValidation(r => {
+      expect(r).to.statusCode(200);
+      const validValues = r.body.filter(obj => obj.updated >= "2018-02-01");
+      expect(validValues.length).to.equal(r.body.length);
+    })
     .withName('should allow GET with option updated_min')
     .should.return200OnGet();
 });

--- a/src/test/elements/freshbooksv2/tasks.js
+++ b/src/test/elements/freshbooksv2/tasks.js
@@ -6,11 +6,15 @@ const expect = require('chakram').expect;
 const payload = tools.requirePayload(`${__dirname}/assets/task.json`);
 
 suite.forElement('finance', 'tasks', { payload: payload }, (test) => {
-    test.should.supportCruds();
-    test.should.supportPagination();
-    test.withApi(test.api)
+  test.should.supportCruds();
+  test.should.supportPagination();
+  test.withApi(test.api)
     .withOptions({ qs: { where: "rate_min=0" } })
-    .withValidation(r => expect(r.body.filter(obj => obj.rate.amount >= 0)).to.not.be.empty)
+    .withValidation(r => {
+      expect(r).to.statusCode(200);
+      const validValues = r.body.filter(obj => obj.rate.amount >= 0);
+      expect(validValues.length).to.equal(r.body.length);
+    })
     .withName('should allow GET with option rate_min')
     .should.return200OnGet();
 });

--- a/src/test/elements/freshbooksv2/taxes.js
+++ b/src/test/elements/freshbooksv2/taxes.js
@@ -10,7 +10,11 @@ suite.forElement('finance', 'taxes', { payload: payload }, (test) => {
   test.should.supportPagination();
   test.withApi(test.api)
     .withOptions({ qs: { where: "updated_min='2018-02-01'" } })
-    .withValidation(r => expect(r.body.filter(obj => obj.updated >= "2018-02-01")).to.not.be.empty)
+    .withValidation(r => {
+      expect(r).to.statusCode(200);
+      const validValues = r.body.filter(obj => obj.updated >= "2018-02-01");
+      expect(validValues.length).to.equal(r.body.length);
+    })
     .withName('should allow GET with option updated_min')
     .should.return200OnGet();
 });

--- a/src/test/elements/freshbooksv2/vendors.js
+++ b/src/test/elements/freshbooksv2/vendors.js
@@ -17,7 +17,11 @@ suite.forElement('finance', 'vendors', { payload: payload }, (test) => {
   test.should.supportPagination();
   test.withApi(test.api)
     .withOptions({ qs: { where: "updated_min='2018-02-01'" } })
-    .withValidation(r => expect(r.body.filter(obj => obj.updated >= "2018-02-01")).to.not.be.empty)
-    .withName('should allow GET with option updated_min')
+    .withValidation(r => {
+      expect(r).to.statusCode(200);
+      const validValues = r.body.filter(obj => obj.updated >= "2018-02-01");
+      expect(validValues.length).to.equal(r.body.length);
+    })
+  .withName('should allow GET with option updated_min')
     .should.return200OnGet();
 });


### PR DESCRIPTION
## Highlights
* Added tests for `expenses` object.
* The earlier test may fail when the test for where clause may return empty responses.
So, corrected tests for following objects:
  * `customers`
  * `invoices`
  * `items`
  * `payments`
  * `tasks`
  * `taxes`
  * `vendors`

## Screenshot
![image](https://user-images.githubusercontent.com/29943090/44521735-b17eb380-a6f1-11e8-9c92-5424fb534c22.png)

## Reference
* [SOBA](https://github.com/cloud-elements/soba/pull/9220)
* [RALLY-#${US13482}](https://rally1.rallydev.com/#/144349237612d/detail/userstory/246880392732)

## Closes
* Closes #${[US13482](https://rally1.rallydev.com/#/144349237612d/detail/userstory/246880392732)}