### PR TITLE
Zuorav2 tests added for two product-rate-plans APIs

### DIFF
--- a/src/test/elements/zuorav2/productRatePlans.js
+++ b/src/test/elements/zuorav2/productRatePlans.js
@@ -1,0 +1,17 @@
+'use strict';
+
+const suite = require('core/suite');
+const expect = require('chakram').expect;
+
+suite.forElement('payment', 'product-rate-plans', (test) => {
+  test.should.return200OnGet();
+  test.should.supportNextPagePagination(2);
+  test
+    .withName(`should support searching ${test.api} by CreatedDate`)
+    .withOptions({ qs: { where: 'CreatedDate=\'2018-06-18T02:51:51.000-07:00\'' } })
+    .withValidation((r) => {
+      expect(r).to.have.statusCode(200);
+      const validValues = r.body.filter(obj => obj.CreatedDate === '2018-06-18T02:51:51.000-07:00');
+      expect(validValues.length).to.equal(r.body.length);
+    }).should.return200OnGet();
+});

--- a/src/test/elements/zuorav2/productRatePlans.js
+++ b/src/test/elements/zuorav2/productRatePlans.js
@@ -6,6 +6,7 @@ const expect = require('chakram').expect;
 suite.forElement('payment', 'product-rate-plans', (test) => {
   test.should.return200OnGet();
   test.should.supportNextPagePagination(2);
+  
   test
     .withName(`should support searching ${test.api} by CreatedDate`)
     .withOptions({ qs: { where: 'CreatedDate=\'2018-06-18T02:51:51.000-07:00\'' } })
@@ -14,4 +15,5 @@ suite.forElement('payment', 'product-rate-plans', (test) => {
       const validValues = r.body.filter(obj => obj.CreatedDate === '2018-06-18T02:51:51.000-07:00');
       expect(validValues.length).to.equal(r.body.length);
     }).should.return200OnGet();
+	
 });

--- a/src/test/elements/zuorav2/products.js
+++ b/src/test/elements/zuorav2/products.js
@@ -20,10 +20,10 @@ suite.forElement('payment', 'products', { payload: accountsPayload }, (test) => 
   test.should.supportNextPagePagination(2);
   test.should.supportCeqlSearch('id');
 
-  it('should allow S for /hubs/payment/products/{id}/product-rate-plans', () => {
+  it('should allow S for /hubs/payment/products/{id}/rate-plans', () => {
     let productId = -1;
     return cloud.get(test.api)
       .then(r => productId = r.body[0].id)
-      .then(r => cloud.withOptions({ qs: { page: 1, pageSize: 1 } }).get(`${test.api}/${productId}/product-rate-plans`));
+      .then(r => cloud.withOptions({ qs: { page: 1, pageSize: 1 } }).get(`${test.api}/${productId}/rate-plans`));
   });
 });

--- a/src/test/elements/zuorav2/products.js
+++ b/src/test/elements/zuorav2/products.js
@@ -4,6 +4,7 @@ const suite = require('core/suite');
 const payload = require('./assets/products');
 const chakram = require('chakram');
 const tools = require('core/tools');
+const cloud = require('core/cloud');
 const build = (overrides) => Object.assign({}, payload, overrides);
 const accountsPayload = build({ Name: tools.random(), SKU: tools.random() });
 
@@ -18,4 +19,11 @@ suite.forElement('payment', 'products', { payload: accountsPayload }, (test) => 
   test.withOptions(options).should.supportCruds(chakram.put);
   test.should.supportNextPagePagination(2);
   test.should.supportCeqlSearch('id');
+
+  it('should allow S for /hubs/payment/products/{id}/product-rate-plans', () => {
+    let productId = -1;
+    return cloud.get(test.api)
+      .then(r => productId = r.body[0].id)
+      .then(r => cloud.withOptions({ qs: { page: 1, pageSize: 1 } }).get(`${test.api}/${productId}/product-rate-plans`));
+  });
 });


### PR DESCRIPTION
## Highlights
* Added tests for GET `product-rate-plans` and GET `products/{id}/rate-plans` APIs.

## Screenshot
![churros_local_1](https://user-images.githubusercontent.com/35719878/44937126-63bf1680-ad95-11e8-8928-b3592e2b3159.PNG)
![churros_local_2](https://user-images.githubusercontent.com/35719878/44937127-63bf1680-ad95-11e8-83f1-1408691cdbfd.PNG)

## Reference
* [SOBA](https://github.com/cloud-elements/soba/pull/9244)
* [Churros-ibm](https://github.com/cloud-elements/churros/pull/1734)
* [Churros-sauce-ibm](https://github.com/cloud-elements/churros-sauce/pull/221)

## Closes
* [Zuorav2](https://cloudelements.atlassian.net/browse/IBM-7)
