### PR TITLE
Facebook lead ads: updated the payloads

### DIFF
--- a/src/test/elements/facebookleadads/assets/context-card.json
+++ b/src/test/elements/facebookleadads/assets/context-card.json
@@ -1,6 +1,5 @@
 {
-    "cover_photo_id": "1261980613946210",
-	"button_text": "Post test button_text",
+   	"button_text": "Post test button_text",
     "style": "PARAGRAPH_STYLE",
     "title": "<<random.word>>",
     "content": [

--- a/src/test/elements/facebookleadads/assets/draft-form.json
+++ b/src/test/elements/facebookleadads/assets/draft-form.json
@@ -55,7 +55,6 @@
     ]
   },
   "context_card": {
-    "cover_photo_id": "1261929010618037",
     "button_text": "Post test button",
     "style": "PARAGRAPH_STYLE",
     "title": "Post test",

--- a/src/test/elements/facebookleadads/assets/form.json
+++ b/src/test/elements/facebookleadads/assets/form.json
@@ -34,29 +34,7 @@
     "button_description": "View button",
     "enable_messenger": true
   },
-  "custom_disclaimer": {
-    "title": "Custom Disclaimer 1",
-    "body": {
-      "text": "custom disclaimer body text",
-      "url_entities": [
-        {
-          "offset": "1",
-          "length": "20",
-          "url": "www.google.com"
-        }
-      ]
-    },
-    "checkboxes": [
-      {
-        "is_required": true,
-        "is_checked_by_default": true,
-        "text": "I Agree",
-        "key": "i_agree"
-      }
-    ]
-  },
   "context_card": {
-    "cover_photo_id": "1261929010618037",
     "button_text": "Post test button",
     "style": "PARAGRAPH_STYLE",
     "title": "Post test",


### PR DESCRIPTION
## Highlights
*  Updated the payloads for `context-cards`, `draft-forms`, `forms`


## Screenshot
![churros](https://user-images.githubusercontent.com/30625203/45622013-3ca85a80-baa0-11e8-8292-f92a4699bce8.PNG)


## Reference
* [SOBA](https://github.com/cloud-elements/soba/pull/9336)
* [elements-irs](https://github.com/cloud-elements/elements-irs/pull/39)


## Closes
* [Jira](https://cloudelements.atlassian.net/browse/IBM-25)
