### PR TITLE
Added a test to validate that the GET /vendors API's response payload

### DIFF
--- a/src/test/elements/sageone/vendors.js
+++ b/src/test/elements/sageone/vendors.js
@@ -30,4 +30,20 @@ suite.forElement('finance', 'vendors', { payload: vendorsPayload }, (test) => {
           }).should.return200OnGet();
       });
   });
+
+  it('should validate GET /vendors/{id} response payload', () => {
+    let newVendorPayload = build({ reference: "re" + tools.randomInt(), name: "name" + tools.randomInt() });
+    let vendorId;
+    return cloud.post(test.api, newVendorPayload)
+      .then(r => vendorId = r.body.id)
+      .then(r => cloud.get(`${test.api}/${vendorId}`))
+      .then(r => expect(r).to.have.statusCode(200) && expect(r.body).to.not.be.null &&
+        expect(r.body).to.contain.key('bank_account_details') &&
+        expect(r.body).to.contain.key('default_purchase_ledger_account') &&
+        expect(r.body).to.contain.key('main_contact_person') &&
+        expect(r.body).to.contain.key('main_address') &&
+        expect(r.body).to.contain.key('displayed_as') &&
+        expect(r.body).to.contain.key('id') &&
+        expect(r.body.id).to.equal(vendorId));
+  });
 });


### PR DESCRIPTION
## Highlights
* Ensure that the `GET /vendors` and `GET /vendors/{id}` APIs for the SageOne element are returning the full response payload.

## Screenshot
![image](https://user-images.githubusercontent.com/3017448/44623380-5b487680-a891-11e8-85b2-45a706c4ffff.png)

## Reference
* https://github.com/cloud-elements/soba/pull/9231
* [Jira-#SLYT-408](https://cloudelements.atlassian.net/browse/SLYT-408)

## Closes
* Closes #[SLYT-408](https://cloudelements.atlassian.net/browse/SLYT-408)
