### PR TITLE
Dropbox Business : Added test cases for Team Spaces support

### DIFF
--- a/src/test/elements/dropboxbusiness/folders.js
+++ b/src/test/elements/dropboxbusiness/folders.js
@@ -90,17 +90,19 @@ suite.forElement('documents', 'folders', (test) => {
    });
 
    test.withApi(`${test.api}/contents`).withOptions({qs: {path :'/'}}).should.supportNextPagePagination(1);
-   
+
    it('should allow GET /folders/contents', () => {
      return cloud.withOptions({qs: { path: `/` } , headers: { "Elements-As-Team-Member": memberId }}).get(`${test.api}/contents`)
          .then(r => expect(r.body.length).to.equal(r.body.filter(obj => obj.directory === true || obj.directory === false).length));
      });
 
+  //skipping since there is no where clause supported
    it.skip('should allow GET /folders/contents with name', () => {
      return cloud.withOptions({qs: { path: `/`, where: "name='dontdelete.jpg'" }, headers: { "Elements-As-Team-Member": memberId }}).get(`${test.api}/contents`)
        .then(r => expect(r.body[0].name).to.contain('dontdelete'));
    });
 
+  //skipping since there is no where clause supported
    it.skip('should allow GET /folders/contents with extension', () => {
      return cloud.withOptions({qs: { path: `/`, where: "extension='.csv'" }, headers: { "Elements-As-Team-Member": memberId }}).get(`${test.api}/contents`)
        .then(r => expect(r.body[0].name).to.contain('.csv'));
@@ -111,10 +113,24 @@ suite.forElement('documents', 'folders', (test) => {
          .then(r => expect(r.body.parentFolderId).to.not.equal(null));
    });
 
-   it('should allow GET /folders/contents with directory', () => {
+  //skipping since there is no where clause supported
+   it.skip('should allow GET /folders/contents with directory', () => {
      return cloud.withOptions({qs: { path: `/`, where: "directory='true'" }, headers: { "Elements-As-Team-Member": memberId }}).get(`${test.api}/contents`)
       .then(r => expect(r.body[0].directory).to.equal(true));
    });
 
-
+   it('should allow for GET folder contents and folder metadata for teamspace folders', () => {
+   let teamfolder;
+   const folder = { path: `/teams-${random}` };
+   let path = `/teams${tools.randomStr('abcdefghijklmnopqrstuvwxyz1234567890', 10)}.jpg`;
+   return cloud.get(`/namespaces`)
+     .then(r => teamspaceId = r.body[0].namespace_id)
+     .then(r => cloud.withOptions({ qs: { includeTeamSpaces: 'true', teamSpaceId: `${teamspaceId}` }, headers: { "Elements-As-Team-Member": memberId } }).post(`${test.api}`, folder))
+     .then(r => teamfolder = r.body)
+     .then(r => cloud.withOptions({ qs: { path: `${teamfolder.path}`, includeTeamSpaces: 'true', teamSpaceId: `${teamspaceId}` }, headers: { "Elements-As-Team-Member": memberId } }).get(`${test.api}/metadata`))
+     .then(r => cloud.withOptions({ qs: { includeTeamSpaces: 'true', teamSpaceId: `${teamspaceId}` }, headers: { "Elements-As-Team-Member": memberId } }).get(`${test.api}/${teamfolder.id}/metadata`))
+     .then(r => cloud.withOptions({ qs: { path: `${teamfolder.path}`, includeTeamSpaces: 'true', teamSpaceId: `${teamspaceId}` }, headers: { "Elements-As-Team-Member": memberId } }).get(`${test.api}/metadata`))
+     .then(r => cloud.withOptions({ qs: { includeTeamSpaces: 'true', teamSpaceId: `${teamspaceId}` }, headers: { "Elements-As-Team-Member": memberId } }).get(`${test.api}/${teamfolder.refId}/metadata`))
+     .then(r => cloud.withOptions({ qs: { includeTeamSpaces: 'true', teamSpaceId: `${teamspaceId}` }, headers: { "Elements-As-Team-Member": memberId } }).delete(`/hubs/documents/folders/${teamfolder.refId}`));
+ });
 });

--- a/src/test/elements/dropboxbusiness/folders.js
+++ b/src/test/elements/dropboxbusiness/folders.js
@@ -120,9 +120,8 @@ suite.forElement('documents', 'folders', (test) => {
    });
 
    it('should allow for GET folder contents and folder metadata for teamspace folders', () => {
-   let teamfolder;
+   let teamfolder, teamspaceId;
    const folder = { path: `/teams-${random}` };
-   let path = `/teams${tools.randomStr('abcdefghijklmnopqrstuvwxyz1234567890', 10)}.jpg`;
    return cloud.get(`/namespaces`)
      .then(r => teamspaceId = r.body[0].namespace_id)
      .then(r => cloud.withOptions({ qs: { includeTeamSpaces: 'true', teamSpaceId: `${teamspaceId}` }, headers: { "Elements-As-Team-Member": memberId } }).post(`${test.api}`, folder))

--- a/src/test/elements/dropboxbusiness/namespaces.js
+++ b/src/test/elements/dropboxbusiness/namespaces.js
@@ -1,0 +1,10 @@
+'use strict';
+
+const suite = require('core/suite');
+const props = require('core/props');
+
+suite.forElement('documents', 'namespaces', (test) => {
+  let memberId = props.getForKey('dropboxbusiness', 'username');
+  test.should.supportS();
+  test.should.supportPagination();
+});

--- a/src/test/elements/dropboxbusiness/namespaces.js
+++ b/src/test/elements/dropboxbusiness/namespaces.js
@@ -4,7 +4,6 @@ const suite = require('core/suite');
 const props = require('core/props');
 
 suite.forElement('documents', 'namespaces', (test) => {
-  let memberId = props.getForKey('dropboxbusiness', 'username');
   test.should.supportS();
   test.should.supportPagination();
 });

--- a/src/test/elements/dropboxbusiness/namespaces.js
+++ b/src/test/elements/dropboxbusiness/namespaces.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const suite = require('core/suite');
-const props = require('core/props');
 
 suite.forElement('documents', 'namespaces', (test) => {
   test.should.supportS();


### PR DESCRIPTION
## Highlights
* Added tests for support for `team spaces` in `dropboxbusiness`
* Added test for files and folders
* Added test for new endpoint `/namespaces'

## Screenshot
![image](https://user-images.githubusercontent.com/29943090/45221245-8342cb80-b2ce-11e8-8ac7-c701a332394f.png)
![image](https://user-images.githubusercontent.com/29943090/45221275-98b7f580-b2ce-11e8-9442-d39f0fb8fc66.png)

## Reference
* [SOBA](https://github.com/cloud-elements/soba/pull/9283)
* [RALLY-#${US13235}]https://rally1.rallydev.com/#/144349237612d/detail/userstory/239218486112)

## Closes
* Closes #${US13235}
