### PR TITLE
pagination update and removed order by test for vsts element

### DIFF
--- a/src/test/elements/vsts/workitems.js
+++ b/src/test/elements/vsts/workitems.js
@@ -13,7 +13,8 @@ suite.forElement('collaboration', 'work-items', { payload: payload }, (test) => 
   };
 
   test.withOptions(update).should.supportCruds();
-  test.should.supportNextPagePagination(1);
+  test.should.supportPagination();
+  test.should.supportNextPagePagination(3, false);
   test.should.supportCeqlSearch('System.Title');
 
   it('should allow fields for work-items', () => {

--- a/src/test/elements/vsts/workitems.js
+++ b/src/test/elements/vsts/workitems.js
@@ -13,21 +13,8 @@ suite.forElement('collaboration', 'work-items', { payload: payload }, (test) => 
   };
 
   test.withOptions(update).should.supportCruds();
-  test.should.supportPagination();
+  test.should.supportNextPagePagination(1);
   test.should.supportCeqlSearch('System.Title');
-
-  it('should allow orderBy for work-items', () => {
-    let ids = [],
-      query = { orderBy: 'System.Id desc', pageSize: 2000 };
-    return cloud.withOptions({ qs: query }).get(test.api)
-      .then(r => ids = r.body.map(o => o.id))
-      .then(r => cloud.withOptions({ qs: { pageSize: 2000 }}).get(test.api))
-      .then(r => {
-        expect(r.body).to.not.be.empty;
-        let descIds = r.body.map(o => o.id).sort((a, b) => b - a);
-        expect(descIds).to.deep.equal(ids);
-      });
-  });
 
   it('should allow fields for work-items', () => {
     return cloud.withOptions({ qs: { fields: 'System.Id' } }).get(test.api)


### PR DESCRIPTION
## Highlights
* Updated pagination test to `cursor` type pagination
* Removed order by test case as we no longer have the option for the resource

## Screenshot
<img width="982" alt="vsts_updated" src="https://user-images.githubusercontent.com/11171313/44869200-957b9480-ac52-11e8-8b99-d49899e51be9.png">

## Reference
* [DE2357](https://rally1.rallydev.com/#/144349237612d/detail/defect/248019618728)

