### PR TITLE
SFMC :  Updated test for contacts resource 

### DIFF
--- a/src/test/elements/salesforcemarketingcloud/contacts.js
+++ b/src/test/elements/salesforcemarketingcloud/contacts.js
@@ -28,11 +28,12 @@ const updatedPayload = {
 suite.forElement('marketing', 'contacts', { payload: contactsPayload }, (test) => {
   it('should allow CUD for /contacts', () => {
     let id;
+    let options = {};
     return cloud.post(test.api, contactsPayload)
       .then(r => id = r.body.id)
       .then(r => cloud.patch(`${test.api}/${id}`, updatedPayload))
-      .then(r => cloud.delete(`${test.api}/${id}`));
-  //    .then(r => cloud.get(test.api), { qs: { key: 'Email Addresses', value: '${tools.randomStr()}' } });
+      .then(r => cloud.delete(`${test.api}/${id}`))
+      .then(r => cloud.withOptions(options).get(test.api), { qs: { key: 'Email Addresses', value: '${tools.randomStr()}' } },  options ? options.skip : true);
   });
-//  test.should.supportPagination();
+  test.withOptions({skip : true}).should.supportPagination();
 });

--- a/src/test/elements/salesforcemarketingcloud/contacts.js
+++ b/src/test/elements/salesforcemarketingcloud/contacts.js
@@ -26,12 +26,13 @@ const updatedPayload = {
 };
 
 suite.forElement('marketing', 'contacts', { payload: contactsPayload }, (test) => {
-  it('should allow CUS for /contacts', () => {
+  it('should allow CUD for /contacts', () => {
     let id;
     return cloud.post(test.api, contactsPayload)
       .then(r => id = r.body.id)
       .then(r => cloud.patch(`${test.api}/${id}`, updatedPayload))
-      .then(r => cloud.get(test.api), { qs: { key: 'Email Addresses', value: '${tools.randomStr()}' } });
+      .then(r => cloud.delete(`${test.api}/${id}`));
+  //    .then(r => cloud.get(test.api), { qs: { key: 'Email Addresses', value: '${tools.randomStr()}' } });
   });
-  test.should.supportPagination();
+//  test.should.supportPagination();
 });


### PR DESCRIPTION
## Highlights
* Added tests `DELETE /contacts` and skipped tests for `GET /contacts` as it is marked as `API NO DOC`.

## Screenshot
![churros_local_1](https://user-images.githubusercontent.com/35719878/45299815-538fff80-b52a-11e8-833b-b8e25acd1110.PNG)
![churros_local_2](https://user-images.githubusercontent.com/35719878/45299816-538fff80-b52a-11e8-8403-3838d55e7e95.PNG)
![churros_local_3](https://user-images.githubusercontent.com/35719878/45299817-54289600-b52a-11e8-8a0e-5023a18b16fb.PNG)

## Reference
* [SOBA](https://github.com/cloud-elements/soba/pull/9298)
* [Element-irs](https://github.com/cloud-elements/elements-irs/pull/28)

## Closes
* [SFMC](https://cloudelements.atlassian.net/browse/IBM-19)
