### PR TITLE
Added `GET /contacts/{userToken}/profile`  API test to HubSpot CRM

### DIFF
--- a/src/test/elements/hubspotcrm/contacts.js
+++ b/src/test/elements/hubspotcrm/contacts.js
@@ -32,6 +32,11 @@ suite.forElement('crm', 'contacts', { payload: payload }, (test) => {
       .then(r => cloud.delete(`${test.api}/${contactId}`));
   });
 
+  //Need to skip as a valid user token is not available for testing	
+  it.skip('should allow GET on contacts/{userToken}/profile using user token', () => {
+      return => cloud.get(`${test.api}/75e08573d958018c7dce928bd8f5c8cb/profile`);
+  });
+
   it('should test contacts poller url', () => {
     let id;
     let objects;

--- a/src/test/elements/hubspotcrm/contacts.js
+++ b/src/test/elements/hubspotcrm/contacts.js
@@ -32,9 +32,9 @@ suite.forElement('crm', 'contacts', { payload: payload }, (test) => {
       .then(r => cloud.delete(`${test.api}/${contactId}`));
   });
 
-  //Need to skip as a valid user token is not available for testing	
+  //Need to skip as a valid user token is not available for testing
   it.skip('should allow GET on contacts/{userToken}/profile using user token', () => {
-      return => cloud.get(`${test.api}/75e08573d958018c7dce928bd8f5c8cb/profile`);
+      return cloud.get(`${test.api}/75e08573d958018c7dce928bd8f5c8cb/profile`);
   });
 
   it('should test contacts poller url', () => {


### PR DESCRIPTION
## Highlights
* Added test for the newly added API `GET /contacts/{userToken}/profile` 

## Screenshot
info: Using url: http://localhost:8080
info: Using user: mithila.garud@gslab.com
info: Using oauth username: developer@cloud-elements.com
info: Using api key: da5693c8-48d8-4a54-90b0-9e83eb76a6fc
info: Running tests for element: hubspotcrm
Trying the portal ID: 4821991
info: Provisioned with instance id of 15
  Basic tests
    √ should provision
    √ should GET /objects (339ms)
    - docs
    √ metadata (234ms)
    √ transformations (6791ms)
    - should not allow provisioning with bad credentials

  accounts
    √ should allow paginating with page and pageSize for /hubs/crm/accounts (2410ms)
    √ should test CRUD for /accounts and GET /accounts/{id}/activities (5828ms)
    √ should test accounts poller url (12251ms)

  accounts/285826161/activities
    - should allow paginating with page and nextPage /hubs/crm/accounts/285826161/activities

  activities
    √ should allow CRUD for /hubs/crm/activities (3742ms)

  contacts-search
    √ should test newly added account resource contacts-search (898ms)

  contacts
    √ should allow paginating with page and nextPage /hubs/crm/contacts (1479ms)
    √ should allow pagination for all contacts with page and nextPage (1646ms)
    √ should test CRUD for /contacts and GET /contacts/{id}/activities (7282ms)
    - should allow GET on contacts/{userToken}/profile using user token
    √ should test contacts poller url (13093ms)
    √ should test get for xformed contact (5036ms)
    √ should allow paginating with page and nextPage /hubs/crm/contacts (884ms)

  leads
    √ should allow CRUDS for /hubs/crm/leads (4740ms)
    √ should allow paginating with page and pageSize for /hubs/crm/leads (2199ms)

  opportunities
    √ should allow CRUDS for /hubs/crm/opportunities (4433ms)
    √ should allow paginating with page and pageSize for /hubs/crm/opportunities (2490ms)
    √ should test opportunities poller url (12830ms)

  owners
    √ should allow S for /hubs/crm/owners (589ms)
    √ should allow paginating with page and pageSize for /hubs/crm/owners (2237ms)
    √ should support email search (736ms)

  pipelines
    √ should allow CRUDS for /hubs/crm/pipelines (4767ms)
    √ should allow paginating with page and pageSize for /hubs/crm/pipelines (2027ms)

  polling
    - polling /hubs/crm/accounts
    - polling /hubs/crm/contacts
    - polling /hubs/crm/opportunities

  timeline-event-types
    √ should allow paginating with page and pageSize for /hubs/crm/timeline-event-types (2251ms)
    √ should support CUDS for /hubs/crm/timeline-event-types (2926ms)
    √ it should allow CUD for /timeline-event-types/:id/properties (3490ms)
    √ it should allow CRU for /timeline-event-types/:id/events (3904ms)


  29 passing (3m)
  7 pending

## Reference
* [SOBA](https://github.com/cloud-elements/soba/pull/9259)
* [Churros-sause](https://github.com/cloud-elements/churros-sauce/pull/219)
* [RALLY-#US13526](https://rally1.rallydev.com/#/144349237612d/detail/userstory/248214928424)

## Closes
* [#US13526](https://rally1.rallydev.com/#/144349237612d/detail/userstory/248214928424)
