### PR TITLE
added churros for the voucher-series and financial-years endpoints

### DIFF
--- a/src/test/elements/fortnox/financial-years.js
+++ b/src/test/elements/fortnox/financial-years.js
@@ -1,8 +1,6 @@
 'use strict';
 
 const suite = require('core/suite');
-const tools = require('core/tools');
-const cloud = require('core/cloud');
 
 suite.forElement('erp', 'financial-years', (test) => {
   test.withApi(`${test.api}`)

--- a/src/test/elements/fortnox/financial-years.js
+++ b/src/test/elements/fortnox/financial-years.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const suite = require('core/suite');
+const expect = require('chakram').expect;
 
 suite.forElement('erp', 'financial-years', (test) => {
   test.withApi(`${test.api}`)
@@ -9,7 +10,11 @@ suite.forElement('erp', 'financial-years', (test) => {
   test.withApi(`${test.api}`)
     .withOptions({ qs: { where: 'date = \'2014-01-01\'' } })
     .withName('should allow GET financial years by date')
+    .withValidation(r => {
+      expect(r).to.statusCode(200);
+      const validValues = r.body.filter(obj => obj.Id = 3);
+      expect(validValues.length).to.equal(r.body.length);
+    })
     .should.return200OnGet();
-
   test.should.supportPagination();
 });

--- a/src/test/elements/fortnox/financial-years.js
+++ b/src/test/elements/fortnox/financial-years.js
@@ -1,0 +1,17 @@
+'use strict';
+
+const suite = require('core/suite');
+const tools = require('core/tools');
+const cloud = require('core/cloud');
+
+suite.forElement('erp', 'financial-years', (test) => {
+  test.withApi(`${test.api}`)
+    .withName('should allow GET financial years')
+    .should.return200OnGet();
+  test.withApi(`${test.api}`)
+    .withOptions({ qs: { where: 'date = \'2014-01-01\'' } })
+    .withName('should allow GET financial years by date')
+    .should.return200OnGet();
+
+  test.should.supportPagination();
+});

--- a/src/test/elements/fortnox/voucher-series.js
+++ b/src/test/elements/fortnox/voucher-series.js
@@ -1,0 +1,13 @@
+'use strict';
+
+const suite = require('core/suite');
+const tools = require('core/tools');
+const cloud = require('core/cloud');
+
+suite.forElement('erp', 'voucher-series', (test) => {
+  test.withApi(`${test.api}`)
+    .withName('should allow GET voucher series')
+    .should.return200OnGet();
+
+  test.should.supportPagination();
+});

--- a/src/test/elements/fortnox/voucher-series.js
+++ b/src/test/elements/fortnox/voucher-series.js
@@ -1,8 +1,6 @@
 'use strict';
 
 const suite = require('core/suite');
-const tools = require('core/tools');
-const cloud = require('core/cloud');
 
 suite.forElement('erp', 'voucher-series', (test) => {
   test.withApi(`${test.api}`)


### PR DESCRIPTION
## Highlights
* Added tests for 'voucher-series' and 'financial-years' objects.

## Screenshot
![churros](https://user-images.githubusercontent.com/42342474/44852695-8b24bf00-ac81-11e8-9d64-f1192bfae4e6.PNG)


## Reference
* [SOBA](https://github.com/cloud-elements/soba/pull/9253)
* [US13486](https://rally1.rallydev.com/#/144349237612d/detail/userstory/246881224644)

## Closes
* Closes [US13486](https://rally1.rallydev.com/#/144349237612d/detail/userstory/246881224644)