### PR TITLE
Added test cases for Docusign bulk

### DIFF
--- a/src/test/elements/docusign/bulk.js
+++ b/src/test/elements/docusign/bulk.js
@@ -1,0 +1,33 @@
+'use strict';
+
+const suite = require('core/suite');
+const cloud = require('core/cloud');
+const tools = require('core/tools');
+const expect = require('chakram').expect;
+const argv = require('optimist').argv;
+
+suite.forElement('esignature', 'bulk', null, (test) => {
+
+  it('should support bulk download of envelopes', () => {
+    let bulkId;
+    const opts = { qs: { q: 'select * from envelopes' } };
+
+    // start bulk download
+    return cloud.withOptions(opts).post('/hubs/marketing/bulk/query')
+      .then(r => {
+        expect(r.body.status).to.equal('CREATED');
+        bulkId = r.body.id;
+      })
+      // get bulk download status
+      .then(r => tools.wait.upTo(30000).for(() => cloud.get(`/hubs/marketing/bulk/${bulkId}/status`, r => {
+        expect(r.body.status).to.equal('COMPLETED');
+        expect(r.body.recordsCount > 0).to.be.true;
+        expect(r.body.recordsFailedCount).to.equal(0);
+      })))
+      .then(r => cloud.get(`/hubs/marketing/bulk/${bulkId}/envelopes`, r => {
+        expect(r.body).to.contain('envelopeId');
+      }))
+      // get bulk download errors
+      .then(r => cloud.get(`/hubs/marketing/bulk/${bulkId}/errors`));
+  });
+});


### PR DESCRIPTION
## Highlights
* Added test cases for bulk download on DocuSign

## Screenshot
(node:13144) [DEP0022] DeprecationWarning: os.tmpDir() is deprecated. Use os.tmpdir() instead.

info: Using url: http://localhost:8080
info: Using user: mithila.garud@gslab.com
info: Using oauth username: developer@cloud-elements.com
info: Using api key: 41a5318c-598e-48ee-bbdc-220a04915905
info: Running tests for element: docusign
info: Provisioned with instance id of 28
  Basic tests
    √ should provision
    √ should GET /objects (231ms)
    - docs
    √ metadata (205ms)
    √ transformations (1590ms)
    - should not allow provisioning with bad credentials

  bulk
error: Failed to retrieve or validate: /hubs/marketing/bulk/43/status
    √ should support bulk download of envelopes (4882ms)

  envelopes
    √ should support CRU on /hubs/esignature/envelopes (25705ms)
    √ should support C on /hubs/esignature/envelopes, SRUD /hubs/esignature/envelopes/:id/documents (28793ms)
    √ should support Ceql search on /hubs/esignature/envelopes and S on /hubs/esignature/envelopes/:id/documents/certificates (8437ms)
    √ should support CR on /hubs/esignature/envelopes/:id/recipients and /hubs/esignature/envelopes/:id/recipients/:id/tabs (17589ms)
    √ should allow GET for /hubs/esignature/envelopes (661ms)

  ping
    √ should allow GET /ping for system health (1122ms)

  polling
    - polling /hubs/esignature/envelopes

  templates
    √ should support SR on /hubs/esignature/templates (1327ms)


  12 passing (2m)
  3 pending

## Reference
* [SOBA](https://github.com/cloud-elements/soba/pull/9297)
* [RALLY-#US13546](https://rally1.rallydev.com/#/144349237612d/detail/userstory/248797397256)

## Closes
* [#US13546](https://rally1.rallydev.com/#/144349237612d/detail/userstory/248797397256)
